### PR TITLE
P-ext: add Averaging Add instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1057,59 +1057,675 @@ TODO: Add missing PSSUBU.DW
 
 ==== PAADD.B
 
-TODO: Add missing PAADD.B
+===== Encoding
+
+PAADD.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x3, attr: ['PAADD.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    sum = a + b
+    d[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PAADD.B performs a signed averaging addition on packed 8-bit elements. For each
+byte lane, it adds the signed elements from `rs1` and `rs2` at full precision
+(9 bits), then shifts the result right by 1 (toward negative infinity), and
+writes the lower 8 bits to the corresponding byte of `rd`.
 
 ==== PAADD.H
 
-TODO: Add missing PAADD.H
+===== Encoding
+
+PAADD.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x3, attr: ['PAADD.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    sum = a + b
+    d[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PAADD.H performs a signed averaging addition on packed 16-bit halfword elements.
+For each halfword lane, it adds the signed elements from `rs1` and `rs2` at full
+precision (17 bits), then shifts the result right by 1 (toward negative
+infinity), and writes the lower 16 bits to the corresponding halfword of `rd`.
 
 ==== PAADD.W
 
-TODO: Add missing PAADD.W
+===== Encoding
+
+PAADD.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x3, attr: ['PAADD.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Signed averaging add on packed 32-bit elements
+a_lo = signed(s1[31:0])
+b_lo = signed(s2[31:0])
+sum_lo = a_lo + b_lo
+d[31:0] = to_bits(32, sum_lo >> 1)
+
+a_hi = signed(s1[63:32])
+b_hi = signed(s2[63:32])
+sum_hi = a_hi + b_hi
+d[63:32] = to_bits(32, sum_hi >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PAADD.W performs a signed averaging addition on packed 32-bit word elements.
+For each word lane, it adds the signed elements from `rs1` and `rs2` at full
+precision (33 bits), then shifts the result right by 1 (toward negative
+infinity), and writes the lower 32 bits to the corresponding word of `rd`.
+Available only in RV64.
 
 ==== PAADDU.B
 
-TODO: Add missing PAADDU.B
+===== Encoding
+
+PAADDU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    sum = a + b
+    d[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PAADDU.B performs an unsigned averaging addition on packed 8-bit elements. For
+each byte lane, it adds the unsigned elements from `rs1` and `rs2` at full
+precision (9 bits), then shifts the result right by 1, and writes the lower
+8 bits to the corresponding byte of `rd`.
 
 ==== PAADDU.H
 
-TODO: Add missing PAADDU.H
+===== Encoding
+
+PAADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    sum = a + b
+    d[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PAADDU.H performs an unsigned averaging addition on packed 16-bit halfword
+elements. For each halfword lane, it adds the unsigned elements from `rs1` and
+`rs2` at full precision (17 bits), then shifts the result right by 1, and writes
+the lower 16 bits to the corresponding halfword of `rd`.
 
 ==== PAADDU.W
 
-TODO: Add missing PAADDU.W
+===== Encoding
+
+PAADDU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Unsigned averaging add on packed 32-bit elements
+a_lo = unsigned(s1[31:0])
+b_lo = unsigned(s2[31:0])
+sum_lo = a_lo + b_lo
+d[31:0] = to_bits(32, sum_lo >> 1)
+
+a_hi = unsigned(s1[63:32])
+b_hi = unsigned(s2[63:32])
+sum_hi = a_hi + b_hi
+d[63:32] = to_bits(32, sum_hi >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PAADDU.W performs an unsigned averaging addition on packed 32-bit word elements.
+For each word lane, it adds the unsigned elements from `rs1` and `rs2` at full
+precision (33 bits), then shifts the result right by 1, and writes the lower
+32 bits to the corresponding word of `rd`. Available only in RV64.
 
 ==== AADD
 
-TODO: Add missing AADD
+===== Encoding
+
+AADD is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x3, attr: ['AADD'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = signed(X[rs1])
+s2 = signed(X[rs2])
+
+sum = s1 + s2
+X[rd] = to_bits(32, sum >> 1)
+----
+
+===== Description
+
+AADD performs a signed averaging addition on a single XLEN-wide value. It adds
+the signed values in `rs1` and `rs2` at full precision (33 bits), then shifts
+the result right by 1 (toward negative infinity), and writes the lower 32 bits
+to `rd`. Available only in RV32; the RV64 counterpart is PAADD.W.
 
 ==== AADDU
 
-TODO: Add missing AADDU
+===== Encoding
+
+AADDU is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['AADDU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = unsigned(X[rs1])
+s2 = unsigned(X[rs2])
+
+sum = s1 + s2
+X[rd] = to_bits(32, sum >> 1)
+----
+
+===== Description
+
+AADDU performs an unsigned averaging addition on a single XLEN-wide value. It
+adds the unsigned values in `rs1` and `rs2` at full precision (33 bits), then
+shifts the result right by 1, and writes the lower 32 bits to `rd`. Available
+only in RV32; the RV64 counterpart is PAADDU.W.
 
 ==== PAADD.DB
 
-TODO: Add missing PAADD.DB
+===== Encoding
+
+PAADD.DB is the register-pair (double-wide) variant of PAADD.B and is available
+only in RV32. It is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with register-pair operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x3, attr: ['PAADD.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: double the number of byte elements
+s1_lo = X[2*rs1_p]
+s1_hi = X[2*rs1_p+1]
+s2_lo = X[2*rs2_p]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 3:
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    b = signed(s2_lo[(8*i+7):(8*i)])
+    sum = a + b
+    d_lo[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+
+for i = 0 .. 3:
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    b = signed(s2_hi[(8*i+7):(8*i)])
+    sum = a + b
+    d_hi[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PAADD.DB (Packed Averaging Add, Double-wide Byte) performs a signed averaging
+addition on packed 8-bit elements across register pairs. It is equivalent to
+performing PAADD.B independently on both the even and odd registers of the
+source and destination pairs. This instruction is available only on RV32.
 
 ==== PAADD.DH
 
-TODO: Add missing PAADD.DH
+===== Encoding
+
+PAADD.DH is the register-pair (double-wide) variant of PAADD.H and is available
+only in RV32. It is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with register-pair operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x3, attr: ['PAADD.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: double the number of halfword elements
+s1_lo = X[2*rs1_p]
+s1_hi = X[2*rs1_p+1]
+s2_lo = X[2*rs2_p]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 1:
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    b = signed(s2_lo[(16*i+15):(16*i)])
+    sum = a + b
+    d_lo[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+
+for i = 0 .. 1:
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    b = signed(s2_hi[(16*i+15):(16*i)])
+    sum = a + b
+    d_hi[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PAADD.DH (Packed Averaging Add, Double-wide Halfword) performs a signed
+averaging addition on packed 16-bit halfword elements across register pairs. It
+is equivalent to performing PAADD.H independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 
 ==== PAADD.DW
 
-TODO: Add missing PAADD.DW
+===== Encoding
+
+PAADD.DW is the register-pair (double-wide) variant of PAADD.W and is available
+only in RV32. It is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with register-pair operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x3, attr: ['PAADD.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: two 32-bit word elements
+s1_lo = X[2*rs1_p]
+s1_hi = X[2*rs1_p+1]
+s2_lo = X[2*rs2_p]
+s2_hi = X[2*rs2_p+1]
+
+sum_lo = signed(s1_lo) + signed(s2_lo)
+d_lo = to_bits(32, sum_lo >> 1)
+
+sum_hi = signed(s1_hi) + signed(s2_hi)
+d_hi = to_bits(32, sum_hi >> 1)
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PAADD.DW (Packed Averaging Add, Double-wide Word) performs a signed averaging
+addition on packed 32-bit word elements across register pairs. It is equivalent
+to performing AADD independently on both the even and odd registers of the
+source and destination pairs. This instruction is available only on RV32.
 
 ==== PAADDU.DB
 
-TODO: Add missing PAADDU.DB
+===== Encoding
+
+PAADDU.DB is the register-pair (double-wide) variant of PAADDU.B and is
+available only in RV32. It shares the same encoding as PAADDU.B with
+register-pair operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: double the number of byte elements
+s1_lo = X[2*rs1_p]
+s1_hi = X[2*rs1_p+1]
+s2_lo = X[2*rs2_p]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 3:
+    a = unsigned(s1_lo[(8*i+7):(8*i)])
+    b = unsigned(s2_lo[(8*i+7):(8*i)])
+    sum = a + b
+    d_lo[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+
+for i = 0 .. 3:
+    a = unsigned(s1_hi[(8*i+7):(8*i)])
+    b = unsigned(s2_hi[(8*i+7):(8*i)])
+    sum = a + b
+    d_hi[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PAADDU.DB (Packed Averaging Add Unsigned, Double-wide Byte) performs an unsigned
+averaging addition on packed 8-bit elements across register pairs. It is
+equivalent to performing PAADDU.B independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 
 ==== PAADDU.DH
 
-TODO: Add missing PAADDU.DH
+===== Encoding
+
+PAADDU.DH is the register-pair (double-wide) variant of PAADDU.H and is
+available only in RV32. It is encoded in the OP-IMM-32 major opcode using the
+double-wide register-pair format with register-pair operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: double the number of halfword elements
+s1_lo = X[2*rs1_p]
+s1_hi = X[2*rs1_p+1]
+s2_lo = X[2*rs2_p]
+s2_hi = X[2*rs2_p+1]
+
+for i = 0 .. 1:
+    a = unsigned(s1_lo[(16*i+15):(16*i)])
+    b = unsigned(s2_lo[(16*i+15):(16*i)])
+    sum = a + b
+    d_lo[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+
+for i = 0 .. 1:
+    a = unsigned(s1_hi[(16*i+15):(16*i)])
+    b = unsigned(s2_hi[(16*i+15):(16*i)])
+    sum = a + b
+    d_hi[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PAADDU.DH (Packed Averaging Add Unsigned, Double-wide Halfword) performs an
+unsigned averaging addition on packed 16-bit halfword elements across register
+pairs. It is equivalent to performing PAADDU.H independently on both the even
+and odd registers of the source and destination pairs. This instruction is
+available only on RV32.
 
 ==== PAADDU.DW
 
-TODO: Add missing PAADDU.DW
+===== Encoding
+
+PAADDU.DW is the register-pair (double-wide) variant of PAADDU.W and is
+available only in RV32. It is encoded in the OP-IMM-32 major opcode using the
+double-wide register-pair format with register-pair operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: two 32-bit word elements
+s1_lo = X[2*rs1_p]
+s1_hi = X[2*rs1_p+1]
+s2_lo = X[2*rs2_p]
+s2_hi = X[2*rs2_p+1]
+
+sum_lo = unsigned(s1_lo) + unsigned(s2_lo)
+d_lo = to_bits(32, sum_lo >> 1)
+
+sum_hi = unsigned(s1_hi) + unsigned(s2_hi)
+d_hi = to_bits(32, sum_hi >> 1)
+
+X[2*rd_p] = d_lo
+X[2*rd_p+1] = d_hi
+----
+
+===== Description
+
+PAADDU.DW (Packed Averaging Add Unsigned, Double-wide Word) performs an unsigned
+averaging addition on packed 32-bit word elements across register pairs. It is
+equivalent to performing AADDU independently on both the even and odd registers
+of the source and destination pairs. This instruction is available only on RV32.
 
 === Averaging Subtract
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 14 Averaging Add instructions

## Instructions
- PAADD.B
- PAADD.H
- PAADD.W
- PAADDU.B
- PAADDU.H
- PAADDU.W
- AADD
- AADDU
- PAADD.DB
- PAADD.DH
- PAADD.DW
- PAADDU.DB
- PAADDU.DH
- PAADDU.DW
