### PR TITLE
Correct the formatting of the instruction name table

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -178,11 +178,15 @@ SUB
 a|
 V
 
+{nbsp}
+
 Common
 
 Common
 
 V
+
+{nbsp}
 
 Zbb
 
@@ -198,17 +202,39 @@ Common
 
 M
 
+{nbsp}
+
+{nbsp}
+
+{nbsp}
+
+{nbsp}
+
 V
 
-I
+{nbsp}
+
+{nbsp}
+
+{nbsp}
 
 I
 
 I
+
+{nbsp}
+
+I
+
+{nbsp}
+
+{nbsp}
+
+{nbsp}
 
 V
 
-common
+Common
 
 a|
 Averaging addition, (a+b)/2
@@ -287,6 +313,10 @@ V
 
 V
 
+{nbsp}
+
+{nbsp}
+
 V
 
 a|
@@ -314,7 +344,11 @@ NSRL
 a|
 V
 
+{nbsp}
+
 V
+
+{nbsp}
 
 V
 


### PR DESCRIPTION
We need to add {nbsp} to all of the empty spots we want in the Precedent column. Otherwise that column has less paragraphs than the others and gets vertically centered.