### PR TITLE
P-ext: add Load Immediate instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -739,35 +739,319 @@ corresponding `rd+`, `rs1+`, or `rs2+` also denotes `x0`.
 
 ==== PLI.B
 
-TODO: Add missing PLI.B
+===== Encoding
+
+PLI.B is encoded in the OP-IMM-32 major opcode with an 8-bit immediate
+and packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0x2 },
+    { bits: 8, name: 'imm[7:0]' },
+    { bits: 8, name: 0xb4 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+for i = 0 .. (XLEN/8 - 1):
+    d[(8*i+7):(8*i)] = imm[7:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PLI.B (Packed Load Immediate, Byte) loads an 8-bit immediate into every
+byte element of `rd`.
 
 ==== PLI.H
 
-TODO: Add missing PLI.H
+===== Encoding
+
+PLI.H is encoded in the OP-IMM-32 major opcode with a 10-bit signed immediate
+and packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 10, name: 'imm[8:0|9]' },
+    { bits: 2, name: 0x0 },
+    { bits: 5, name: 0x16 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+imm_h = sign_extend(16, imm[9:0])
+
+for i = 0 .. (XLEN/16 - 1):
+    d[(16*i+15):(16*i)] = imm_h
+
+X[rd] = d
+----
+
+===== Description
+
+PLI.H (Packed Load Immediate, Halfword) sign-extends a 10-bit signed immediate
+to 16 bits and replicates it into every halfword element of `rd`.
 
 ==== PLI.W
 
-TODO: Add missing PLI.W
+===== Encoding
+
+PLI.W is encoded in the OP-IMM-32 major opcode with a 10-bit signed immediate
+and packed word elements. This instruction exists only for RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 10, name: 'imm[8:0|9]' },
+    { bits: 2, name: 0x1 },
+    { bits: 5, name: 0x16 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+imm_w = sign_extend(32, imm[9:0])
+
+for i = 0 .. (XLEN/32 - 1):
+    d[(32*i+31):(32*i)] = imm_w
+
+X[rd] = d
+----
+
+===== Description
+
+PLI.W (Packed Load Immediate, Word) sign-extends a 10-bit signed immediate
+to 32 bits and replicates it into every word element of `rd`. This instruction
+is available only on RV64.
 
 ==== PLUI.H
 
-TODO: Add missing PLUI.H
+===== Encoding
+
+PLUI.H is encoded in the OP-IMM-32 major opcode with a 10-bit immediate
+loaded into the upper bits of each halfword element.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 10, name: 'imm[6|15:7]' },
+    { bits: 2, name: 0x0 },
+    { bits: 5, name: 0x1e },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+imm_h = sign_extend(16, imm[9:0] << 6)
+
+for i = 0 .. (XLEN/16 - 1):
+    d[(16*i+15):(16*i)] = imm_h
+
+X[rd] = d
+----
+
+===== Description
+
+PLUI.H (Packed Load Upper Immediate, Halfword) loads a 10-bit signed immediate
+into the most-significant 10 bits of each 16-bit halfword element, with the
+lower 6 bits set to zero, and replicates the result into every halfword
+element of `rd`.
 
 ==== PLUI.W
 
-TODO: Add missing PLUI.W
+===== Encoding
+
+PLUI.W is encoded in the OP-IMM-32 major opcode with a 10-bit immediate
+loaded into the upper bits of each word element. This instruction exists
+only for RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 10, name: 'imm[22|31:23]' },
+    { bits: 2, name: 0x1 },
+    { bits: 5, name: 0x1e },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+imm_w = sign_extend(32, imm[9:0] << 22)
+
+for i = 0 .. (XLEN/32 - 1):
+    d[(32*i+31):(32*i)] = imm_w
+
+X[rd] = d
+----
+
+===== Description
+
+PLUI.W (Packed Load Upper Immediate, Word) loads a 10-bit signed immediate
+into the most-significant 10 bits of each 32-bit word element, with the
+lower 22 bits set to zero, and replicates the result into every word element
+of `rd`. This instruction is available only on RV64.
 
 ==== PLI.DB
 
-TODO: Add missing PLI.DB
+===== Encoding
+
+PLI.DB is encoded in the OP-IMM-32 major opcode (register-pair variant)
+with an 8-bit immediate and packed byte elements. This instruction exists
+only for RV32 and uses a register-pair destination `rd_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x2 },
+    { bits: 8, name: 'imm[7:0]' },
+    { bits: 8, name: 0x34 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+for i = 0 .. 3:
+    d_lo[(8*i+7):(8*i)] = imm[7:0]
+
+for i = 0 .. 3:
+    d_hi[(8*i+7):(8*i)] = imm[7:0]
+
+if (rd_p != 0):
+    X[2*rd_p] = d_lo
+    X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PLI.DB (Packed Load Immediate, Double-wide Byte) loads an 8-bit immediate
+into every byte element of the register pair designated by `rd_p`. This is
+equivalent to performing PLI.B on both the even and odd registers of the
+pair. This instruction is available only on RV32.
 
 ==== PLI.DH
 
-TODO: Add missing PLI.DH
+===== Encoding
+
+PLI.DH is encoded in the OP-IMM-32 major opcode (register-pair variant)
+with a 10-bit signed immediate and packed halfword elements. This instruction
+exists only for RV32 and uses a register-pair destination `rd_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 10, name: 'imm[8:0|9]' },
+    { bits: 2, name: 0x0 },
+    { bits: 5, name: 0x6 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+imm_h = sign_extend(16, imm[9:0])
+
+for i = 0 .. 1:
+    d_lo[(16*i+15):(16*i)] = imm_h
+
+for i = 0 .. 1:
+    d_hi[(16*i+15):(16*i)] = imm_h
+
+if (rd_p != 0):
+    X[2*rd_p] = d_lo
+    X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PLI.DH (Packed Load Immediate, Double-wide Halfword) sign-extends a 10-bit
+signed immediate to 16 bits and replicates it into every halfword element of
+the register pair designated by `rd_p`. This is equivalent to performing
+PLI.H on both the even and odd registers of the pair. This instruction is
+available only on RV32.
 
 ==== PLUI.DH
 
-TODO: Add missing PLUI.DH
+===== Encoding
+
+PLUI.DH is encoded in the OP-IMM-32 major opcode (register-pair variant)
+with a 10-bit immediate loaded into the upper bits of each halfword element.
+This instruction exists only for RV32 and uses a register-pair destination
+`rd_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 10, name: 'imm[6|15:7]' },
+    { bits: 2, name: 0x0 },
+    { bits: 5, name: 0xe },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+imm_h = sign_extend(16, imm[9:0] << 6)
+
+for i = 0 .. 1:
+    d_lo[(16*i+15):(16*i)] = imm_h
+
+for i = 0 .. 1:
+    d_hi[(16*i+15):(16*i)] = imm_h
+
+if (rd_p != 0):
+    X[2*rd_p] = d_lo
+    X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PLUI.DH (Packed Load Upper Immediate, Double-wide Halfword) loads a 10-bit
+signed immediate into the most-significant 10 bits of each 16-bit halfword
+element, with the lower 6 bits set to zero, and replicates the result into
+every halfword element of the register pair designated by `rd_p`. This is
+equivalent to performing PLUI.H on both the even and odd registers of the
+pair. This instruction is available only on RV32.
 
 === Basic Packed Add
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 8 Load Immediate instructions

## Instructions
- PLI.B
- PLI.H
- PLI.W
- PLUI.H
- PLUI.W
- PLI.DB
- PLI.DH
- PLUI.DH
