### PR TITLE
P-ext: add Basic Packed Add instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -773,15 +773,123 @@ TODO: Add missing PLUI.DH
 
 ==== PADD.B
 
-TODO: Add missing PADD.B
+===== Encoding
+
+PADD.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x0, attr: ['PADD.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1[(8*i+7):(8*i)]
+    b = s2[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = a + b
+
+X[rd] = d
+----
+
+===== Description
+
+PADD.B adds corresponding packed 8-bit elements of `rs1` and `rs2` and writes
+the packed byte results to `rd`. Each element addition wraps modulo 2^8.
 
 ==== PADD.H
 
-TODO: Add missing PADD.H
+===== Encoding
+
+PADD.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x0, attr: ['PADD.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = a + b
+
+X[rd] = d
+----
+
+===== Description
+
+PADD.H adds corresponding packed 16-bit halfword elements of `rs1` and `rs2`
+and writes the packed halfword results to `rd`. Each element addition wraps
+modulo 2^16.
 
 ==== PADD.W
 
-TODO: Add missing PADD.W
+===== Encoding
+
+PADD.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PADD.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = s1[31:0]  + s2[31:0]
+d[63:32] = s1[63:32] + s2[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PADD.W adds corresponding packed 32-bit word elements of `rs1` and `rs2` and
+writes the packed word results to `rd`. Each element addition wraps modulo 2^32.
+Available only in RV64.
 
 ==== PADD.BS
 
@@ -885,27 +993,309 @@ The PADD.WS instruction adds the least-significant word of `rs2` to each packed
 
 ==== PADD.DB
 
-TODO: Add missing PADD.DB
+===== Encoding
+
+PADD.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x0, attr: ['PADD.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PADD.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_lo[(8*i+7):(8*i)]
+    b = s2_lo[(8*i+7):(8*i)]
+    d_lo[(8*i+7):(8*i)] = a + b
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_hi[(8*i+7):(8*i)]
+    b = s2_hi[(8*i+7):(8*i)]
+    d_hi[(8*i+7):(8*i)] = a + b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PADD.DB performs packed 8-bit byte addition on double-wide (register-pair)
+operands. It is equivalent to two PADD.B operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Each element
+addition wraps modulo 2^8. Available only in RV32.
 
 ==== PADD.DH
 
-TODO: Add missing PADD.DH
+===== Encoding
+
+PADD.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x0, attr: ['PADD.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PADD.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_lo[(16*i+15):(16*i)]
+    b = s2_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = a + b
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_hi[(16*i+15):(16*i)]
+    b = s2_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = a + b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PADD.DH performs packed 16-bit halfword addition on double-wide (register-pair)
+operands. It is equivalent to two PADD.H operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Each element
+addition wraps modulo 2^16. Available only in RV32.
 
 ==== PADD.DW
 
-TODO: Add missing PADD.DW
+===== Encoding
+
+PADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PADD.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two ADD operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = s1_lo + s2_lo
+d_hi = s1_hi + s2_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PADD.DW performs 32-bit word addition on double-wide (register-pair) operands.
+It is equivalent to two ADD operations: one on the even registers and one on
+the odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`)
+are register pairs and must specify even register numbers. Each element addition
+wraps modulo 2^32. Available only in RV32.
 
 ==== PADD.DBS
 
-TODO: Add missing PADD.DBS
+===== Encoding
+
+PADD.DBS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x1, attr: ['PADD.DBS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PADD.BS operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+s2_b0  = X[rs2][7:0]           // least-significant byte of X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_lo[(8*i+7):(8*i)]
+    d_lo[(8*i+7):(8*i)] = a + s2_b0
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_hi[(8*i+7):(8*i)]
+    d_hi[(8*i+7):(8*i)] = a + s2_b0
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PADD.DBS adds the least-significant byte of `rs2` to each packed 8-bit element
+across a double-wide (register-pair) source. It is equivalent to two PADD.BS
+operations: one on the even registers and one on the odd registers of each pair.
+The destination (`rd_p`) and first source (`rs1_p`) are register pairs and must
+specify even register numbers; `rs2` is a single register. Each element addition
+wraps modulo 2^8. Available only in RV32.
 
 ==== PADD.DHS
 
-TODO: Add missing PADD.DHS
+===== Encoding
+
+PADD.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x1, attr: ['PADD.DHS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PADD.HS operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+s2_h0  = X[rs2][15:0]          // least-significant halfword of X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = a + s2_h0
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = a + s2_h0
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PADD.DHS adds the least-significant halfword of `rs2` to each packed 16-bit
+element across a double-wide (register-pair) source. It is equivalent to two
+PADD.HS operations: one on the even registers and one on the odd registers of
+each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register. Each
+element addition wraps modulo 2^16. Available only in RV32.
 
 ==== PADD.DWS
 
-TODO: Add missing PADD.DWS
+===== Encoding
+
+PADD.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x1, attr: ['PADD.DWS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PADD.WS operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+s2_w0  = X[rs2][31:0]          // least-significant word of X[rs2]
+
+d_lo = s1_lo + s2_w0
+d_hi = s1_hi + s2_w0
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PADD.DWS adds the least-significant word of `rs2` to each 32-bit element across
+a double-wide (register-pair) source. It is equivalent to two PADD.WS
+operations: one on the even registers and one on the odd registers of each pair.
+The destination (`rd_p`) and first source (`rs1_p`) are register pairs and must
+specify even register numbers; `rs2` is a single register. Each element addition
+wraps modulo 2^32. Available only in RV32.
 
 === Basic Packed Subtract
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 9 Basic Packed Add instructions

## Instructions
- PADD.B
- PADD.H
- PADD.W
- PADD.DB
- PADD.DH
- PADD.DW
- PADD.DBS
- PADD.DHS
- PADD.DWS
