### PR TITLE
P-ext: add Absolute Difference instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1622,27 +1622,320 @@ result to `rd`.
 
 ==== PABDSUMU.B
 
-TODO: Add missing PABDSUMU.B
+===== Encoding
+
+PABDSUMU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x6, attr: ['PABDSUMU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+sum = 0
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    diff = (a >= b) ? (a - b) : (b - a)
+    sum = sum + diff
+
+X[rd] = to_bits(XLEN, sum)
+----
+
+===== Description
+
+PABDSUMU.B (Packed Absolute Difference Sum, Unsigned Byte) computes the sum of
+absolute differences of packed unsigned 8-bit byte elements from `rs1` and
+`rs2`. For each byte lane, the unsigned absolute difference is computed, and all
+differences are summed into a single scalar result written to `rd`. This
+instruction is commonly used in motion estimation and image processing
+algorithms.
 
 ==== PABDSUMAU.B
 
-TODO: Add missing PABDSUMAU.B
+===== Encoding
+
+PABDSUMAU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x7, attr: ['PABDSUMAU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+sum = unsigned(X[rd])
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    diff = (a >= b) ? (a - b) : (b - a)
+    sum = sum + diff
+
+X[rd] = to_bits(XLEN, sum)
+----
+
+===== Description
+
+PABDSUMAU.B (Packed Absolute Difference Sum Accumulate, Unsigned Byte) computes
+the sum of absolute differences of packed unsigned 8-bit byte elements from
+`rs1` and `rs2`, and accumulates the result into `rd`. For each byte lane, the
+unsigned absolute difference is computed. All differences are summed and added to
+the current value of `rd`. This accumulating form is useful for iteratively
+computing the sum of absolute differences across multiple register-widths of
+data, as commonly needed in motion estimation and image processing algorithms.
 
 ==== PABD.DB
 
-TODO: Add missing PABD.DB
+===== Encoding
+
+PABD.DB is the register-pair (double-wide) variant of PABD.B and is available
+only in RV32. It shares the same encoding as PABD.B with register-pair
+operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x9, attr: ['PABD.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: double the number of byte elements
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. 3:
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    b = signed(s2_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
+
+for i = 0 .. 3:
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    b = signed(s2_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PABD.DB (Packed Absolute Difference, Double-wide Byte) computes the signed
+absolute difference of packed 8-bit elements across register pairs. It is
+equivalent to performing PABD.B independently on both the even and odd registers
+of the source and destination pairs. For each byte lane, the signed absolute
+difference |rs1[i] - rs2[i]| is computed. This instruction is available only
+on RV32.
 
 ==== PABD.DH
 
-TODO: Add missing PABD.DH
+===== Encoding
+
+PABD.DH is the register-pair (double-wide) variant of PABD.H and is available
+only in RV32. It shares the same encoding as PABD.H with register-pair
+operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x9, attr: ['PABD.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: double the number of halfword elements
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. 1:
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    b = signed(s2_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
+
+for i = 0 .. 1:
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    b = signed(s2_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PABD.DH (Packed Absolute Difference, Double-wide Halfword) computes the signed
+absolute difference of packed 16-bit halfword elements across register pairs. It
+is equivalent to performing PABD.H independently on both the even and odd
+registers of the source and destination pairs. For each halfword lane, the
+signed absolute difference |rs1[i] - rs2[i]| is computed. This instruction is
+available only on RV32.
 
 ==== PABDU.DB
 
-TODO: Add missing PABDU.DB
+===== Encoding
+
+PABDU.DB is the register-pair (double-wide) variant of PABDU.B and is available
+only in RV32. It shares the same encoding as PABDU.B with register-pair
+operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xd, attr: ['PABDU.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: double the number of byte elements
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. 3:
+    a = unsigned(s1_lo[(8*i+7):(8*i)])
+    b = unsigned(s2_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
+
+for i = 0 .. 3:
+    a = unsigned(s1_hi[(8*i+7):(8*i)])
+    b = unsigned(s2_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PABDU.DB (Packed Absolute Difference Unsigned, Double-wide Byte) computes the
+unsigned absolute difference of packed 8-bit elements across register pairs. It
+is equivalent to performing PABDU.B independently on both the even and odd
+registers of the source and destination pairs. For each byte lane, the unsigned
+absolute difference |rs1[i] - rs2[i]| is computed. This instruction is
+available only on RV32.
 
 ==== PABDU.DH
 
-TODO: Add missing PABDU.DH
+===== Encoding
+
+PABDU.DH is the register-pair (double-wide) variant of PABDU.H and is available
+only in RV32. It shares the same encoding as PABDU.H with register-pair
+operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xd, attr: ['PABDU.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Register-pair sources: double the number of halfword elements
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. 1:
+    a = unsigned(s1_lo[(16*i+15):(16*i)])
+    b = unsigned(s2_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
+
+for i = 0 .. 1:
+    a = unsigned(s1_hi[(16*i+15):(16*i)])
+    b = unsigned(s2_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PABDU.DH (Packed Absolute Difference Unsigned, Double-wide Halfword) computes
+the unsigned absolute difference of packed 16-bit halfword elements across
+register pairs. It is equivalent to performing PABDU.H independently on both the
+even and odd registers of the source and destination pairs. For each halfword
+lane, the unsigned absolute difference |rs1[i] - rs2[i]| is computed. This
+instruction is available only on RV32.
 
 === Saturating Absolute
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 6 Absolute Difference instructions

## Instructions
- PABDSUMU.B
- PABDSUMAU.B
- PABD.DB
- PABD.DH
- PABDU.DB
- PABDU.DH
