### PR TITLE
P-ext: add Saturating Subtract instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -998,59 +998,745 @@ TODO: Add missing PSADDU.DW
 
 ==== PSSUB.B
 
-TODO: Add missing PSSUB.B
+===== Encoding
+
+PSSUB.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xa, attr: ['PSSUB.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    res = a - b
+    if res > 2^7 - 1:
+        res = 2^7 - 1
+    else if res < -(2^7):
+        res = -(2^7)
+    d[(8*i+7):(8*i)] = res[7:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSUB.B performs signed saturating subtraction on corresponding packed 8-bit
+byte elements of `rs1` and `rs2`, writing the results to `rd`. Each element
+result is clamped to the range [-(2^7), 2^7-1].
 
 ==== PSSUB.H
 
-TODO: Add missing PSSUB.H
+===== Encoding
+
+PSSUB.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xa, attr: ['PSSUB.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    res = a - b
+    if res > 2^15 - 1:
+        res = 2^15 - 1
+    else if res < -(2^15):
+        res = -(2^15)
+    d[(16*i+15):(16*i)] = res[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSUB.H performs signed saturating subtraction on corresponding packed 16-bit
+halfword elements of `rs1` and `rs2`, writing the results to `rd`. Each
+element result is clamped to the range [-(2^15), 2^15-1].
 
 ==== PSSUB.W
 
-TODO: Add missing PSSUB.W
+===== Encoding
+
+PSSUB.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['PSSUB.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Lower 32-bit element
+a_lo = signed(s1[31:0])
+b_lo = signed(s2[31:0])
+res_lo = a_lo - b_lo
+if res_lo > 2^31 - 1:
+    res_lo = 2^31 - 1
+else if res_lo < -(2^31):
+    res_lo = -(2^31)
+d[31:0] = res_lo[31:0]
+
+// Upper 32-bit element
+a_hi = signed(s1[63:32])
+b_hi = signed(s2[63:32])
+res_hi = a_hi - b_hi
+if res_hi > 2^31 - 1:
+    res_hi = 2^31 - 1
+else if res_hi < -(2^31):
+    res_hi = -(2^31)
+d[63:32] = res_hi[31:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSUB.W performs signed saturating subtraction on corresponding packed 32-bit
+word elements of `rs1` and `rs2`, writing the results to `rd`. Each element
+result is clamped to the range [-(2^31), 2^31-1]. Available only in RV64.
 
 ==== PSSUBU.B
 
-TODO: Add missing PSSUBU.B
+===== Encoding
+
+PSSUBU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    res = a - b
+    if res < 0:
+        res = 0
+    d[(8*i+7):(8*i)] = res[7:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSUBU.B performs unsigned saturating subtraction on corresponding packed
+8-bit byte elements of `rs1` and `rs2`, writing the results to `rd`. Each
+element result is clamped to the range [0, 2^8-1].
 
 ==== PSSUBU.H
 
-TODO: Add missing PSSUBU.H
+===== Encoding
+
+PSSUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    res = a - b
+    if res < 0:
+        res = 0
+    d[(16*i+15):(16*i)] = res[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSUBU.H performs unsigned saturating subtraction on corresponding packed
+16-bit halfword elements of `rs1` and `rs2`, writing the results to `rd`.
+Each element result is clamped to the range [0, 2^16-1].
 
 ==== PSSUBU.W
 
-TODO: Add missing PSSUBU.W
+===== Encoding
+
+PSSUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Lower 32-bit element
+a_lo = unsigned(s1[31:0])
+b_lo = unsigned(s2[31:0])
+res_lo = a_lo - b_lo
+if res_lo < 0:
+    res_lo = 0
+d[31:0] = res_lo[31:0]
+
+// Upper 32-bit element
+a_hi = unsigned(s1[63:32])
+b_hi = unsigned(s2[63:32])
+res_hi = a_hi - b_hi
+if res_hi < 0:
+    res_hi = 0
+d[63:32] = res_hi[31:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSUBU.W performs unsigned saturating subtraction on corresponding packed
+32-bit word elements of `rs1` and `rs2`, writing the results to `rd`. Each
+element result is clamped to the range [0, 2^32-1]. Available only in RV64.
 
 ==== SSUB
 
-TODO: Add missing SSUB
+===== Encoding
+
+SSUB is encoded in the OP-32 major opcode. On RV32 it operates on a single
+XLEN-wide (32-bit) value; on RV64 it is the PSSUB.W instruction.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['SSUB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+a = signed(X[rs1])
+b = signed(X[rs2])
+res = a - b
+
+if res > 2^(XLEN-1) - 1:
+    res = 2^(XLEN-1) - 1
+else if res < -(2^(XLEN-1)):
+    res = -(2^(XLEN-1))
+
+X[rd] = res[XLEN-1:0]
+----
+
+===== Description
+
+SSUB performs signed saturating subtraction of `rs2` from `rs1`, writing the
+result to `rd`. The result is clamped to the range [-(2^(XLEN-1)),
+2^(XLEN-1)-1]. On RV32 this is the XLEN-wide scalar form; on RV64 this
+encoding is used by PSSUB.W.
 
 ==== SSUBU
 
-TODO: Add missing SSUBU
+===== Encoding
+
+SSUBU is encoded in the OP-32 major opcode. On RV32 it operates on a single
+XLEN-wide (32-bit) value; on RV64 it is the PSSUBU.W instruction.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['SSUBU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+a = unsigned(X[rs1])
+b = unsigned(X[rs2])
+res = a - b
+
+if res < 0:
+    res = 0
+
+X[rd] = res[XLEN-1:0]
+----
+
+===== Description
+
+SSUBU performs unsigned saturating subtraction of `rs2` from `rs1`, writing
+the result to `rd`. The result is clamped to the range [0, 2^XLEN-1]. On
+RV32 this is the XLEN-wide scalar form; on RV64 this encoding is used by
+PSSUBU.W.
 
 ==== PSSUB.DB
 
-TODO: Add missing PSSUB.DB
+===== Encoding
+
+PSSUB.DB is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format with
+packed byte elements. This instruction exists only for RV32 and uses register
+pairs `rd_p`, `rs1_p`, and `rs2_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xa, attr: ['PSSUB.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Even registers
+s1_lo = X[2*rs1_p]
+s2_lo = X[2*rs2_p]
+
+for i = 0 .. 3:
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    b = signed(s2_lo[(8*i+7):(8*i)])
+    res = a - b
+    if res > 2^7 - 1:
+        res = 2^7 - 1
+    else if res < -(2^7):
+        res = -(2^7)
+    d_lo[(8*i+7):(8*i)] = res[7:0]
+
+// Odd registers
+s1_hi = X[2*rs1_p+1]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 3:
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    b = signed(s2_hi[(8*i+7):(8*i)])
+    res = a - b
+    if res > 2^7 - 1:
+        res = 2^7 - 1
+    else if res < -(2^7):
+        res = -(2^7)
+    d_hi[(8*i+7):(8*i)] = res[7:0]
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PSSUB.DB (Packed Signed Saturating Subtract, Double-wide Byte) performs signed
+saturating subtraction on corresponding packed 8-bit byte elements across a
+register pair. This is equivalent to performing PSSUB.B on both the even and
+odd registers of the pair. Each element result is clamped to the range
+[-(2^7), 2^7-1]. Available only on RV32.
 
 ==== PSSUB.DH
 
-TODO: Add missing PSSUB.DH
+===== Encoding
+
+PSSUB.DH is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format with
+packed halfword elements. This instruction exists only for RV32 and uses
+register pairs `rd_p`, `rs1_p`, and `rs2_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xa, attr: ['PSSUB.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Even registers
+s1_lo = X[2*rs1_p]
+s2_lo = X[2*rs2_p]
+
+for i = 0 .. 1:
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    b = signed(s2_lo[(16*i+15):(16*i)])
+    res = a - b
+    if res > 2^15 - 1:
+        res = 2^15 - 1
+    else if res < -(2^15):
+        res = -(2^15)
+    d_lo[(16*i+15):(16*i)] = res[15:0]
+
+// Odd registers
+s1_hi = X[2*rs1_p+1]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 1:
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    b = signed(s2_hi[(16*i+15):(16*i)])
+    res = a - b
+    if res > 2^15 - 1:
+        res = 2^15 - 1
+    else if res < -(2^15):
+        res = -(2^15)
+    d_hi[(16*i+15):(16*i)] = res[15:0]
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PSSUB.DH (Packed Signed Saturating Subtract, Double-wide Halfword) performs
+signed saturating subtraction on corresponding packed 16-bit halfword elements
+across a register pair. This is equivalent to performing PSSUB.H on both the
+even and odd registers of the pair. Each element result is clamped to the
+range [-(2^15), 2^15-1]. Available only on RV32.
 
 ==== PSSUB.DW
 
-TODO: Add missing PSSUB.DW
+===== Encoding
+
+PSSUB.DW is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format. This
+instruction exists only for RV32 and uses register pairs `rd_p`, `rs1_p`, and
+`rs2_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['PSSUB.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Even registers
+a_lo = signed(X[2*rs1_p])
+b_lo = signed(X[2*rs2_p])
+res_lo = a_lo - b_lo
+if res_lo > 2^31 - 1:
+    res_lo = 2^31 - 1
+else if res_lo < -(2^31):
+    res_lo = -(2^31)
+X[2*rd_p] = res_lo[31:0]
+
+// Odd registers
+a_hi = signed(X[2*rs1_p+1])
+b_hi = signed(X[2*rs2_p+1])
+res_hi = a_hi - b_hi
+if res_hi > 2^31 - 1:
+    res_hi = 2^31 - 1
+else if res_hi < -(2^31):
+    res_hi = -(2^31)
+X[2*rd_p+1] = res_hi[31:0]
+----
+
+===== Description
+
+PSSUB.DW (Packed Signed Saturating Subtract, Double-wide Word) performs signed
+saturating subtraction on corresponding 32-bit word values across a register
+pair. This is equivalent to performing SSUB on both the even and odd registers
+of the pair. Each element result is clamped to the range [-(2^31), 2^31-1].
+Available only on RV32.
 
 ==== PSSUBU.DB
 
-TODO: Add missing PSSUBU.DB
+===== Encoding
+
+PSSUBU.DB is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format with
+packed byte elements. This instruction exists only for RV32 and uses register
+pairs `rd_p`, `rs1_p`, and `rs2_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Even registers
+s1_lo = X[2*rs1_p]
+s2_lo = X[2*rs2_p]
+
+for i = 0 .. 3:
+    a = unsigned(s1_lo[(8*i+7):(8*i)])
+    b = unsigned(s2_lo[(8*i+7):(8*i)])
+    res = a - b
+    if res < 0:
+        res = 0
+    d_lo[(8*i+7):(8*i)] = res[7:0]
+
+// Odd registers
+s1_hi = X[2*rs1_p+1]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 3:
+    a = unsigned(s1_hi[(8*i+7):(8*i)])
+    b = unsigned(s2_hi[(8*i+7):(8*i)])
+    res = a - b
+    if res < 0:
+        res = 0
+    d_hi[(8*i+7):(8*i)] = res[7:0]
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PSSUBU.DB (Packed Unsigned Saturating Subtract, Double-wide Byte) performs
+unsigned saturating subtraction on corresponding packed 8-bit byte elements
+across a register pair. This is equivalent to performing PSSUBU.B on both the
+even and odd registers of the pair. Each element result is clamped to the
+range [0, 2^8-1]. Available only on RV32.
 
 ==== PSSUBU.DH
 
-TODO: Add missing PSSUBU.DH
+===== Encoding
+
+PSSUBU.DH is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format with
+packed halfword elements. This instruction exists only for RV32 and uses
+register pairs `rd_p`, `rs1_p`, and `rs2_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Even registers
+s1_lo = X[2*rs1_p]
+s2_lo = X[2*rs2_p]
+
+for i = 0 .. 1:
+    a = unsigned(s1_lo[(16*i+15):(16*i)])
+    b = unsigned(s2_lo[(16*i+15):(16*i)])
+    res = a - b
+    if res < 0:
+        res = 0
+    d_lo[(16*i+15):(16*i)] = res[15:0]
+
+// Odd registers
+s1_hi = X[2*rs1_p+1]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 1:
+    a = unsigned(s1_hi[(16*i+15):(16*i)])
+    b = unsigned(s2_hi[(16*i+15):(16*i)])
+    res = a - b
+    if res < 0:
+        res = 0
+    d_hi[(16*i+15):(16*i)] = res[15:0]
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PSSUBU.DH (Packed Unsigned Saturating Subtract, Double-wide Halfword) performs
+unsigned saturating subtraction on corresponding packed 16-bit halfword
+elements across a register pair. This is equivalent to performing PSSUBU.H on
+both the even and odd registers of the pair. Each element result is clamped to
+the range [0, 2^16-1]. Available only on RV32.
 
 ==== PSSUBU.DW
 
-TODO: Add missing PSSUBU.DW
+===== Encoding
+
+PSSUBU.DW is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format. This
+instruction exists only for RV32 and uses register pairs `rd_p`, `rs1_p`, and
+`rs2_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Even registers
+a_lo = unsigned(X[2*rs1_p])
+b_lo = unsigned(X[2*rs2_p])
+res_lo = a_lo - b_lo
+if res_lo < 0:
+    res_lo = 0
+X[2*rd_p] = res_lo[31:0]
+
+// Odd registers
+a_hi = unsigned(X[2*rs1_p+1])
+b_hi = unsigned(X[2*rs2_p+1])
+res_hi = a_hi - b_hi
+if res_hi < 0:
+    res_hi = 0
+X[2*rd_p+1] = res_hi[31:0]
+----
+
+===== Description
+
+PSSUBU.DW (Packed Unsigned Saturating Subtract, Double-wide Word) performs
+unsigned saturating subtraction on corresponding 32-bit word values across a
+register pair. This is equivalent to performing SSUBU on both the even and odd
+registers of the pair. Each element result is clamped to the range
+[0, 2^32-1]. Available only on RV32.
 
 === Averaging Add
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 14 Saturating Subtract instructions

## Instructions
- PSSUB.B
- PSSUB.H
- PSSUB.W
- PSSUBU.B
- PSSUBU.H
- PSSUBU.W
- SSUB
- SSUBU
- PSSUB.DB
- PSSUB.DH
- PSSUB.DW
- PSSUBU.DB
- PSSUBU.DH
- PSSUBU.DW
