### PR TITLE
P-ext: add Saturating Add instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -939,59 +939,755 @@ TODO: Add missing PSUB.DW
 
 ==== PSADD.B
 
-TODO: Add missing PSADD.B
+===== Encoding
+
+PSADD.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x2, attr: ['PSADD.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    result = a + b
+    if result > 127:
+        d[(8*i+7):(8*i)] = to_bits(8, 127)
+    else if result < -128:
+        d[(8*i+7):(8*i)] = to_bits(8, -128)
+    else:
+        d[(8*i+7):(8*i)] = to_bits(8, result)
+
+X[rd] = d
+----
+
+===== Description
+
+PSADD.B performs signed saturating addition on packed 8-bit byte elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [-128, 127]. Corresponds to KADD8 in the earlier P extension draft.
 
 ==== PSADD.H
 
-TODO: Add missing PSADD.H
+===== Encoding
+
+PSADD.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PSADD.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    result = a + b
+    if result > 32767:
+        d[(16*i+15):(16*i)] = to_bits(16, 32767)
+    else if result < -32768:
+        d[(16*i+15):(16*i)] = to_bits(16, -32768)
+    else:
+        d[(16*i+15):(16*i)] = to_bits(16, result)
+
+X[rd] = d
+----
+
+===== Description
+
+PSADD.H performs signed saturating addition on packed 16-bit halfword elements
+of `rs1` and `rs2`, writing the results to `rd`. Each element result is clamped
+to the range [-32768, 32767]. Corresponds to KADD16 in the earlier P extension
+draft.
 
 ==== PSADD.W
 
-TODO: Add missing PSADD.W
+===== Encoding
+
+PSADD.W is encoded in the OP-32 major opcode with packed word elements.
+Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PSADD.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Two packed 32-bit signed saturating additions
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    b = signed(s2[(32*i+31):(32*i)])
+    result = a + b
+    if result > 2147483647:
+        d[(32*i+31):(32*i)] = to_bits(32, 2147483647)
+    else if result < -2147483648:
+        d[(32*i+31):(32*i)] = to_bits(32, -2147483648)
+    else:
+        d[(32*i+31):(32*i)] = to_bits(32, result)
+
+X[rd] = d
+----
+
+===== Description
+
+PSADD.W performs signed saturating addition on packed 32-bit word elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [-(2^31), 2^31-1]. Corresponds to KADD32 in the earlier P extension
+draft. Available only in RV64.
 
 ==== PSADDU.B
 
-TODO: Add missing PSADDU.B
+===== Encoding
+
+PSADDU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    result = a + b
+    if result > 255:
+        d[(8*i+7):(8*i)] = to_bits(8, 255)
+    else:
+        d[(8*i+7):(8*i)] = to_bits(8, result)
+
+X[rd] = d
+----
+
+===== Description
+
+PSADDU.B performs unsigned saturating addition on packed 8-bit byte elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [0, 255]. Corresponds to UKADD8 in the earlier P extension draft.
 
 ==== PSADDU.H
 
-TODO: Add missing PSADDU.H
+===== Encoding
+
+PSADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    result = a + b
+    if result > 65535:
+        d[(16*i+15):(16*i)] = to_bits(16, 65535)
+    else:
+        d[(16*i+15):(16*i)] = to_bits(16, result)
+
+X[rd] = d
+----
+
+===== Description
+
+PSADDU.H performs unsigned saturating addition on packed 16-bit halfword
+elements of `rs1` and `rs2`, writing the results to `rd`. Each element result is
+clamped to the range [0, 65535]. Corresponds to UKADD16 in the earlier P
+extension draft.
 
 ==== PSADDU.W
 
-TODO: Add missing PSADDU.W
+===== Encoding
+
+PSADDU.W is encoded in the OP-32 major opcode with packed word elements.
+Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Two packed 32-bit unsigned saturating additions
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    result = a + b
+    if result > 4294967295:
+        d[(32*i+31):(32*i)] = to_bits(32, 4294967295)
+    else:
+        d[(32*i+31):(32*i)] = to_bits(32, result)
+
+X[rd] = d
+----
+
+===== Description
+
+PSADDU.W performs unsigned saturating addition on packed 32-bit word elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [0, 2^32-1]. Corresponds to UKADD32 in the earlier P extension draft.
+Available only in RV64.
 
 ==== SADD
 
-TODO: Add missing SADD
+===== Encoding
+
+SADD is encoded in the OP-32 major opcode as a scalar XLEN-wide signed
+saturating addition. In RV32, it occupies the w=01 slot shared with PSADD.W in
+RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['SADD'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+a = signed(X[rs1])
+b = signed(X[rs2])
+result = a + b
+
+if result > (2^(XLEN-1) - 1):
+    d = to_bits(XLEN, 2^(XLEN-1) - 1)
+else if result < -(2^(XLEN-1)):
+    d = to_bits(XLEN, -(2^(XLEN-1)))
+else:
+    d = to_bits(XLEN, result)
+
+X[rd] = d
+----
+
+===== Description
+
+SADD performs signed saturating addition of the full XLEN-wide values in `rs1`
+and `rs2`, writing the result to `rd`. The result is clamped to the range
+[-(2^(XLEN-1)), 2^(XLEN-1)-1]. Corresponds to KADDW in the earlier P extension
+draft.
 
 ==== SADDU
 
-TODO: Add missing SADDU
+===== Encoding
+
+SADDU is encoded in the OP-32 major opcode as a scalar XLEN-wide unsigned
+saturating addition. In RV32, it occupies the w=01 slot shared with PSADDU.W in
+RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['SADDU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+a = unsigned(X[rs1])
+b = unsigned(X[rs2])
+result = a + b
+
+if result > (2^XLEN - 1):
+    d = to_bits(XLEN, 2^XLEN - 1)
+else:
+    d = to_bits(XLEN, result)
+
+X[rd] = d
+----
+
+===== Description
+
+SADDU performs unsigned saturating addition of the full XLEN-wide values in
+`rs1` and `rs2`, writing the result to `rd`. The result is clamped to the range
+[0, 2^XLEN-1]. Corresponds to UKADDW in the earlier P extension draft.
 
 ==== PSADD.DB
 
-TODO: Add missing PSADD.DB
+===== Encoding
+
+PSADD.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x2, attr: ['PSADD.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSADD.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    b = signed(s2_lo[(8*i+7):(8*i)])
+    result = a + b
+    if result > 127:
+        d_lo[(8*i+7):(8*i)] = to_bits(8, 127)
+    else if result < -128:
+        d_lo[(8*i+7):(8*i)] = to_bits(8, -128)
+    else:
+        d_lo[(8*i+7):(8*i)] = to_bits(8, result)
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    b = signed(s2_hi[(8*i+7):(8*i)])
+    result = a + b
+    if result > 127:
+        d_hi[(8*i+7):(8*i)] = to_bits(8, 127)
+    else if result < -128:
+        d_hi[(8*i+7):(8*i)] = to_bits(8, -128)
+    else:
+        d_hi[(8*i+7):(8*i)] = to_bits(8, result)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSADD.DB performs signed saturating addition on packed 8-bit byte elements using
+double-wide (register-pair) operands. It is equivalent to two PSADD.B
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
+specify even register numbers. Each element result is clamped to the range
+[-128, 127]. Available only in RV32.
 
 ==== PSADD.DH
 
-TODO: Add missing PSADD.DH
+===== Encoding
+
+PSADD.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PSADD.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSADD.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    b = signed(s2_lo[(16*i+15):(16*i)])
+    result = a + b
+    if result > 32767:
+        d_lo[(16*i+15):(16*i)] = to_bits(16, 32767)
+    else if result < -32768:
+        d_lo[(16*i+15):(16*i)] = to_bits(16, -32768)
+    else:
+        d_lo[(16*i+15):(16*i)] = to_bits(16, result)
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    b = signed(s2_hi[(16*i+15):(16*i)])
+    result = a + b
+    if result > 32767:
+        d_hi[(16*i+15):(16*i)] = to_bits(16, 32767)
+    else if result < -32768:
+        d_hi[(16*i+15):(16*i)] = to_bits(16, -32768)
+    else:
+        d_hi[(16*i+15):(16*i)] = to_bits(16, result)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSADD.DH performs signed saturating addition on packed 16-bit halfword elements
+using double-wide (register-pair) operands. It is equivalent to two PSADD.H
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
+specify even register numbers. Each element result is clamped to the range
+[-32768, 32767]. Available only in RV32.
 
 ==== PSADD.DW
 
-TODO: Add missing PSADD.DW
+===== Encoding
+
+PSADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PSADD.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SADD operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+a = signed(s1_lo)
+b = signed(s2_lo)
+result = a + b
+if result > 2147483647:
+    d_lo = to_bits(32, 2147483647)
+else if result < -2147483648:
+    d_lo = to_bits(32, -2147483648)
+else:
+    d_lo = to_bits(32, result)
+
+a = signed(s1_hi)
+b = signed(s2_hi)
+result = a + b
+if result > 2147483647:
+    d_hi = to_bits(32, 2147483647)
+else if result < -2147483648:
+    d_hi = to_bits(32, -2147483648)
+else:
+    d_hi = to_bits(32, result)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSADD.DW performs signed saturating 32-bit word addition on double-wide
+(register-pair) operands. It is equivalent to two SADD operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Each element result is clamped to the range [-(2^31), 2^31-1].
+Available only in RV32.
 
 ==== PSADDU.DB
 
-TODO: Add missing PSADDU.DB
+===== Encoding
+
+PSADDU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSADDU.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_lo[(8*i+7):(8*i)])
+    b = unsigned(s2_lo[(8*i+7):(8*i)])
+    result = a + b
+    if result > 255:
+        d_lo[(8*i+7):(8*i)] = to_bits(8, 255)
+    else:
+        d_lo[(8*i+7):(8*i)] = to_bits(8, result)
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_hi[(8*i+7):(8*i)])
+    b = unsigned(s2_hi[(8*i+7):(8*i)])
+    result = a + b
+    if result > 255:
+        d_hi[(8*i+7):(8*i)] = to_bits(8, 255)
+    else:
+        d_hi[(8*i+7):(8*i)] = to_bits(8, result)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSADDU.DB performs unsigned saturating addition on packed 8-bit byte elements
+using double-wide (register-pair) operands. It is equivalent to two PSADDU.B
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
+specify even register numbers. Each element result is clamped to the range
+[0, 255]. Available only in RV32.
 
 ==== PSADDU.DH
 
-TODO: Add missing PSADDU.DH
+===== Encoding
+
+PSADDU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed halfword elements. This instruction exists
+only for RV32 and uses register pairs `rd_p`, `rs1_p`, and `rs2_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Even registers
+s1_lo = X[2*rs1_p]
+s2_lo = X[2*rs2_p]
+
+for i = 0 .. 1:
+    a = unsigned(s1_lo[(16*i+15):(16*i)])
+    b = unsigned(s2_lo[(16*i+15):(16*i)])
+    res = a + b
+    if res > 2^16 - 1:
+        res = 2^16 - 1
+    d_lo[(16*i+15):(16*i)] = res[15:0]
+
+// Odd registers
+s1_hi = X[2*rs1_p+1]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 1:
+    a = unsigned(s1_hi[(16*i+15):(16*i)])
+    b = unsigned(s2_hi[(16*i+15):(16*i)])
+    res = a + b
+    if res > 2^16 - 1:
+        res = 2^16 - 1
+    d_hi[(16*i+15):(16*i)] = res[15:0]
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PSADDU.DH (Packed Saturating Add Unsigned, Double-wide Halfword) performs
+unsigned saturating addition on corresponding packed 16-bit halfword elements
+across a register pair. This is equivalent to performing PSADDU.H on both the
+even and odd registers of the pair. Each element result is clamped to the
+range [0, 2^16-1]. Available only on RV32.
 
 ==== PSADDU.DW
 
-TODO: Add missing PSADDU.DW
+===== Encoding
+
+PSADDU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. This instruction exists only for RV32 and uses register
+pairs `rd_p`, `rs1_p`, and `rs2_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Even registers
+a_lo = unsigned(X[2*rs1_p])
+b_lo = unsigned(X[2*rs2_p])
+res_lo = a_lo + b_lo
+if res_lo > 2^32 - 1:
+    res_lo = 2^32 - 1
+X[2*rd_p] = res_lo[31:0]
+
+// Odd registers
+a_hi = unsigned(X[2*rs1_p+1])
+b_hi = unsigned(X[2*rs2_p+1])
+res_hi = a_hi + b_hi
+if res_hi > 2^32 - 1:
+    res_hi = 2^32 - 1
+X[2*rd_p+1] = res_hi[31:0]
+----
+
+===== Description
+
+PSADDU.DW (Packed Saturating Add Unsigned, Double-wide Word) performs unsigned
+saturating addition on corresponding 32-bit word values across a register
+pair. This is equivalent to performing SADDU on both the even and odd
+registers of the pair. Each element result is clamped to the range
+[0, 2^32-1]. Available only on RV32.
 
 === Saturating Subtract
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 14 Saturating Add instructions

## Instructions
- PSADD.B
- PSADD.H
- PSADD.W
- PSADDU.B
- PSADDU.H
- PSADDU.W
- SADD
- SADDU
- PSADD.DB
- PSADD.DH
- PSADD.DW
- PSADDU.DB
- PSADDU.DH
- PSADDU.DW
