### PR TITLE
P-ext: add Add-Subtract Cross instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1407,75 +1407,1026 @@ TODO: Add missing PSSH1SADD.DW
 
 ==== PAS.HX
 
-TODO: Add missing PAS.HX
+===== Encoding
+
+PAS.HX is encoded in the OP-32 major opcode with packed halfword cross
+elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x0, attr: ['PAS.HX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    // Even halfword: add
+    a_even = s1[(32*i+15):(32*i)]
+    b_even = s2[(32*i+15):(32*i)]
+    d[(32*i+15):(32*i)] = a_even + b_even
+
+    // Odd halfword: subtract
+    a_odd = s1[(32*i+31):(32*i+16)]
+    b_odd = s2[(32*i+31):(32*i+16)]
+    d[(32*i+31):(32*i+16)] = a_odd - b_odd
+
+X[rd] = d
+----
+
+===== Description
+
+PAS.HX (Packed Add-Subtract Cross, Halfword) performs a cross add-subtract on
+packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
+halfword of `rs1` is added to the even halfword of `rs2`, while the odd (upper)
+halfword of `rs1` has the odd halfword of `rs2` subtracted from it. Results
+wrap modulo 2^16. This instruction is useful for complex number arithmetic.
 
 ==== PAS.WX
 
-TODO: Add missing PAS.WX
+===== Encoding
+
+PAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PAS.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Even word: add
+a_even = s1[31:0]
+b_even = s2[31:0]
+d[31:0] = a_even + b_even
+
+// Odd word: subtract
+a_odd = s1[63:32]
+b_odd = s2[63:32]
+d[63:32] = a_odd - b_odd
+
+X[rd] = d
+----
+
+===== Description
+
+PAS.WX (Packed Add-Subtract Cross, Word) performs a cross add-subtract on
+packed 32-bit word pairs. The even (lower) word of `rs1` is added to the even
+word of `rs2`, while the odd (upper) word of `rs1` has the odd word of `rs2`
+subtracted from it. Results wrap modulo 2^32. This instruction is useful for
+complex number arithmetic. Available only in RV64.
 
 ==== PSA.HX
 
-TODO: Add missing PSA.HX
+===== Encoding
+
+PSA.HX is encoded in the OP-32 major opcode with packed halfword cross
+elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x0, attr: ['PSA.HX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    // Even halfword: subtract
+    a_even = s1[(32*i+15):(32*i)]
+    b_even = s2[(32*i+15):(32*i)]
+    d[(32*i+15):(32*i)] = a_even - b_even
+
+    // Odd halfword: add
+    a_odd = s1[(32*i+31):(32*i+16)]
+    b_odd = s2[(32*i+31):(32*i+16)]
+    d[(32*i+31):(32*i+16)] = a_odd + b_odd
+
+X[rd] = d
+----
+
+===== Description
+
+PSA.HX (Packed Subtract-Add Cross, Halfword) performs a cross subtract-add on
+packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
+halfword of `rs1` has the even halfword of `rs2` subtracted from it, while the
+odd (upper) halfword of `rs1` is added to the odd halfword of `rs2`. Results
+wrap modulo 2^16. This instruction is useful for complex number arithmetic.
 
 ==== PSA.WX
 
-TODO: Add missing PSA.WX
+===== Encoding
+
+PSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['PSA.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Even word: subtract
+a_even = s1[31:0]
+b_even = s2[31:0]
+d[31:0] = a_even - b_even
+
+// Odd word: add
+a_odd = s1[63:32]
+b_odd = s2[63:32]
+d[63:32] = a_odd + b_odd
+
+X[rd] = d
+----
+
+===== Description
+
+PSA.WX (Packed Subtract-Add Cross, Word) performs a cross subtract-add on
+packed 32-bit word pairs. The even (lower) word of `rs1` has the even word of
+`rs2` subtracted from it, while the odd (upper) word of `rs1` is added to the
+odd word of `rs2`. Results wrap modulo 2^32. This instruction is useful for
+complex number arithmetic. Available only in RV64.
 
 ==== PSAS.HX
 
-TODO: Add missing PSAS.HX
+===== Encoding
+
+PSAS.HX is encoded in the OP-32 major opcode with packed halfword cross
+elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PSAS.HX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    // Even halfword: saturating add
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    res_even = a_even + b_even
+    if res_even > 2^15 - 1:
+        res_even = 2^15 - 1; vxsat = 1
+    else if res_even < -(2^15):
+        res_even = -(2^15); vxsat = 1
+    d[(32*i+15):(32*i)] = res_even[15:0]
+
+    // Odd halfword: saturating subtract
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    res_odd = a_odd - b_odd
+    if res_odd > 2^15 - 1:
+        res_odd = 2^15 - 1; vxsat = 1
+    else if res_odd < -(2^15):
+        res_odd = -(2^15); vxsat = 1
+    d[(32*i+31):(32*i+16)] = res_odd[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSAS.HX (Packed Saturating Add-Subtract Cross, Halfword) performs a cross
+saturating add-subtract on packed 16-bit halfword pairs. Within each 32-bit
+word, the even (lower) halfword is computed as a signed saturating addition,
+while the odd (upper) halfword is computed as a signed saturating subtraction.
+Results are clamped to the range [-2^15, 2^15-1]. Sets `vxsat` on saturation.
+This instruction is useful for complex number arithmetic.
 
 ==== PSAS.WX
 
-TODO: Add missing PSAS.WX
+===== Encoding
+
+PSAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PSAS.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Even word: saturating add
+a_even = signed(s1[31:0])
+b_even = signed(s2[31:0])
+res_even = a_even + b_even
+if res_even > 2^31 - 1:
+    res_even = 2^31 - 1; vxsat = 1
+else if res_even < -(2^31):
+    res_even = -(2^31); vxsat = 1
+d[31:0] = res_even[31:0]
+
+// Odd word: saturating subtract
+a_odd = signed(s1[63:32])
+b_odd = signed(s2[63:32])
+res_odd = a_odd - b_odd
+if res_odd > 2^31 - 1:
+    res_odd = 2^31 - 1; vxsat = 1
+else if res_odd < -(2^31):
+    res_odd = -(2^31); vxsat = 1
+d[63:32] = res_odd[31:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSAS.WX (Packed Saturating Add-Subtract Cross, Word) performs a cross saturating
+add-subtract on packed 32-bit word pairs. The even (lower) word is computed as a
+signed saturating addition, while the odd (upper) word is computed as a signed
+saturating subtraction. Results are clamped to the range [-2^31, 2^31-1]. Sets
+`vxsat` on saturation. This instruction is useful for complex number arithmetic.
+Available only in RV64.
 
 ==== PSSA.HX
 
-TODO: Add missing PSSA.HX
+===== Encoding
+
+PSSA.HX is encoded in the OP-32 major opcode with packed halfword cross
+elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x2, attr: ['PSSA.HX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    // Even halfword: saturating subtract
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    res_even = a_even - b_even
+    if res_even > 2^15 - 1:
+        res_even = 2^15 - 1; vxsat = 1
+    else if res_even < -(2^15):
+        res_even = -(2^15); vxsat = 1
+    d[(32*i+15):(32*i)] = res_even[15:0]
+
+    // Odd halfword: saturating add
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    res_odd = a_odd + b_odd
+    if res_odd > 2^15 - 1:
+        res_odd = 2^15 - 1; vxsat = 1
+    else if res_odd < -(2^15):
+        res_odd = -(2^15); vxsat = 1
+    d[(32*i+31):(32*i+16)] = res_odd[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSA.HX (Packed Saturating Subtract-Add Cross, Halfword) performs a cross
+saturating subtract-add on packed 16-bit halfword pairs. Within each 32-bit
+word, the even (lower) halfword is computed as a signed saturating subtraction,
+while the odd (upper) halfword is computed as a signed saturating addition.
+Results are clamped to the range [-2^15, 2^15-1]. Sets `vxsat` on saturation.
+This instruction is useful for complex number arithmetic.
 
 ==== PSSA.WX
 
-TODO: Add missing PSSA.WX
+===== Encoding
+
+PSSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x2, attr: ['PSSA.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Even word: saturating subtract
+a_even = signed(s1[31:0])
+b_even = signed(s2[31:0])
+res_even = a_even - b_even
+if res_even > 2^31 - 1:
+    res_even = 2^31 - 1; vxsat = 1
+else if res_even < -(2^31):
+    res_even = -(2^31); vxsat = 1
+d[31:0] = res_even[31:0]
+
+// Odd word: saturating add
+a_odd = signed(s1[63:32])
+b_odd = signed(s2[63:32])
+res_odd = a_odd + b_odd
+if res_odd > 2^31 - 1:
+    res_odd = 2^31 - 1; vxsat = 1
+else if res_odd < -(2^31):
+    res_odd = -(2^31); vxsat = 1
+d[63:32] = res_odd[31:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSA.WX (Packed Saturating Subtract-Add Cross, Word) performs a cross saturating
+subtract-add on packed 32-bit word pairs. The even (lower) word is computed as a
+signed saturating subtraction, while the odd (upper) word is computed as a
+signed saturating addition. Results are clamped to the range [-2^31, 2^31-1].
+Sets `vxsat` on saturation. This instruction is useful for complex number
+arithmetic. Available only in RV64.
 
 ==== PAAS.HX
 
-TODO: Add missing PAAS.HX
+===== Encoding
+
+PAAS.HX is encoded in the OP-32 major opcode with packed halfword cross
+operations.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x3, attr: ['PAAS.HX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    // Odd halfword: averaging add with cross operand
+    a_hi = signed(s1[(32*i+31):(32*i+16)])
+    b_lo = signed(s2[(32*i+15):(32*i)])
+    sum = a_hi + b_lo
+    d[(32*i+31):(32*i+16)] = to_bits(16, sum >> 1)
+    // Even halfword: averaging subtract with cross operand
+    a_lo = signed(s1[(32*i+15):(32*i)])
+    b_hi = signed(s2[(32*i+31):(32*i+16)])
+    diff = a_lo - b_hi
+    d[(32*i+15):(32*i)] = to_bits(16, diff >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PAAS.HX (Packed Averaging Add-Subtract, Cross Halfword) performs a signed
+averaging cross add-subtract on packed 16-bit halfword elements. For each pair
+of halfwords, the odd (upper) halfword of `rs1` is added to the even (lower)
+halfword of `rs2` at full precision and the result is shifted right by 1, while
+the even (lower) halfword of `rs1` has the odd (upper) halfword of `rs2`
+subtracted at full precision and the result is shifted right by 1. The truncated
+results are written to the corresponding halfwords of `rd`.
 
 ==== PAAS.WX
 
-TODO: Add missing PAAS.WX
+===== Encoding
+
+PAAS.WX is encoded in the OP-32 major opcode with packed word cross operations.
+Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x3, attr: ['PAAS.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Odd word: averaging add with cross operand
+a_hi = signed(s1[63:32])
+b_lo = signed(s2[31:0])
+sum = a_hi + b_lo
+d[63:32] = to_bits(32, sum >> 1)
+
+// Even word: averaging subtract with cross operand
+a_lo = signed(s1[31:0])
+b_hi = signed(s2[63:32])
+diff = a_lo - b_hi
+d[31:0] = to_bits(32, diff >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PAAS.WX (Packed Averaging Add-Subtract, Cross Word) performs a signed averaging
+cross add-subtract on packed 32-bit word elements within a 64-bit register. The
+upper word of `rs1` is added to the lower word of `rs2` at full precision and
+the result is shifted right by 1, while the lower word of `rs1` has the upper
+word of `rs2` subtracted at full precision and the result is shifted right by 1.
+The truncated results are written to the corresponding words of `rd`. Available
+only in RV64.
 
 ==== PASA.HX
 
-TODO: Add missing PASA.HX
+===== Encoding
+
+PASA.HX is encoded in the OP-32 major opcode with packed halfword cross
+operations.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x3, attr: ['PASA.HX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    // Odd halfword: averaging subtract with cross operand
+    a_hi = signed(s1[(32*i+31):(32*i+16)])
+    b_lo = signed(s2[(32*i+15):(32*i)])
+    diff = a_hi - b_lo
+    d[(32*i+31):(32*i+16)] = to_bits(16, diff >> 1)
+    // Even halfword: averaging add with cross operand
+    a_lo = signed(s1[(32*i+15):(32*i)])
+    b_hi = signed(s2[(32*i+31):(32*i+16)])
+    sum = a_lo + b_hi
+    d[(32*i+15):(32*i)] = to_bits(16, sum >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PASA.HX (Packed Averaging Subtract-Add, Cross Halfword) performs a signed
+averaging cross subtract-add on packed 16-bit halfword elements. For each pair
+of halfwords, the odd (upper) halfword of `rs1` has the even (lower) halfword of
+`rs2` subtracted at full precision and the result is shifted right by 1, while
+the even (lower) halfword of `rs1` is added to the odd (upper) halfword of
+`rs2` at full precision and the result is shifted right by 1. The truncated
+results are written to the corresponding halfwords of `rd`.
 
 ==== PASA.WX
 
-TODO: Add missing PASA.WX
+===== Encoding
+
+PASA.WX is encoded in the OP-32 major opcode with packed word cross operations.
+Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x3, attr: ['PASA.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Odd word: averaging subtract with cross operand
+a_hi = signed(s1[63:32])
+b_lo = signed(s2[31:0])
+diff = a_hi - b_lo
+d[63:32] = to_bits(32, diff >> 1)
+
+// Even word: averaging add with cross operand
+a_lo = signed(s1[31:0])
+b_hi = signed(s2[63:32])
+sum = a_lo + b_hi
+d[31:0] = to_bits(32, sum >> 1)
+
+X[rd] = d
+----
+
+===== Description
+
+PASA.WX (Packed Averaging Subtract-Add, Cross Word) performs a signed averaging
+cross subtract-add on packed 32-bit word elements within a 64-bit register. The
+upper word of `rs1` has the lower word of `rs2` subtracted at full precision and
+the result is shifted right by 1, while the lower word of `rs1` is added to the
+upper word of `rs2` at full precision and the result is shifted right by 1. The
+truncated results are written to the corresponding words of `rd`. Available only
+in RV64.
 
 ==== PAS.DHX
 
-TODO: Add missing PAS.DHX
+===== Encoding
+
+PAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x0, attr: ['PAS.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PAS.HX operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+// Even register pair
+d_lo[31:16] = s1_lo[31:16] + s2_lo[15:0]
+d_lo[15:0]  = s1_lo[15:0]  - s2_lo[31:16]
+
+// Odd register pair
+d_hi[31:16] = s1_hi[31:16] + s2_hi[15:0]
+d_hi[15:0]  = s1_hi[15:0]  - s2_hi[31:16]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PAS.DHX (Packed Add-Subtract, Double-wide Cross Halfword) performs packed
+16-bit cross add-subtract on double-wide (register-pair) operands. It is
+equivalent to two PAS.HX operations: one on the even registers and one on the
+odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`) are
+register pairs and must specify even register numbers. For each pair of
+halfwords, the upper halfword is added cross with the lower halfword of the
+other operand, and vice versa with subtraction. Available only in RV32.
 
 ==== PSA.DHX
 
-TODO: Add missing PSA.DHX
+===== Encoding
+
+PSA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x0, attr: ['PSA.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSA.HX operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+// Even register pair
+d_lo[31:16] = s1_lo[31:16] - s2_lo[15:0]
+d_lo[15:0]  = s1_lo[15:0]  + s2_lo[31:16]
+
+// Odd register pair
+d_hi[31:16] = s1_hi[31:16] - s2_hi[15:0]
+d_hi[15:0]  = s1_hi[15:0]  + s2_hi[31:16]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSA.DHX (Packed Subtract-Add, Double-wide Cross Halfword) performs packed
+16-bit cross subtract-add on double-wide (register-pair) operands. It is
+equivalent to two PSA.HX operations: one on the even registers and one on the
+odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`) are
+register pairs and must specify even register numbers. For each pair of
+halfwords, the upper halfword of `rs1` has the lower halfword of `rs2`
+subtracted, and the lower halfword of `rs1` is added with the upper halfword
+of `rs2`. Available only in RV32.
 
 ==== PSAS.DHX
 
-TODO: Add missing PSAS.DHX
+===== Encoding
+
+PSAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PSAS.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSAS.HX operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+// Even register pair: saturating add-subtract cross
+a_hi = signed(s1_lo[31:16])
+b_lo = signed(s2_lo[15:0])
+sum = a_hi + b_lo
+d_lo[31:16] = SAT16(sum)
+a_lo = signed(s1_lo[15:0])
+b_hi = signed(s2_lo[31:16])
+diff = a_lo - b_hi
+d_lo[15:0] = SAT16(diff)
+
+// Odd register pair
+a_hi = signed(s1_hi[31:16])
+b_lo = signed(s2_hi[15:0])
+sum = a_hi + b_lo
+d_hi[31:16] = SAT16(sum)
+a_lo = signed(s1_hi[15:0])
+b_hi = signed(s2_hi[31:16])
+diff = a_lo - b_hi
+d_hi[15:0] = SAT16(diff)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSAS.DHX (Packed Saturating Add-Subtract, Double-wide Cross Halfword) performs
+signed saturating cross add-subtract on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PSAS.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Results are saturated to the signed 16-bit range [-2^15, 2^15-1]. If saturation
+occurs, the overflow flag `vxsat` is set. Available only in RV32.
 
 ==== PSSA.DHX
 
-TODO: Add missing PSSA.DHX
+===== Encoding
+
+PSSA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x2, attr: ['PSSA.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSSA.HX operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+// Even register pair: saturating subtract-add cross
+a_hi = signed(s1_lo[31:16])
+b_lo = signed(s2_lo[15:0])
+diff = a_hi - b_lo
+d_lo[31:16] = SAT16(diff)
+a_lo = signed(s1_lo[15:0])
+b_hi = signed(s2_lo[31:16])
+sum = a_lo + b_hi
+d_lo[15:0] = SAT16(sum)
+
+// Odd register pair
+a_hi = signed(s1_hi[31:16])
+b_lo = signed(s2_hi[15:0])
+diff = a_hi - b_lo
+d_hi[31:16] = SAT16(diff)
+a_lo = signed(s1_hi[15:0])
+b_hi = signed(s2_hi[31:16])
+sum = a_lo + b_hi
+d_hi[15:0] = SAT16(sum)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSSA.DHX (Packed Saturating Subtract-Add, Double-wide Cross Halfword) performs
+signed saturating cross subtract-add on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PSSA.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Results are saturated to the signed 16-bit range [-2^15, 2^15-1]. If saturation
+occurs, the overflow flag `vxsat` is set. Available only in RV32.
 
 ==== PAAS.DHX
 
-TODO: Add missing PAAS.DHX
+===== Encoding
+
+PAAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x3, attr: ['PAAS.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PAAS.HX operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+// Even register pair: averaging add-subtract cross
+a_hi = signed(s1_lo[31:16])
+b_lo = signed(s2_lo[15:0])
+sum = a_hi + b_lo
+d_lo[31:16] = to_bits(16, sum >> 1)
+a_lo = signed(s1_lo[15:0])
+b_hi = signed(s2_lo[31:16])
+diff = a_lo - b_hi
+d_lo[15:0] = to_bits(16, diff >> 1)
+
+// Odd register pair
+a_hi = signed(s1_hi[31:16])
+b_lo = signed(s2_hi[15:0])
+sum = a_hi + b_lo
+d_hi[31:16] = to_bits(16, sum >> 1)
+a_lo = signed(s1_hi[15:0])
+b_hi = signed(s2_hi[31:16])
+diff = a_lo - b_hi
+d_hi[15:0] = to_bits(16, diff >> 1)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PAAS.DHX (Packed Averaging Add-Subtract, Double-wide Cross Halfword) performs
+signed averaging cross add-subtract on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PAAS.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Each result is computed at full precision and then shifted right by 1 (toward
+negative infinity). Available only in RV32.
 
 ==== PASA.DHX
 
-TODO: Add missing PASA.DHX
+===== Encoding
+
+PASA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x3, attr: ['PASA.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PASA.HX operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+// Even register pair: averaging subtract-add cross
+a_hi = signed(s1_lo[31:16])
+b_lo = signed(s2_lo[15:0])
+diff = a_hi - b_lo
+d_lo[31:16] = to_bits(16, diff >> 1)
+a_lo = signed(s1_lo[15:0])
+b_hi = signed(s2_lo[31:16])
+sum = a_lo + b_hi
+d_lo[15:0] = to_bits(16, sum >> 1)
+
+// Odd register pair
+a_hi = signed(s1_hi[31:16])
+b_lo = signed(s2_hi[15:0])
+diff = a_hi - b_lo
+d_hi[31:16] = to_bits(16, diff >> 1)
+a_lo = signed(s1_hi[15:0])
+b_hi = signed(s2_hi[31:16])
+sum = a_lo + b_hi
+d_hi[15:0] = to_bits(16, sum >> 1)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PASA.DHX (Packed Averaging Subtract-Add, Double-wide Cross Halfword) performs
+signed averaging cross subtract-add on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PASA.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Each result is computed at full precision and then shifted right by 1 (toward
+negative infinity). Available only in RV32.
 
 === Absolute Difference
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 18 Add-Subtract Cross instructions

## Instructions
- PAS.HX
- PAS.WX
- PSA.HX
- PSA.WX
- PSAS.HX
- PSAS.WX
- PSSA.HX
- PSSA.WX
- PAAS.HX
- PAAS.WX
- PASA.HX
- PASA.WX
- PAS.DHX
- PSA.DHX
- PSAS.DHX
- PSSA.DHX
- PAAS.DHX
- PASA.DHX
