### PR TITLE
P-ext: add Basic Packed Subtract instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -912,27 +912,279 @@ TODO: Add missing PADD.DWS
 
 ==== PSUB.B
 
-TODO: Add missing PSUB.B
+===== Encoding
+
+PSUB.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x8, attr: ['PSUB.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1[(8*i+7):(8*i)]
+    b = s2[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = a - b
+
+X[rd] = d
+----
+
+===== Description
+
+PSUB.B subtracts corresponding packed 8-bit elements of `rs2` from `rs1` and
+writes the packed byte results to `rd`. Each element subtraction wraps modulo
+2^8.
 
 ==== PSUB.H
 
-TODO: Add missing PSUB.H
+===== Encoding
+
+PSUB.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x8, attr: ['PSUB.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = a - b
+
+X[rd] = d
+----
+
+===== Description
+
+PSUB.H subtracts corresponding packed 16-bit halfword elements of `rs2` from
+`rs1` and writes the packed halfword results to `rd`. Each element subtraction
+wraps modulo 2^16.
 
 ==== PSUB.W
 
-TODO: Add missing PSUB.W
+===== Encoding
+
+PSUB.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x8, attr: ['PSUB.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = s1[31:0]  - s2[31:0]
+d[63:32] = s1[63:32] - s2[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PSUB.W subtracts corresponding packed 32-bit word elements of `rs2` from `rs1`
+and writes the packed word results to `rd`. Each element subtraction wraps
+modulo 2^32. Available only in RV64.
 
 ==== PSUB.DB
 
-TODO: Add missing PSUB.DB
+===== Encoding
+
+PSUB.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x8, attr: ['PSUB.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSUB.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_lo[(8*i+7):(8*i)]
+    b = s2_lo[(8*i+7):(8*i)]
+    d_lo[(8*i+7):(8*i)] = a - b
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_hi[(8*i+7):(8*i)]
+    b = s2_hi[(8*i+7):(8*i)]
+    d_hi[(8*i+7):(8*i)] = a - b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSUB.DB performs packed 8-bit byte subtraction on double-wide (register-pair)
+operands. It is equivalent to two PSUB.B operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Each element
+subtraction wraps modulo 2^8. Available only in RV32.
 
 ==== PSUB.DH
 
-TODO: Add missing PSUB.DH
+===== Encoding
+
+PSUB.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x8, attr: ['PSUB.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSUB.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_lo[(16*i+15):(16*i)]
+    b = s2_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = a - b
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_hi[(16*i+15):(16*i)]
+    b = s2_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = a - b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSUB.DH performs packed 16-bit halfword subtraction on double-wide
+(register-pair) operands. It is equivalent to two PSUB.H operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Each element subtraction wraps modulo 2^16. Available only in RV32.
 
 ==== PSUB.DW
 
-TODO: Add missing PSUB.DW
+===== Encoding
+
+PSUB.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x8, attr: ['PSUB.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SUB operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = s1_lo - s2_lo
+d_hi = s1_hi - s2_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSUB.DW performs 32-bit word subtraction on double-wide (register-pair)
+operands. It is equivalent to two SUB operations: one on the even registers and
+one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Each element
+subtraction wraps modulo 2^32. Available only in RV32.
 
 === Saturating Add
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 6 Basic Packed Subtract instructions

## Instructions
- PSUB.B
- PSUB.H
- PSUB.W
- PSUB.DB
- PSUB.DH
- PSUB.DW
