### PR TITLE
Adding mention of Zmmul dependency

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -35,7 +35,7 @@ these various DSP applications with lower power and higher performance.
 
 == P extension for Packed Single Instruction Multiple Data, version 0.12
 
-The P extension depends on Zba and Zbb extensions.
+The P extension depends on Zmmul, Zba and Zbb extensions.
 
 The P extension is defined for RV32 (RV32E?) and RV64.
 


### PR DESCRIPTION
Making the other dependency to the integer multiply instructions (Zmmul extension) explicit.

Dependency being discussed in https://lists.riscv.org/g/tech-p-ext/topic/117659395#msg859