### PR TITLE
Correct the major opcode name for some instructions.

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -931,7 +931,7 @@ The PADD.BS instruction adds the least-significant byte of `rs2` to each packed
 
 ==== Encoding
 
-PABD.B is encoded in the OP-IMM-32 major opcode. It uses packed byte elements.
+PABD.B is encoded in the OP-32 major opcode. It uses packed byte elements.
 
 [cols="^,^,^,^,^,^,^,^"]
 |===


### PR DESCRIPTION
I did this based on the opcode bits in the encoding. If the encoding is not correct, I did not catch it.