### PR TITLE
P-ext: add Averaging Subtract instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1116,59 +1116,676 @@ TODO: Add missing PAADDU.DW
 
 ==== PASUB.B
 
-TODO: Add missing PASUB.B
+===== Encoding
+
+PASUB.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xb, attr: ['PASUB.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    diff = a - b
+    d[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PASUB.B performs a signed averaging subtraction on packed 8-bit elements. For
+each byte lane, it subtracts the signed element in `rs2` from the signed element
+in `rs1` at full precision (9 bits), then shifts the result right by 1 (toward
+negative infinity), and writes the lower 8 bits to the corresponding byte of
+`rd`.
 
 ==== PASUB.H
 
-TODO: Add missing PASUB.H
+===== Encoding
+
+PASUB.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xb, attr: ['PASUB.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    diff = a - b
+    d[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PASUB.H performs a signed averaging subtraction on packed 16-bit halfword
+elements. For each halfword lane, it subtracts the signed element in `rs2` from
+the signed element in `rs1` at full precision (17 bits), then shifts the result
+right by 1 (toward negative infinity), and writes the lower 16 bits to the
+corresponding halfword of `rd`.
 
 ==== PASUB.W
 
-TODO: Add missing PASUB.W
+===== Encoding
+
+PASUB.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['PASUB.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Signed averaging subtract on packed 32-bit elements
+a_lo = signed(s1[31:0])
+b_lo = signed(s2[31:0])
+diff_lo = a_lo - b_lo
+d[31:0] = to_bits(32, diff_lo >> 1)
+
+a_hi = signed(s1[63:32])
+b_hi = signed(s2[63:32])
+diff_hi = a_hi - b_hi
+d[63:32] = to_bits(32, diff_hi >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PASUB.W performs a signed averaging subtraction on packed 32-bit word elements.
+For each word lane, it subtracts the signed element in `rs2` from the signed
+element in `rs1` at full precision (33 bits), then shifts the result right by 1
+(toward negative infinity), and writes the lower 32 bits to the corresponding
+word of `rd`. Available only in RV64.
 
 ==== PASUBU.B
 
-TODO: Add missing PASUBU.B
+===== Encoding
+
+PASUBU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    diff = a - b
+    d[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PASUBU.B performs an unsigned averaging subtraction on packed 8-bit elements.
+For each byte lane, it subtracts the unsigned element in `rs2` from the unsigned
+element in `rs1` at full precision (9 bits), then shifts the result right by 1,
+and writes the lower 8 bits to the corresponding byte of `rd`.
 
 ==== PASUBU.H
 
-TODO: Add missing PASUBU.H
+===== Encoding
+
+PASUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    diff = a - b
+    d[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PASUBU.H performs an unsigned averaging subtraction on packed 16-bit halfword
+elements. For each halfword lane, it subtracts the unsigned element in `rs2`
+from the unsigned element in `rs1` at full precision (17 bits), then shifts the
+result right by 1, and writes the lower 16 bits to the corresponding halfword
+of `rd`.
 
 ==== PASUBU.W
 
-TODO: Add missing PASUBU.W
+===== Encoding
+
+PASUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Unsigned averaging subtract on packed 32-bit elements
+a_lo = unsigned(s1[31:0])
+b_lo = unsigned(s2[31:0])
+diff_lo = a_lo - b_lo
+d[31:0] = to_bits(32, diff_lo >> 1)
+
+a_hi = unsigned(s1[63:32])
+b_hi = unsigned(s2[63:32])
+diff_hi = a_hi - b_hi
+d[63:32] = to_bits(32, diff_hi >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PASUBU.W performs an unsigned averaging subtraction on packed 32-bit word
+elements. For each word lane, it subtracts the unsigned element in `rs2` from
+the unsigned element in `rs1` at full precision (33 bits), then shifts the
+result right by 1, and writes the lower 32 bits to the corresponding word of
+`rd`. Available only in RV64.
 
 ==== ASUB
 
-TODO: Add missing ASUB
+===== Encoding
+
+ASUB is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['ASUB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = signed(X[rs1])
+s2 = signed(X[rs2])
+
+diff = s1 - s2
+X[rd] = to_bits(32, diff >> 1)
+----
+
+===== Description
+
+ASUB performs a signed averaging subtraction on a single XLEN-wide value. It
+subtracts the signed value in `rs2` from `rs1` at full precision (33 bits), then
+shifts the result right by 1 (toward negative infinity), and writes the lower
+32 bits to `rd`. Available only in RV32; the RV64 counterpart is PASUB.W.
 
 ==== ASUBU
 
-TODO: Add missing ASUBU
+===== Encoding
+
+ASUBU is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['ASUBU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = unsigned(X[rs1])
+s2 = unsigned(X[rs2])
+
+diff = s1 - s2
+X[rd] = to_bits(32, diff >> 1)
+----
+
+===== Description
+
+ASUBU performs an unsigned averaging subtraction on a single XLEN-wide value. It
+subtracts the unsigned value in `rs2` from `rs1` at full precision (33 bits),
+then shifts the result right by 1, and writes the lower 32 bits to `rd`.
+Available only in RV32; the RV64 counterpart is PASUBU.W.
 
 ==== PASUB.DB
 
-TODO: Add missing PASUB.DB
+===== Encoding
+
+PASUB.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xb, attr: ['PASUB.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PASUB.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    b = signed(s2_lo[(8*i+7):(8*i)])
+    diff = a - b
+    d_lo[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    b = signed(s2_hi[(8*i+7):(8*i)])
+    diff = a - b
+    d_hi[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PASUB.DB (Packed Averaging Subtract, Double-wide Byte) performs a signed
+averaging subtraction on packed 8-bit elements across register pairs. It is
+equivalent to performing PASUB.B independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 
 ==== PASUB.DH
 
-TODO: Add missing PASUB.DH
+===== Encoding
+
+PASUB.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xb, attr: ['PASUB.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PASUB.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    b = signed(s2_lo[(16*i+15):(16*i)])
+    diff = a - b
+    d_lo[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    b = signed(s2_hi[(16*i+15):(16*i)])
+    diff = a - b
+    d_hi[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PASUB.DH (Packed Averaging Subtract, Double-wide Halfword) performs a signed
+averaging subtraction on packed 16-bit halfword elements across register pairs.
+It is equivalent to performing PASUB.H independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 
 ==== PASUB.DW
 
-TODO: Add missing PASUB.DW
+===== Encoding
+
+PASUB.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['PASUB.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two ASUB operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+diff_lo = signed(s1_lo) - signed(s2_lo)
+d_lo = to_bits(32, diff_lo >> 1)
+
+diff_hi = signed(s1_hi) - signed(s2_hi)
+d_hi = to_bits(32, diff_hi >> 1)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PASUB.DW (Packed Averaging Subtract, Double-wide Word) performs a signed
+averaging subtraction on packed 32-bit word elements across register pairs. It
+is equivalent to performing ASUB independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 
 ==== PASUBU.DB
 
-TODO: Add missing PASUBU.DB
+===== Encoding
+
+PASUBU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PASUBU.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_lo[(8*i+7):(8*i)])
+    b = unsigned(s2_lo[(8*i+7):(8*i)])
+    diff = a - b
+    d_lo[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_hi[(8*i+7):(8*i)])
+    b = unsigned(s2_hi[(8*i+7):(8*i)])
+    diff = a - b
+    d_hi[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PASUBU.DB (Packed Averaging Subtract Unsigned, Double-wide Byte) performs an
+unsigned averaging subtraction on packed 8-bit elements across register pairs.
+It is equivalent to performing PASUBU.B independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 
 ==== PASUBU.DH
 
-TODO: Add missing PASUBU.DH
+===== Encoding
+
+PASUBU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PASUBU.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1_lo[(16*i+15):(16*i)])
+    b = unsigned(s2_lo[(16*i+15):(16*i)])
+    diff = a - b
+    d_lo[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1_hi[(16*i+15):(16*i)])
+    b = unsigned(s2_hi[(16*i+15):(16*i)])
+    diff = a - b
+    d_hi[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PASUBU.DH (Packed Averaging Subtract Unsigned, Double-wide Halfword) performs
+an unsigned averaging subtraction on packed 16-bit halfword elements across
+register pairs. It is equivalent to performing PASUBU.H independently on both
+the even and odd registers of the source and destination pairs. This instruction
+is available only on RV32.
 
 ==== PASUBU.DW
 
-TODO: Add missing PASUBU.DW
+===== Encoding
+
+PASUBU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two ASUBU operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+diff_lo = unsigned(s1_lo) - unsigned(s2_lo)
+d_lo = to_bits(32, diff_lo >> 1)
+
+diff_hi = unsigned(s1_hi) - unsigned(s2_hi)
+d_hi = to_bits(32, diff_hi >> 1)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PASUBU.DW (Packed Averaging Subtract Unsigned, Double-wide Word) performs an
+unsigned averaging subtraction on packed 32-bit word elements across register
+pairs. It is equivalent to performing ASUBU independently on both the even and
+odd registers of the source and destination pairs. This instruction is available
+only on RV32.
 
 === Shift-Add
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 14 Averaging Subtract instructions

## Instructions
- PASUB.B
- PASUB.H
- PASUB.W
- PASUBU.B
- PASUBU.H
- PASUBU.W
- ASUB
- ASUBU
- PASUB.DB
- PASUB.DH
- PASUB.DW
- PASUBU.DB
- PASUBU.DH
- PASUBU.DW
