### PR TITLE
Adding dependency and supported RV architecture

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -37,7 +37,7 @@ these various DSP applications with lower power and higher performance.
 
 The P extension depends on Zba and Zbb extensions.
 
-The P extension isdefined for RV32 (RV32E?) and RV64.
+The P extension is defined for RV32 (RV32E?) and RV64.
 
 
 == Instruction Mnemonic Naming Conventions


### PR DESCRIPTION
Adding an early section for P extension details including dependencies and supported architectures.


It seemed that P dependencies (mentioned in the ratification plan) were never listed in the actual specification.