### PR TITLE
docs: fix document structure and formatting issues

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -925,7 +925,7 @@ The PADD.BS instruction adds the least-significant byte of `rs2` to each packed
 ==== Notes
 
 * Each 8-bit element addition wraps modulo 2^8.
-* The scalar operand is taken only from bits [7:0] of `rs2`; hig*
+* The scalar operand is taken only from bits [7:0] of `rs2`; higher bits are ignored.
 
 === PABD.B
 
@@ -10999,7 +10999,7 @@ is written to `x(2*rdp+1)`.
 ==== Notes
 
 * If `rdp=0`, the result is not written.
-* The destination is the re*
+* The destination is the register pair `x(2*rdp)` and `x(2*rdp+1)`.
 
 === PWMACC.H (RV32)
 


### PR DESCRIPTION
## Summary

This PR addresses several document structure and formatting issues in the P-extension proposal.

## Changes

1. **Update version number** (`d546a46`)
   - Update title from "Version 0.1-draft" to "Version 0.12-draft" to match the Revision History
   - Note: The actual spec version should be 0.18 or 0.19, but for now we keep it consistent with the Revision History table

2. **Replace manual TOC with auto-generated `:toc:`** (`5c127f4`)
   - Remove the non-standard manual Table of Contents using `link:#xxx[...]` format
   - Use AsciiDoc's automatic `:toc:` macro to ensure chapter numbers and links stay consistent with actual content
   - This also fixes the incorrect Appendix A link that pointed to non-existent `PSHADD.H` instruction

3. **Fix truncated text in instruction notes** (`b5fb6cc`)
   - PADD.BS: Complete truncated text `hig*` → `higher bits are ignored.`
   - PWMULSU.H: Complete truncated text `The destination is the re*` → `The destination is the register pair x(2*rdp) and x(2*rdp+1).`