### PR TITLE
fix typos and do some changes in intrinsics

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -12635,7 +12635,7 @@ The two 32-bit Q30 results are then written into Rd. The result calculated from 
 
 * Required:
 
- uint64_t __rv_smul16(uint32_t a, uint32_t b);
+ int64_t __rv_smul16(uint32_t a, uint32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -12646,7 +12646,7 @@ The two 32-bit Q30 results are then written into Rd. The result calculated from 
 
 * Required:
 
- uint64_t __rv_smulx16(uint32_t a, uint32_t b);
+ int64_t __rv_smulx16(uint32_t a, uint32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17036,7 +17036,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_kabs32(uint64_t a);
+ int64_t __rv_kabs32(int64_t a);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17089,7 +17089,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_kadd32(uint64_t a, uint64_t b);
+ int64_t __rv_kadd32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17144,7 +17144,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_kcras32(uint64_t a, uint64_t b);
+ int64_t __rv_kcras32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17201,7 +17201,7 @@ This instruction subtracts the 32-bit integer element in [31:0] of Rs2 from the 
 
 * Required:
 
- uint64_t __rv_kcrsa32(uint64_t a, uint64_t b);
+ int64_t __rv_kcrsa32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17292,7 +17292,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_kdmbb16(uint64_t a, uint64_t b);
+ int64_t __rv_kdmbb16(uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17302,7 +17302,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_kdmbt16(uint64_t a, uint64_t b);
+ int64_t __rv_kdmbt16(uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17312,7 +17312,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_kdmtt16(uint64_t a, uint64_t b);
+ int64_t __rv_kdmtt16(uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17413,7 +17413,7 @@ When both the two Q15 inputs are 0x8000, saturation will happen and the overflow
 
 * Required:
 
- uint64_t __rv_kdmabb16(uint64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kdmabb16(int64_t t, uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17423,7 +17423,7 @@ When both the two Q15 inputs are 0x8000, saturation will happen and the overflow
 
 * Required:
 
- uint64_t __rv_kdmabt16(uint64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kdmabt16(int64_t t, uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17433,7 +17433,7 @@ When both the two Q15 inputs are 0x8000, saturation will happen and the overflow
 
 * Required:
 
- uint64_t __rv_kdmatt16(uint64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kdmatt16(int64_t t, uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17523,7 +17523,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_khmbb16(uint64_t a, uint64_t b);
+ int64_t __rv_khmbb16(uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17533,7 +17533,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_khmbt16(uint64_t a, uint64_t b);
+ int64_t __rv_khmbt16(uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17543,7 +17543,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_khmtt16(uint64_t a, uint64_t b);
+ int64_t __rv_khmtt16(uint64_t a, uint64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17646,7 +17646,7 @@ The multiplication result is added to the content of 64-bit data in Rd. If the a
 
 * Required:
 
- int64_t __rv_kmabb32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmabb32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17656,7 +17656,7 @@ The multiplication result is added to the content of 64-bit data in Rd. If the a
 
 * Required:
 
- int64_t __rv_kmabt32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmabt32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17666,7 +17666,7 @@ The multiplication result is added to the content of 64-bit data in Rd. If the a
 
 * Required:
 
- int64_t __rv_kmatt32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmatt32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17756,7 +17756,7 @@ The result is added to the content of 64-bit data in Rd. If the addition result 
 
 * Required:
 
- int64_t __rv_kmada32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmada32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17766,7 +17766,7 @@ The result is added to the content of 64-bit data in Rd. If the addition result 
 
 * Required:
 
- int64_t __rv_kmaxda32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmaxda32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17849,7 +17849,7 @@ The addition result is checked for saturation. If saturation happens, the result
 
 * Required:
 
- int64_t __rv_kmda32(uint64_t a, uint64_t b);
+ int64_t __rv_kmda32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17859,7 +17859,7 @@ The addition result is checked for saturation. If saturation happens, the result
 
 * Required:
 
- int64_t __rv_kmxda32(uint64_t a, uint64_t b);
+ int64_t __rv_kmxda32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17962,7 +17962,7 @@ The subtraction result is then added to the content of 64-bit data in Rd. If the
 
 * Required:
 
- int64_t __rv_kmads32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmads32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17972,7 +17972,7 @@ The subtraction result is then added to the content of 64-bit data in Rd. If the
 
 * Required:
 
- int64_t __rv_kmadrs32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmadrs32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -17982,7 +17982,7 @@ The subtraction result is then added to the content of 64-bit data in Rd. If the
 
 * Required:
 
- int64_t __rv_kmaxds32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmaxds32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18067,7 +18067,7 @@ The two 64-bit multiplication results are then subtracted from the content of Rd
 
 * Required:
 
- int64_t __rv_kmsda32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmsda32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18077,7 +18077,7 @@ The two 64-bit multiplication results are then subtracted from the content of Rd
 
 * Required:
 
- int64_t __rv_kmsxda32(int64_t t, uint64_t a, uint64_t b);
+ int64_t __rv_kmsxda32(int64_t t, int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18133,7 +18133,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_ksll32(uint64_t a, uint32_t b);
+ int64_t __rv_ksll32(int64_t a, uint32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18189,7 +18189,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_ksll32(uint64_t a, uint32_t b);
+ int64_t __rv_ksll32(int64_t a, uint32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18276,7 +18276,7 @@ The left-shifted results are saturated to the 32-bit signed integer range of [-2
 
 * Required:
 
- uint64_t __rv_kslra32(uint64_t a, int32_t b);
+ int64_t __rv_kslra32(int64_t a, int32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18286,7 +18286,7 @@ The left-shifted results are saturated to the 32-bit signed integer range of [-2
 
 * Required:
 
- uint64_t __rv_kslra32_u(uint64_t a, int32_t b);
+ int64_t __rv_kslra32_u(int64_t a, int32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18341,7 +18341,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_kstas32(uint64_t a, uint64_t b);
+ int64_t __rv_kstas32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18398,7 +18398,7 @@ This instruction subtracts the 32-bit integer element in [63:32] of Rs2 from the
 
 * Required:
 
- uint64_t __rv_kstsa32(uint64_t a, uint64_t b);
+ int64_t __rv_kstsa32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18451,7 +18451,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_ksub32(uint64_t a, uint64_t b);
+ int64_t __rv_ksub32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18618,7 +18618,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_radd32(uint64_t a, uint64_t b);
+ int64_t __rv_radd32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18665,7 +18665,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_rcras32(uint64_t a, uint64_t b);
+ int64_t __rv_rcras32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18712,7 +18712,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_rcrsa32(uint64_t a, uint64_t b);
+ int64_t __rv_rcrsa32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18759,7 +18759,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_rstas32(uint64_t a, uint64_t b);
+ int64_t __rv_rstas32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18806,7 +18806,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_rstsa32(uint64_t a, uint64_t b);
+ int64_t __rv_rstsa32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18856,7 +18856,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_rsub32(uint64_t a, uint64_t b);
+ int64_t __rv_rsub32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -18995,7 +18995,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_smax32(uint64_t a, uint64_t b);
+ int64_t __rv_smax32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19095,7 +19095,7 @@ Rd = res;
 
 * Required:
 
- int64_t __rv_smbb32(uint64_t a, uint64_t b);
+ int64_t __rv_smbb32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19105,7 +19105,7 @@ Rd = res;
 
 * Required:
 
- int64_t __rv_smbt32(uint64_t a, uint64_t b);
+ int64_t __rv_smbt32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19115,7 +19115,7 @@ Rd = res;
 
 * Required:
 
- int64_t __rv_smtt32(uint64_t a, uint64_t b);
+ int64_t __rv_smtt32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19212,7 +19212,7 @@ The subtraction result is written to Rd. The 32-bit contents of Rs1 and Rs2 are 
 
 * Required:
 
- int64_t __rv_smds32(uint64_t a, uint64_t b);
+ int64_t __rv_smds32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19222,7 +19222,7 @@ The subtraction result is written to Rd. The 32-bit contents of Rs1 and Rs2 are 
 
 * Required:
 
- int64_t __rv_smdrs32(uint64_t a, uint64_t b);
+ int64_t __rv_smdrs32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19232,7 +19232,7 @@ The subtraction result is written to Rd. The 32-bit contents of Rs1 and Rs2 are 
 
 * Required:
 
- int64_t __rv_smxds32(uint64_t a, uint64_t b);
+ int64_t __rv_smxds32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19277,7 +19277,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_smin32(uint64_t a, uint64_t b);
+ int64_t __rv_smin32(int64_t a, int64_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19354,7 +19354,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_sra32(uint64_t a, uint32_t b);
+ int64_t __rv_sra32(int64_t a, uint32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19364,7 +19364,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_sra32_u(uint64_t a, uint32_t b);
+ int64_t __rv_sra32_u(int64_t a, uint32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19441,7 +19441,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_sra32(uint64_t a, uint32_t b);
+ int64_t __rv_sra32(int64_t a, uint32_t b);
 
 * Optional (e.g., GCC vector extensions):
 
@@ -19451,7 +19451,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- uint64_t __rv_sra32_u(uint64_t a, uint32_t b);
+ int64_t __rv_sra32_u(int64_t a, uint32_t b);
 
 * Optional (e.g., GCC vector extensions):
 


### PR DESCRIPTION
1. fix typos
- 1.1. wext introduction
```
7.181. WEXT (Extract Word from 64-bit)
Type: DSP
RV32: Replaced with FSRI in Zbpbo extension. RV64: Replaced with FSRW in Zbpbo extension.
```
the alias for wext should be `FSR`
- 1.2. bitrevi intrinsic argument type
```
The intrinsic function of this instruction is the same as the intrinsic function of "BITREV" instruction. A compiler can detect constant value in the function msb argument and use this instruction.

 uintXLEN_t __rv_bitrev(uintXLEN_t a, uintXLEN_t msb);
```
change to `uint32_t msb`

2. change the return type of maxw and minw
int32_t as the return type of `intXLEN_t __rv_maxw(int32_t a, int32_t b);`  would be better (__rv_max in zbpbo also uses int32_t).

3. change the argument type of __rv_kmada32
the second argument of `int64_t __rv_kmada32(int64_t t, uint64_t a, uint64_t b);` should be int64_t for the convension with int32x2_t , according to the https://github.com/riscv/riscv-p-spec/pull/81 (also, its alias kmar64 in zbpbo uses int64_t in RV64). 