### PR TITLE
P-ext: add Saturating Absolute instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1649,19 +1649,221 @@ TODO: Add missing PABDU.DH
 
 ==== PSABS.B
 
-TODO: Add missing PSABS.B
+===== Encoding
+
+PSABS.B is encoded as a unary instruction in the OP-IMM-32 major opcode with
+packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 0x7, attr: ['PSABS.B'] },
+    { bits: 2, name: 0x2 },
+    { bits: 5, name: 0x1c },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+
+for i = 0 .. (XLEN/8 - 1):
+    val = signed(s1[(8*i+7):(8*i)])
+    if val == -128:
+        d[(8*i+7):(8*i)] = 0x7F
+        vxsat = 1
+    else if val < 0:
+        d[(8*i+7):(8*i)] = to_bits(8, -val)
+    else:
+        d[(8*i+7):(8*i)] = to_bits(8, val)
+
+X[rd] = d
+----
+
+===== Description
+
+PSABS.B (Packed Saturating Absolute Value, Byte) computes the saturating
+absolute value of each packed signed 8-bit byte element in `rs1` and writes the
+results to `rd`. If an element is -128 (the most negative value), the result
+saturates to 127 and the overflow flag `vxsat` is set. For all other values,
+the result is the standard absolute value.
 
 ==== PSABS.H
 
-TODO: Add missing PSABS.H
+===== Encoding
+
+PSABS.H is encoded as a unary instruction in the OP-IMM-32 major opcode with
+packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 0x7, attr: ['PSABS.H'] },
+    { bits: 2, name: 0x0 },
+    { bits: 5, name: 0x1c },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+
+for i = 0 .. (XLEN/16 - 1):
+    val = signed(s1[(16*i+15):(16*i)])
+    if val == -32768:
+        d[(16*i+15):(16*i)] = 0x7FFF
+        vxsat = 1
+    else if val < 0:
+        d[(16*i+15):(16*i)] = to_bits(16, -val)
+    else:
+        d[(16*i+15):(16*i)] = to_bits(16, val)
+
+X[rd] = d
+----
+
+===== Description
+
+PSABS.H (Packed Saturating Absolute Value, Halfword) computes the saturating
+absolute value of each packed signed 16-bit halfword element in `rs1` and writes
+the results to `rd`. If an element is -32768 (the most negative value), the
+result saturates to 32767 and the overflow flag `vxsat` is set. For all other
+values, the result is the standard absolute value.
 
 ==== PSABS.DB
 
-TODO: Add missing PSABS.DB
+===== Encoding
+
+PSABS.DB is the register-pair (double-wide) variant of PSABS.B and is available
+only in RV32. It is encoded as a unary instruction in the OP-IMM-32 major
+opcode using the double-wide register-pair format.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 0x7, attr: ['PSABS.DB'] },
+    { bits: 2, name: 0x2 },
+    { bits: 5, name: 0xc },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSABS.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+
+for i = 0 .. 3:
+    val = signed(s1_lo[(8*i+7):(8*i)])
+    if val == -128:
+        d_lo[(8*i+7):(8*i)] = 0x7F
+        vxsat = 1
+    else if val < 0:
+        d_lo[(8*i+7):(8*i)] = to_bits(8, -val)
+    else:
+        d_lo[(8*i+7):(8*i)] = to_bits(8, val)
+
+for i = 0 .. 3:
+    val = signed(s1_hi[(8*i+7):(8*i)])
+    if val == -128:
+        d_hi[(8*i+7):(8*i)] = 0x7F
+        vxsat = 1
+    else if val < 0:
+        d_hi[(8*i+7):(8*i)] = to_bits(8, -val)
+    else:
+        d_hi[(8*i+7):(8*i)] = to_bits(8, val)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSABS.DB (Packed Saturating Absolute Value, Double-wide Byte) computes the
+saturating absolute value of packed signed 8-bit byte elements across register
+pairs. It is equivalent to performing PSABS.B independently on both the even and
+odd registers of the source and destination pairs. If an element is -128 (the
+most negative value), the result saturates to 127 and the overflow flag `vxsat`
+is set. This instruction is available only on RV32.
 
 ==== PSABS.DH
 
-TODO: Add missing PSABS.DH
+===== Encoding
+
+PSABS.DH is the register-pair (double-wide) variant of PSABS.H and is available
+only in RV32. It is encoded as a unary instruction in the OP-IMM-32 major
+opcode using the double-wide register-pair format.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 0x7, attr: ['PSABS.DH'] },
+    { bits: 2, name: 0x0 },
+    { bits: 5, name: 0xc },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSABS.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+
+for i = 0 .. 1:
+    val = signed(s1_lo[(16*i+15):(16*i)])
+    if val == -32768:
+        d_lo[(16*i+15):(16*i)] = 0x7FFF
+        vxsat = 1
+    else if val < 0:
+        d_lo[(16*i+15):(16*i)] = to_bits(16, -val)
+    else:
+        d_lo[(16*i+15):(16*i)] = to_bits(16, val)
+
+for i = 0 .. 1:
+    val = signed(s1_hi[(16*i+15):(16*i)])
+    if val == -32768:
+        d_hi[(16*i+15):(16*i)] = 0x7FFF
+        vxsat = 1
+    else if val < 0:
+        d_hi[(16*i+15):(16*i)] = to_bits(16, -val)
+    else:
+        d_hi[(16*i+15):(16*i)] = to_bits(16, val)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSABS.DH (Packed Saturating Absolute Value, Double-wide Halfword) computes the
+saturating absolute value of packed signed 16-bit halfword elements across
+register pairs. It is equivalent to performing PSABS.H independently on both the
+even and odd registers of the source and destination pairs. If an element is
+-32768 (the most negative value), the result saturates to 32767 and the overflow
+flag `vxsat` is set. This instruction is available only on RV32.
 
 === Reduction Sum
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 4 Saturating Absolute instructions

## Instructions
- PSABS.B
- PSABS.H
- PSABS.DB
- PSABS.DH
