### PR TITLE
Removed non-overlapped instructions in Zbpbo (according to RVB v1.0.0)

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1,5 +1,5 @@
 = RISC-V "P" Extension Proposal
-Version 0.9.13-draft-20220331
+Version 0.9.14-draft-20220331
 This document is in the Development state. Assume anything can change.
 :doctype: book
 :encoding: utf-8
@@ -20,6 +20,9 @@ This document is in the Development state. Assume anything can change.
 [cols="^.^10,^.^15,^.^15,<.^60", options="header"]
 |===
 |Rev.|Revision Date|Author|Revised Content
+| v0.9.14 | 2022/03/31 | Harry Lin
+a|
+* Changed legal sub-extension combinations in <<Legal_Sub-extension_Combinations>>.
 | v0.9.13 | 2022/03/31 | Harry Lin
 a|
 * Replaced RVM with Zmmul extension in <<Zmmul_Extension>>.
@@ -3434,15 +3437,16 @@ The instructions in Zpsfoperand are listed in the following table.
 The instructions of RV32P and RV64P not in Zbpbo, and Zpsfoperand extensions will be included in this sub-extension.
 This is a required sub-extension for RV32P and RV64P extension.
 
+[#Legal_Sub-extension_Combinations]
 === Legal Sub-extension Combinations
 The legal combinations of the sub-extensions for RV32P and RV64P are listed in the following table.
 
 [cols="^.^,^.^",options="header",]
 |===
-| Legal Sub-extension Combination     |Architecture
-| Zpn + Zbpbo                         |RV32
-| Zpn + Zbpbo + Zpsfoperand           |RV32
-| Zpn + Zbpbo + Zpsfoperand           |RV64
+| Legal Sub-extension Combination      |Architecture
+| Zmmul + Zbpbo + Zpn                  |RV32
+| Zmmul + Zbpbo + Zpn + Zpsfoperand   |RV32
+| Zpn + Zpsfoperand                    |RV64
 |===
 
 [#Detailed_Instruction_Descriptions_for_Zbpbo_Extension]

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -22,7 +22,8 @@ This document is in the Development state. Assume anything can change.
 |Rev.|Revision Date|Author|Revised Content
 | v0.9.13 | 2022/03/31 | Harry Lin
 a|
-* Changed Zmmul is required by RVP (not whole RVM) in <<Zmmul_Extension>>.| v0.9.12 | 2022/03/30 | Harry Lin
+* Replaced RVM with Zmmul extension in <<Zmmul_Extension>>.
+| v0.9.12 | 2022/03/30 | Harry Lin
 a|
 * Removed B instructions, PACK, PACKU, FSR, FSRI, FSRW, REV8.H, CMIX and REV that are not overlapped by Bit-Manipulation Extension version 1.0.0. (<<Bit_Manipulation_Extension>>, <<Zbpbo>> and <<Detailed_Instruction_Descriptions_for_Zbpbo_Extension>>)
 | v0.9.11 | 2021/12/09 | Chuanhua Chang

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1,5 +1,5 @@
 = RISC-V "P" Extension Proposal
-Version 0.9.11-draft-20211209
+Version 0.9.12-draft-20220330
 This document is in the Development state. Assume anything can change.
 :doctype: book
 :encoding: utf-8
@@ -20,6 +20,9 @@ This document is in the Development state. Assume anything can change.
 [cols="^.^10,^.^15,^.^15,<.^60", options="header"]
 |===
 |Rev.|Revision Date|Author|Revised Content
+| v0.9.12 | 2022/03/30 | Harry Lin
+a|
+* Removed B instructions, PACK, PACKU, FSR, FSRI, FSRW, REV8.H, CMIX and REV that are not overlapped by Bit-Manipulation Extension version 1.0.0. (<<Bit_Manipulation_Extension>>, <<Zbpbo>> and <<Detailed_Instruction_Descriptions_for_Zbpbo_Extension>>)
 | v0.9.11 | 2021/12/09 | Chuanhua Chang
 a|
 * Changed source operand data type of KADDH/UKADDH/KSUBH/UKSUBH from 32-bit to 16-bit.
@@ -3320,25 +3323,15 @@ There are four 32-bit packing instructions here.
 
 == Instructions Duplicated with Other Extensions 
 
-=== Bit Manipulation Extension (v0.93)
+[#Bit_Manipulation_Extension]
+=== Bit-Manipulation Extension (version 1.0.0)
 
-[cols="6*^.^",options="header",]
+[cols="5*^.^",options="header",]
 |===
-|P Instruction |B Instruction |B Extension |Partial |RV32 | RV64
-|CLZ32   |CLZ    |Zbb |         |&#10003; |
-|PKBB16  |PACK   |Zbp |         |&#10003; |
-|PKTT16  |PACKU  |Zbp |         |&#10003; |
-|PKBB32  |PACK   |Zbp |         |         |&#10003;
-|PKTT32  |PACKU  |Zbp |         |         |&#10003;
-|WEXT    |FSR    |Zbt |         |&#10003; |
-|WEXTI   |FSRI   |Zbt |         |&#10003; |
-|WEXT    |FSRW   |Zbt |         |         |&#10003;
-|MAXW    |MAX    |Zbb |         |&#10003; |&#10003;
-|MINW    |MIN    |Zbb |         |&#10003; |&#10003;
-|SWAP8   |REV8.H |Zbp |         |&#10003; |&#10003;
-|BPICK   |CMIX   |Zbt |         |&#10003; |&#10003;
-|BITREV  |REV    |Zbp |&#10003; |&#10003; |&#10003;
-|BITREVI |REV    |Zbp |&#10003; |&#10003; |&#10003;
+|P Instruction |B Instruction |B Extension |RV32 | RV64
+|CLZ32   |CLZ     |Zbb   |&#10003; | 
+|MAXW    |MAX     |Zbb   |&#10003; |
+|MINW    |MIN     |Zbb   |&#10003; |
 |===
 
 A RVB extension, Zbpbo, is created to include these overlapped instructions.
@@ -3360,10 +3353,10 @@ Because regular RVM multiplication instructions are required for RVP extension. 
 The P extension instructions will be divided into several Z-extension subsets to
 facilitate the trade-off between implementation complexity and application performance.
 
-
+[#Zbpbo]
 === Zbpbo
 
-The instructions in Zbpbo extension are a subset of Bitmanipulation extension instructions which
+The instructions in Zbpbo extension are a subset of Bit-manipulation extension instructions which
 are needed in the application domains covered by P extension.
 
 The instructions in this extension are listed in the following table.
@@ -3376,16 +3369,8 @@ The instructions in this extension are listed in the following table.
 |Instruction
 
 | &#10003; |          |  CLZ         | Count leading zero
-| &#10003; | &#10003; |  PACK        | Pack
-| &#10003; | &#10003; |  PACKU       | Pack upper
-| &#10003; |          |  FSR         | Funnel shift right
-| &#10003; |          |  FSRI        | Funnel shift right immediate
-|          | &#10003; |  FSRW        | Funnel shift right word
-| &#10003; | &#10003; |  MAX         | Maximum
-| &#10003; | &#10003; |  MIN         | Minimum
-| &#10003; | &#10003; |  REV8.H      | Swap byte within halfword
-| &#10003; | &#10003; |  CMIX        | Conditional bit selection
-| &#10003; | &#10003; |  REV         | Bit reverse
+| &#10003; |          |  MAX         | Maximum
+| &#10003; |          |  MIN         | Minimum
 |===
 
 === Zpsfoperand
@@ -3455,7 +3440,7 @@ The legal combinations of the sub-extensions for RV32P and RV64P are listed in t
 | Zpn + Zbpbo + Zpsfoperand           |RV64
 |===
 
-
+[#Detailed_Instruction_Descriptions_for_Zbpbo_Extension]
 == Detailed Instruction Descriptions for Zbpbo Extension
 
 The sections in this chapter describe the detailed operations of the Zbpbo extension
@@ -3511,209 +3496,9 @@ general purpose register.
  uint32_t __rv_clz(uint32_t a);
 
 <<<
-=== CMIX (Conditional Mix or Bit-wise Pick)
-
-*Extension:* Zbpbo (RV32 and RV64)
-
-*Format:*
-
-[cols="7*^.^"]
-|===
-l|31    27 l|26  25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
-|Rs3 |CMIX +
-11 |Rs2 |Rs1 |CMIX +
-001 |Rd
-|OP +
-0110011
-|===
-
-*Syntax:*
-
- CMIX  Rd, Rs2, Rs1, Rs3
-
-*Alias:*
-
- BPICK Rd, Rs1, Rs3, Rs2
-
-*Purpose:* Select from two source operands based on a bit mask in the third operand.
-
-*Description:* This instruction selects individual bits from Rs1 or Rs3, based on
-the bit mask value in Rs2. If a bit in Rs2 is 1, the corresponding bit is from Rs1;
-otherwise, the corresponding bit is from Rs3. The selection results are written to Rd.
-
-*Operations:*
-
- Rd[x] = Rs2[x]? Rs1[x] : Rs3[x];
- for RV32, x=31..0
- for RV64, x=63..0
-
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-*Intrinsic functions:*
-
-* Required:
-
- uintXLEN_t __rv_cmix(uintXLEN_t Rs1, uintXLEN_t Rs2, uintXLEN_t Rs3);
-
-<<<
-=== FSR, FSRI
-
-==== FSR (Funnel Shift Right / Extract Word from 64-bit)
-
-==== FSRI (Funnel Shift Right Immediate/ Extract Word from 64-bit Immediate)
-
-*Extension:* Zbpbo (RV32)
-
-*Format:*
-
-[.text-center]
-*FSR*
-
-[cols="7*^.^"]
-|===
-l|31    27 l|26  25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
-|Rs3 |FSR +
-10 |Rs2 |Rs1 |FSR +
-101 |Rd
-|OP +
-0110011
-|===
-
-[.text-center]
-*FSRI*
-
-[cols="7*^.^"]
-|===
-l|31    27 l|26 l|25    20 l|19    15 l|14    12 l|11    7 l|6    0
-|Rs3 |FSRI +
-1 |imm6u |Rs1 |FSRI +
-101 |Rd
-|OP-IMM +
-0010011
-|===
-
-
-*Syntax:*
-
- FSR  Rd, Rs1, Rs3, Rs2
- FSRI Rd, Rs1, Rs3, imm6u
-
-*Alias:*
-
- "WEXT Rd, Rs1, Rs2" == "FSR Rd, Rs1, Rs3, Rs2"
-
-where Rs1 is an even register, Rs3 is an even+1 register, and Rs2[5] == 0.
-
- "WEXTI Rd, Rs1, imm5u" == "FSRI Rd, Rs1, Rs3, imm5u"
-
-where Rs1 is an even register, Rs3 is an even+1 register.
-
-*Purpose:* Extract a 32-bit word from a 64-bit value stored in two registers by doing a right rotation.
-
-*Description:* The FSR instruction creates a 64-bit word by concatenating Rs1 and
-Rs3 (with Rs1 in the LSB half), rotate-right-shifts that word by the amount indicated in Rs2[5:0], and then writes the LSB half of the result to Rd.
-
-The FSRI instruction creates a 64-bit word by concatenating Rs1 and
-Rs3 (with Rs1 in the LSB half), rotate-right-shifts that word by the amount indicated in
-imm6u, and then writes the LSB half of the result to Rd.
-
-*Operations:*
-
- shamt = Rs2[5:0];  // FSR
- shamt = imm6u;     // FSRI
-
- lowpt = Rs1;
- highpt = Rs3;
- if (shamt u>= 32) {
-   shamt = shamt - 32;
-   lowpt = Rs3;
-   highpt = Rs1;
- }
- src[63:0] = CONCAT(highpt, lowpt);
- Rd = src[31+shamt:shamt];
- 
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-For RV32, wext/wexti functionality is a subset of
-
- fsr/fsri
-
-*Intrinsic functions:*
-
-* Required:
-
- uint32_t __rv_fsr(uint32_t Rs1, uint32_t Rs2, uint32_t Rs3);
- 
-<<<
-
-=== FSRW (Funnel Shift Right Word)
-
-*Extension:* Zbpbo (RV64)
-
-*Format:*
-
-[cols="7*^.^"]
-|===
-l|31    27 l|26  25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
-|Rs3 |FSRW +
-10 |Rs2 |Rs1 |FSRW +
-101 |Rd
-|OP-32 +
-0111011
-|===
-
-*Syntax:*
-
- FSRW  Rd, Rs1, Rs3, Rs2
-
-*Purpose:* Extract a 32-bit word from a 64-bit value stored in two registers by doing a right rotation.
-
-*Description:* The FSRW instruction creates a 64-bit word by concatenating the lower 32-bits of Rs1 and
-Rs3 (with Rs1 in the LSB half), rotate-right-shifts that word by the amount indicated in Rs2[5:0], and then sign-extends the 32-bit LSB half of the result and writes to Rd.
-
-*Operations:*
-
- shamt = Rs2[5:0];  // FSRW
- lowpt = Rs1.W[0];
- highpt = Rs3.W[0];
- if (shamt u>= 32) {
-   shamt = shamt - 32;
-   lowpt = Rs3.W[0];
-   highpt = Rs1.W[0];
- }
- src[63:0] = CONCAT(highpt, lowpt);
- wres = src[31+shamt:shamt];
- Rd = SE64(wres);
- 
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-For RV64, wext functionality is a subset of
-
- srai r3, rs1, 32
- fsrw rd, rs1, rs3, rs2
-
-*Intrinsic functions:*
-
-* Required:
-
- uint32_t __rv_fsrw(uint32_t Rs1, uint32_t Rs2, uint32_t Rs3);
-
-<<<
 === MAX (Maximum)
 
-*Extension:* Zbpbo (RV32 and RV64)
+*Extension:* Zbpbo (RV32)
 
 *Format:*
 
@@ -3753,12 +3538,12 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- intXLEN_t __rv_max(intXLEN_t a, intXLEN_t b);
+ int32_t __rv_max(int32_t a, int32_t b);
 
 <<<
 === MIN (Minimum)
 
-*Extension:* Zbpbo (RV32 and RV64)
+*Extension:* Zbpbo (RV32)
 
 *Format:*
 
@@ -3798,209 +3583,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 * Required:
 
- intXLEN_t __rv_min(intXLEN_t a, intXLEN_t b);
-
-<<<
-[#pack_packu]  
-=== PACK, PACKU
-
-==== PACK (Pack from Both Bottom Halves)
-
-==== PACKU (Pack from Both Top Halves)
-
-*Extension:* Zbpbo (RV32/RV64)
-
-*Format:*
-
-[.text-center]
-*PACK*
-
-[cols="6*^.^"]
-|===
-l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
-|PACK +
-0000100 |Rs2 |Rs1 |100 |Rd
-|OP +
-0110011
-|===
-
-[.text-center]
-*PACKU*
-
-[cols="6*^.^"]
-|===
-l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
-|PACKU +
-0100100 |Rs2 |Rs1 |100 |Rd
-|OP +
-0110011
-|===
-
-*Syntax:*
-
- PACK  Rd, Rs1, Rs2
- PACKU Rd, Rs1, Rs2
-
-*Alias:*
-
- PKBB16R == PACK, PKTT16R == PACKU  // RV32
- PKBB32R == PACK, PKTT32R == PACKU  // RV64
-
-*Purpose:* Pack the bottom or top halves of two registers.
-
-* PACK: bottom.bottom
-* PACKU: top.top
-
-*Description:*
-
-(PACK) The PACK instruction packs the XLEN/2-bit lower halves of rs1 and rs2 into rd, with rs1 in the lower half and rs2 in the upper half.
-
-(PACKU) The PACKU instruction packs the XLEN/2-bit upper halves of rs1 and rs2 into rd, with rs1 in the lower half and rs2 in the upper half.
-
-*Operations:*
-
-*RV32*
-
- Rd = CONCAT(Rs2.H[0], Rs1.H[0]); // PACK
- Rd = CONCAT(Rs2.H[1], Rs1.H[1]); // PACKU
-
-*RV64*
-
- Rd = CONCAT(Rs2.W[0], Rs1.W[0]); // PACK
- Rd = CONCAT(Rs2.W[1], Rs1.W[1]); // PACKU
-
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-*Intrinsic functions:*
-
-* *PACK*
-
-* Required:
-
- uintXLEN_t __rv_pack(uintXLEN_t a, uintXLEN_t b);
-
-* *PACKU*
-
-* Required:
-
- uintXLEN_t __rv_packu(uintXLEN_t a, uintXLEN_t b);
-
-<<<
-=== REV (Bit Reverse XLEN bits)
-
-*Extension:* Zbpbo (RV32 and RV64)
-
-*Format:*
-
-[.text-center]
-*RV32*
-
-[cols="6*^.^"]
-|===
-l|31    26 l|25    20 l|19    15 l|14    12 l|11    7 l|6    0
-|GREVI +
-011010 |REV +
-011111 |Rs1 |101 |Rd
-|OP-IMM +
-0010011
-|===
-
-[.text-center]
-*RV64*
-
-[cols="6*^.^"]
-|===
-l|31    26 l|25    20 l|19    15 l|14    12 l|11    7 l|6    0
-|GREVI +
-011010 |REV +
-111111 |Rs1 |101 |Rd
-|OP-IMM +
-0010011
-|===
-
-*Syntax:*
-
- REV  Rd, Rs1
-
-*Purpose:* Reverse the bits of a register.
-
-*Description:* This instruction reverses the XLEN bits of Rs1.
-
-*Operations:*
-
- rev[0:(XLEN-1)] = Rs1[(XLEN-1):0];
- Rd = rev[(XLEN-1):0];
-
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-*Intrinsic functions:*
-
-* Required:
-
- uintXLEN_t __rv_rev(uintXLEN_t a);
-
-<<<
-=== REV8.H (Swap Byte within Halfword)
-
-*Extension:* Zbpbo (RV32 and RV64)
-
-*Format:*
-
-[cols="6*^.^"]
-|===
-l|31    26 l|25    20 l|19    15 l|14    12 l|11    7 l|6    0
-|GREVI +
-011010 |REV8H +
-001000 |Rs1 |101 |Rd
-|OP-IMM +
-0010011
-|===
-
-*Syntax:*
-
- REV8.H  Rd, Rs1
-
-*Alias:*
-
- SWAP8  Rd, Rs1
-
-*Purpose:* Swap the bytes within each halfword of a register.
-
-*Description:* This instruction swaps the bytes within each halfword of Rs1 and writes the result to Rd.
-
-*Operations:*
-
- Rd.H[x] = CONCAT(Rs1.H[x].B[0],Rs1.H[x].B[1]);
- for RV32: x=1..0,
- for RV64: x=3..0
-
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-*Intrinsic functions:*
-
-* Required:
-
- uintXLEN_t __rv_rev8h(uintXLEN_t a);
-
-* Optional (e.g., GCC vector extensions):
-
- RV32:
-   uint8x4_t __rv_v_rev8h(uint8x4_t a);
- RV64:
-   uint8x8_t __rv_v_rev8h(uint8x8_t a);
-
+ int32_t __rv_min(int32_t a, int32_t b);
 
 == Detailed Instruction Descriptions for Zpn Extension (both RV32 & RV64)
 

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1,5 +1,5 @@
 = RISC-V "P" Extension Proposal
-Version 0.9.14-draft-20220331
+Version 0.9.15-draft-20220331
 This document is in the Development state. Assume anything can change.
 :doctype: book
 :encoding: utf-8
@@ -20,6 +20,13 @@ This document is in the Development state. Assume anything can change.
 [cols="^.^10,^.^15,^.^15,<.^60", options="header"]
 |===
 |Rev.|Revision Date|Author|Revised Content
+| v0.9.15 | 2022/03/31 | Harry Lin
+a|
+For instruction summary in <<RISC-V_P_Extension_Instruction_Summary>>, 
+
+* Added MAXW and MINW instructions to <<32-bit_Computation_Instructions>>.
+* Added BPICK instruction to <<Miscellaneous_Instructions>>.
+* Removed CMIX instruction from <<Miscellaneous_Instructions>>.
 | v0.9.14 | 2022/03/31 | Harry Lin
 a|
 * Changed legal sub-extension combinations in <<Legal_Sub-extension_Combinations>>.
@@ -165,6 +172,7 @@ power and higher performance.
 
 
 <<<
+[#RISC-V_P_Extension_Instruction_Summary] 
 == RISC-V P Extension Instruction Summary
 
 === SIMD Data Processing Instructions
@@ -2591,9 +2599,10 @@ rd = SE64(SAT.Q31(ABS(rs1.W[0])));
 |===
 
 <<<
+[#32-bit_Computation_Instructions]
 ==== 32-bit Computation Instructions
 
-There are 7 instructions here.
+There are 9 instructions here.
 
 .32-bit Computation Instructions
 [cols="^.^1,<.^2,<.^2,<.^4",options="header",]
@@ -2619,7 +2628,21 @@ b0 = CONCAT(1'b0, rs2.W[0]);
 res = (a0 - b0) u>> 1;
 rd = SE_XLEN(res);
 
-|5 |MULR64 rd, rs1, rs2 |Multiply Word Unsigned to 64-bit data l|
+|5 |MAXW rd, rs1, rs2 |32-bit Signed Word Maximum l|
+if (rs1.W[0] s>= rs2.W[0]) {
+   rd = SE_XLEN(rs1.W[0]);
+else {
+   rd = SE_XLEN(rs2.W[0]);
+}
+
+|6 |MINW rd, rs1, rs2 |32-bit Signed Word Minimum l|
+if (rs1.W[0] s>= rs2.W[0]) {
+   rd = SE_XLEN(rs2.W[0]);
+else {
+   rd = SE_XLEN(rs1.W[0]);
+}
+
+|7 |MULR64 rd, rs1, rs2 |Multiply Word Unsigned to 64-bit data l|
 RV32:
 mres[63:0] = rs1 u* rs2;
 r[dU] = mres.W[1];
@@ -2628,7 +2651,7 @@ r[dL] = mres.W[0];
 RV64:
 rd = rs1.W[0] u* rs2.W[0];
 
-|6 |MULSR64 rd, rs1, rs2 |Multiply Word Signed to 64-bit data l|
+|8 |MULSR64 rd, rs1, rs2 |Multiply Word Signed to 64-bit data l|
 RV32:
 mres[63:0] = rs1 s* rs2;
 r[dU] = mres.W[1];
@@ -2637,7 +2660,7 @@ r[dL] = mres.W[0];
 RV64:
 rd = rs1.W[0] s* rs2.W[0];
 
-|7 |MSUBR32 rd, rs1, rs2 |Multiply and Subtract from 32-bit Word l|
+|9 |MSUBR32 rd, rs1, rs2 |Multiply and Subtract from 32-bit Word l|
 RV32:
 mres = rs1 * rs2;
 rd = rd - mres.W[0];
@@ -2665,6 +2688,7 @@ vxsat.OV = 0;
 |===
 
 <<<
+[#Miscellaneous_Instructions]
 ==== Miscellaneous Instructions
 
 There are 13 instructions here.
@@ -2736,9 +2760,10 @@ lsb = imm5u;
 exword = a64[(31+lsb):lsb];
 rd = SE64(exword);
 
-|8 |CMIX rd, rs2, rs1, rs3 |Conditional Mix l|
-rd[i] = rs2[i]? rs1[i] : rs3[i];
+|8 |BPICK rd, rs1, rs2, rc |Bit-wise Pick l|
+rd[i] = rc[i]? rs1[i] : rs2[i];
 (RV32: i=31..0, RV64: i=63..0)
+
 |9 |INSB rd, rs1, imm2u/imm3u |Insert Byte l|
 RV32:
 byte_idx = imm2u;

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1,5 +1,5 @@
 = RISC-V "P" Extension Proposal
-Version 0.9.15-draft-20220331
+Version 0.9.16-draft-20220331
 This document is in the Development state. Assume anything can change.
 :doctype: book
 :encoding: utf-8
@@ -20,6 +20,11 @@ This document is in the Development state. Assume anything can change.
 [cols="^.^10,^.^15,^.^15,<.^60", options="header"]
 |===
 |Rev.|Revision Date|Author|Revised Content
+| v0.9.16 | 2022/03/31 | Harry Lin
+a|
+* Moved detailed description of BPICK, MAXW and MINW instructions that are not 
+overlapped by Bit-Manipulation Extension version 1.0.0 to <<Detailed_Instruction_Descriptions_for_Zpn>> 
+(<<bpick>>, <<maxw>> and <<minw>>) from <<Removed_Instructions_Due_to_RVB_overlaps>>.
 | v0.9.15 | 2022/03/31 | Harry Lin
 a|
 For instruction summary in <<RISC-V_P_Extension_Instruction_Summary>>, 
@@ -35,7 +40,9 @@ a|
 * Replaced RVM with Zmmul extension in <<Zmmul_Extension>>.
 | v0.9.12 | 2022/03/30 | Harry Lin
 a|
-* Removed B instructions, PACK, PACKU, FSR, FSRI, FSRW, REV8.H, CMIX and REV that are not overlapped by Bit-Manipulation Extension version 1.0.0. (<<Bit_Manipulation_Extension>>, <<Zbpbo>> and <<Detailed_Instruction_Descriptions_for_Zbpbo_Extension>>)
+* Removed B instructions, PACK, PACKU, FSR, FSRI, FSRW, REV8.H, CMIX and REV that are not 
+overlapped by Bit-Manipulation Extension version 1.0.0. (<<Bit_Manipulation_Extension>>, 
+<<Zbpbo>> and <<Detailed_Instruction_Descriptions_for_Zbpbo_Extension>>)
 | v0.9.11 | 2021/12/09 | Chuanhua Chang
 a|
 * Changed source operand data type of KADDH/UKADDH/KSUBH/UKSUBH from 32-bit to 16-bit.
@@ -3619,6 +3626,7 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
  int32_t __rv_min(int32_t a, int32_t b);
 
+[#Detailed_Instruction_Descriptions_for_Zpn]
 == Detailed Instruction Descriptions for Zpn Extension (both RV32 & RV64)
 
 The sections in this chapter describe the detailed operations of the P extension
@@ -3964,6 +3972,48 @@ The intrinsic function of this instruction is the same as the intrinsic function
 
  uintXLEN_t __rv_bitrev(uintXLEN_t a, uint32_t msb);
 
+<<<
+[#bpick]
+=== BPICK (Bit-wise Pick)
+
+*Type:* DSP
+
+*Format:*
+
+[cols="7*^.^"]
+|===
+l|31    27 l|26    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
+|Rc |BPICK +
+00 |Rs2 |Rs1 |011 |Rd
+|OP-P +
+1110111
+|===
+
+*Syntax:*
+
+ BPICK Rd, Rs1, Rs2, Rc
+
+*Purpose:* Select from two source operands based on a bit mask in the third operand.
+
+*Description:* This instruction selects individual bits from Rs1 or Rs2, based on
+the bit mask value in Rc. If a bit in Rc is 1, the corresponding bit is from Rs1;
+otherwise, the corresponding bit is from Rs2. The selection results are written to Rd.
+
+*Operations:*
+
+ Rd[x] = Rc[x]? Rs1[x] : Rs2[x];
+ for RV32, x=31..0
+ for RV64, x=63..0
+
+*Exceptions:* None
+
+*Privilege level:* All
+
+*Note:*
+
+*Intrinsic functions:*
+
+ uintXLEN_t __rv_bpick(uintXLEN_t a, uintXLEN_t b, uintXLEN_t c);
 
 <<<
 === CLROV (Clear OV flag)
@@ -8751,6 +8801,96 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 *Intrinsic functions:*
 
  int32_t __rv_maddr32(int32_t t, int32_t a, int32_t b);
+
+<<<
+[#maxw]
+=== MAXW (32-bit Signed Word Maximum)
+
+*Type:* DSP
+
+*Format:*
+
+[cols="6*^.^"]
+|===
+l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
+|MAXW +
+1111001 |Rs2 |Rs1 |000 |Rd
+|OP-P +
+1110111
+|===
+
+*Syntax:*
+
+ MAXW Rd, Rs1, Rs2
+
+*Purpose:* Select the larger value from the 32-bit contents of two general purpose registers.
+
+*Description:* This instruction compares two signed 32-bit integers stored in Rs1 and Rs2, picks the larger value as the result, and writes the result to Rd.
+
+*Operations:*
+
+ if (Rs1.W[0] s>= Rs2.W[0]) {
+   res = Rs1.W[0];
+ } else {
+   res = Rs2.W[0];
+ }
+ Rd = res;       // RV32
+ Rd = SE64(res); // RV64 
+
+*Exceptions:* None
+
+*Privilege level:* All
+
+*Note:*
+
+*Intrinsic functions:*
+
+ int32_t __rv_maxw(int32_t a, int32_t b);
+
+<<<
+[#minw]
+=== MINW (32-bit Signed Word Minimum)
+
+*Type:* DSP
+
+*Format:*
+
+[cols="6*^.^"]
+|===
+l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
+|MINW +
+1111000 |Rs2 |Rs1 |000 |Rd
+|OP-P +
+1110111
+|===
+
+*Syntax:*
+
+ MINW Rd, Rs1, Rs2
+
+*Purpose:* Select the smaller value from the 32-bit contents of two general purpose registers.
+
+*Description:* This instruction compares two signed 32-bit integers stored in Rs1 and Rs2, picks the smaller value as the result, and writes the result to Rd.
+
+*Operations:*
+
+ if (Rs1.W[0] s>= Rs2.W[0]) {
+   res = Rs2.W[0];
+ } else {
+   res = Rs1.W[0];
+ }
+ Rd = res;       // RV32
+ Rd = SE64(res); // RV64
+
+*Exceptions:* None
+
+*Privilege level:* All
+
+*Note:*
+
+*Intrinsic functions:*
+
+ int32_t __rv_minw(int32_t a, int32_t b);
 
 <<<
 === MSUBR32 (Multiply and Subtract from 32-Bit Word)
@@ -20814,140 +20954,6 @@ l|XLEN-1                                     1 |0
 |81 |URSUB32 |1 |1
 |===
 
+[#Removed_Instructions_Due_to_RVB_overlaps]
 == Removed Instructions Due to RVB overlaps
 
-<<<
-=== BPICK (Bit-wise Pick)
-
-*Type:* RV32 and RV64
-
-Replaced with CMIX in Zbpbo extension.
-
-*Format:*
-
-[cols="7*^.^"]
-|===
-l|31    27 l|26    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
-|Rc |BPICK +
-00 |Rs2 |Rs1 |011 |Rd
-|OP-P +
-1110111
-|===
-
-*Syntax:*
-
- BPICK Rd, Rs1, Rs2, Rc
-
-*Purpose:* Select from two source operands based on a bit mask in the third operand.
-
-*Description:* This instruction selects individual bits from Rs1 or Rs2, based on
-the bit mask value in Rc. If a bit in Rc is 1, the corresponding bit is from Rs1;
-otherwise, the corresponding bit is from Rs2. The selection results are written to Rd.
-
-*Operations:*
-
- Rd[x] = Rc[x]? Rs1[x] : Rs2[x];
- for RV32, x=31..0
- for RV64, x=63..0
-
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-*Intrinsic functions:*
-
- uintXLEN_t __rv_bpick(uintXLEN_t a, uintXLEN_t b, uintXLEN_t c);
-
-<<<
-=== MAXW (32-bit Signed Word Maximum)
-
-*Type:* DSP
-
-Replaced with MAX in Zbpbo extension.
-
-*Format:*
-
-[cols="6*^.^"]
-|===
-l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
-|MAXW +
-1111001 |Rs2 |Rs1 |000 |Rd
-|OP-P +
-1110111
-|===
-
-*Syntax:*
-
- MAXW Rd, Rs1, Rs2
-
-*Purpose:* Select the larger value from the 32-bit contents of two general purpose registers.
-
-*Description:* This instruction compares two signed 32-bit integers stored in Rs1 and Rs2, picks the larger value as the result, and writes the result to Rd.
-
-*Operations:*
-
- if (Rs1.W[0] s>= Rs2.W[0]) {
-   res = Rs1.W[0];
- } else {
-   res = Rs2.W[0];
- }
- Rd = res;       // RV32
- Rd = SE64(res); // RV64 
-
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-*Intrinsic functions:*
-
- int32_t __rv_maxw(int32_t a, int32_t b);
-
-<<<
-=== MINW (32-bit Signed Word Minimum)
-
-*Type:* DSP
-
-Replaced with MIN in Zbpbo extension.
-
-*Format:*
-
-[cols="6*^.^"]
-|===
-l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
-|MINW +
-1111000 |Rs2 |Rs1 |000 |Rd
-|OP-P +
-1110111
-|===
-
-*Syntax:*
-
- MINW Rd, Rs1, Rs2
-
-*Purpose:* Select the smaller value from the 32-bit contents of two general purpose registers.
-
-*Description:* This instruction compares two signed 32-bit integers stored in Rs1 and Rs2, picks the smaller value as the result, and writes the result to Rd.
-
-*Operations:*
-
- if (Rs1.W[0] s>= Rs2.W[0]) {
-   res = Rs2.W[0];
- } else {
-   res = Rs1.W[0];
- }
- Rd = res;       // RV32
- Rd = SE64(res); // RV64
-
-*Exceptions:* None
-
-*Privilege level:* All
-
-*Note:*
-
-*Intrinsic functions:*
-
- int32_t __rv_minw(int32_t a, int32_t b);

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1,5 +1,5 @@
 = RISC-V "P" Extension Proposal
-Version 0.9.12-draft-20220330
+Version 0.9.13-draft-20220331
 This document is in the Development state. Assume anything can change.
 :doctype: book
 :encoding: utf-8
@@ -20,7 +20,9 @@ This document is in the Development state. Assume anything can change.
 [cols="^.^10,^.^15,^.^15,<.^60", options="header"]
 |===
 |Rev.|Revision Date|Author|Revised Content
-| v0.9.12 | 2022/03/30 | Harry Lin
+| v0.9.13 | 2022/03/31 | Harry Lin
+a|
+* Changed Zmmul is required by RVP (not whole RVM) in <<Zmmul_Extension>>.| v0.9.12 | 2022/03/30 | Harry Lin
 a|
 * Removed B instructions, PACK, PACKU, FSR, FSRI, FSRW, REV8.H, CMIX and REV that are not overlapped by Bit-Manipulation Extension version 1.0.0. (<<Bit_Manipulation_Extension>>, <<Zbpbo>> and <<Detailed_Instruction_Descriptions_for_Zbpbo_Extension>>)
 | v0.9.11 | 2021/12/09 | Chuanhua Chang
@@ -3336,15 +3338,17 @@ There are four 32-bit packing instructions here.
 
 A RVB extension, Zbpbo, is created to include these overlapped instructions.
 
-=== RV32M Extension
+[#Zmmul_Extension]
+=== Zmmul Extension (Version 0.1) of M Extension
 
-[cols="6*^.^",options="header",]
+[cols="5*^.^",options="header",]
 |===
-|P Instruction |M Instruction |M Extension |Partial |RV32 | RV64
-|SMMUL   |MULH    |RVM |         |&#10003; |
+|P Instruction |M Instruction |M Extension |RV32 | RV64
+|SMMUL   |MULH    |Zmmul |&#10003; |
 |===
 
-Because regular RVM multiplication instructions are required for RVP extension. No special RVM extension needs to be created to include MULH instruction.
+Because regular multiplication instructions are required for RVP extension. No special Zmmul extension needs to be created to include MULH instruction.
+
 
 
 [#pext_subset]

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1,5 +1,5 @@
 = RISC-V "P" Extension Proposal
-Version 0.9.16-draft-20220331
+Version 0.9.17-draft-20220331
 This document is in the Development state. Assume anything can change.
 :doctype: book
 :encoding: utf-8
@@ -20,6 +20,10 @@ This document is in the Development state. Assume anything can change.
 [cols="^.^10,^.^15,^.^15,<.^60", options="header"]
 |===
 |Rev.|Revision Date|Author|Revised Content
+| v0.9.17 | 2022/03/31 | Harry Lin
+a|
+* Removed "Replaced with ..." in detailed description of BITREV, BITREVI, PKBB16, PKTT16, SWAP8, WEXTI and WEXT. 
+(<<bitrev>>, <<bitrevi>>, <<pkxx16>>, <<swap8>>, <<wexti>> and <<wext>>)
 | v0.9.16 | 2022/03/31 | Harry Lin
 a|
 * Moved detailed description of BPICK, MAXW and MINW instructions that are not 
@@ -3863,11 +3867,10 @@ writes the result to Rd.
  intXLEN_t __rv_ave(intXLEN_t a, intXLEN_t b);
 
 <<<
+[#bitrev]
 === BITREV (Bit Reverse)
 
 *Type:* DSP
-
-Replaced with REV in Zbpbo extension.
 
 *Format:*
 
@@ -3907,11 +3910,10 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
  uintXLEN_t __rv_bitrev(uintXLEN_t a, uint32_t msb);
 
 <<<
+[#bitrevi]
 ===  BITREVI (Bit Reverse Immediate)
 
 *Type:* DSP
-
-Replaced with REV in Zbpbo extension.
 
 *Format:*
 
@@ -9175,9 +9177,6 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 
 *Type:* DSP
 
-* PKBB16: RV32: Replaced with PACK in Zbpbo, RV64: Zpn
-* PKTT16: RV32: Replaced with PACKU in Zbpbo, RV64: Zpn
-
 *Format:*
 
 [cols="6*^.^"]
@@ -9192,23 +9191,15 @@ l|31    25 l|24    20 l|19    15 l|14    12 l|11    7 l|6    0
 [cols="4*^.^",options="header",]
 |===
 |*[.underline]#xy#* |*[.underline]#zz#* |RV32 |RV64
-|BB |00 |         |&#10003;
+|BB |00 |&#10003; |&#10003;
 |BT |01 |&#10003; |&#10003;
-|TT |10 |         |&#10003;
+|TT |10 |&#10003; |&#10003;
 |TB |11 |&#10003; |&#10003;
 |===
 
-For RV32 PACK/PACKU encoding format, please see <<pack_packu>>.
 
 *Syntax:*
 
- RV32:
- PKBB16 Rd, Rs1, Rs2 == PACK Rd, Rs2, Rs1
- PKBT16 Rd, Rs1, Rs2
- PKTT16 Rd, Rs1, Rs2 == PACKU Rd, Rs2, Rs1
- PKTB16 Rd, Rs1, Rs2
-
- RV64:
  PKBB16 Rd, Rs1, Rs2
  PKBT16 Rd, Rs1, Rs2
  PKTT16 Rd, Rs1, Rs2
@@ -13709,11 +13700,10 @@ halfwords and writes the results to the top part and the bottom part of 32-bit c
    int16x4_t __rv_v_sunpkd832(int8x8_t a);
 
 <<<
+[#swap8]
 === SWAP8 (Swap Byte within Halfword)
 
 *Type:* DSP
-
-Replaced with REV8.H in Zbpbo extension.
 
 *Format:*
 
@@ -16353,11 +16343,10 @@ right-shifted by 1 bit and then sign-extended and written to Rd.
  uint32_t __rv_ursubw(uint32_t a, uint32_t b);
 
 <<<
+[#wexti]
 === WEXTI (Extract Word from 64-bit Immediate)
 
 *Type:* DSP
-
-RV32: Replaced with FSRI in Zbpbo extension.
 
 *Sub-extension:* Zpsfoperand
 
@@ -16416,12 +16405,10 @@ This instruction extracts a 32-bit word from a 64-bit value in Rs1 starting from
  intXLEN_t __rv_wext(uint64_t a, uint32_t b);
 
 <<<
+[#wext]
 === WEXT (Extract Word from 64-bit)
 
 *Type:* DSP
-
-RV32: Replaced with FSR in Zbpbo extension.
-RV64: Replaced with FSRW in Zbpbo extension.
 
 *Sub-extension:* Zpsfoperand
 


### PR DESCRIPTION

Removed B instructions, PACK, PACKU, FSR, FSRI, FSRW, REV8.H, CMIX and
REV that are not overlapped by Bit-Manipulation Extension version 1.0.0.