### PR TITLE
P-ext: add Min/Max instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1853,99 +1853,1099 @@ The PREDSUMU.WS instruction computes an unsigned reduction sum of the two packed
 
 ==== PMIN.B
 
-TODO: Add missing PMIN.B
+===== Encoding
+
+PMIN.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xc, attr: ['PMIN.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? a : b
+
+X[rd] = d
+----
+
+===== Description
+
+PMIN.B computes the signed minimum of corresponding packed 8-bit byte elements
+of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
 ==== PMIN.H
 
-TODO: Add missing PMIN.H
+===== Encoding
+
+PMIN.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xc, attr: ['PMIN.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? a : b
+
+X[rd] = d
+----
+
+===== Description
+
+PMIN.H computes the signed minimum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
 ==== PMIN.W
 
-TODO: Add missing PMIN.W
+===== Encoding
+
+PMIN.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xc, attr: ['PMIN.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = (signed(s1[31:0])  < signed(s2[31:0]))  ? s1[31:0]  : s2[31:0]
+d[63:32] = (signed(s1[63:32]) < signed(s2[63:32])) ? s1[63:32] : s2[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PMIN.W computes the signed minimum of corresponding packed 32-bit word elements
+of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
+in RV64.
 
 ==== PMINU.B
 
-TODO: Add missing PMINU.B
+===== Encoding
+
+PMINU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xd, attr: ['PMINU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? a : b
+
+X[rd] = d
+----
+
+===== Description
+
+PMINU.B computes the unsigned minimum of corresponding packed 8-bit byte
+elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
 ==== PMINU.H
 
-TODO: Add missing PMINU.H
+===== Encoding
+
+PMINU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xd, attr: ['PMINU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? a : b
+
+X[rd] = d
+----
+
+===== Description
+
+PMINU.H computes the unsigned minimum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
 ==== PMINU.W
 
-TODO: Add missing PMINU.W
+===== Encoding
+
+PMINU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xd, attr: ['PMINU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = (unsigned(s1[31:0])  < unsigned(s2[31:0]))  ? s1[31:0]  : s2[31:0]
+d[63:32] = (unsigned(s1[63:32]) < unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PMINU.W computes the unsigned minimum of corresponding packed 32-bit word
+elements of `rs1` and `rs2` and writes the packed word results to `rd`.
+Available only in RV64.
 
 ==== PMAX.B
 
-TODO: Add missing PMAX.B
+===== Encoding
+
+PMAX.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xe, attr: ['PMAX.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a > b) ? a : b
+
+X[rd] = d
+----
+
+===== Description
+
+PMAX.B computes the signed maximum of corresponding packed 8-bit byte elements
+of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
 ==== PMAX.H
 
-TODO: Add missing PMAX.H
+===== Encoding
+
+PMAX.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xe, attr: ['PMAX.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a > b) ? a : b
+
+X[rd] = d
+----
+
+===== Description
+
+PMAX.H computes the signed maximum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
 ==== PMAX.W
 
-TODO: Add missing PMAX.W
+===== Encoding
+
+PMAX.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['PMAX.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = (signed(s1[31:0])  > signed(s2[31:0]))  ? s1[31:0]  : s2[31:0]
+d[63:32] = (signed(s1[63:32]) > signed(s2[63:32])) ? s1[63:32] : s2[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PMAX.W computes the signed maximum of corresponding packed 32-bit word elements
+of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
+in RV64.
 
 ==== PMAXU.B
 
-TODO: Add missing PMAXU.B
+===== Encoding
+
+PMAXU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a > b) ? a : b
+
+X[rd] = d
+----
+
+===== Description
+
+PMAXU.B computes the unsigned maximum of corresponding packed 8-bit byte
+elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
 ==== PMAXU.H
 
-TODO: Add missing PMAXU.H
+===== Encoding
+
+PMAXU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a > b) ? a : b
+
+X[rd] = d
+----
+
+===== Description
+
+PMAXU.H computes the unsigned maximum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
 ==== PMAXU.W
 
-TODO: Add missing PMAXU.W
+===== Encoding
+
+PMAXU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = (unsigned(s1[31:0])  > unsigned(s2[31:0]))  ? s1[31:0]  : s2[31:0]
+d[63:32] = (unsigned(s1[63:32]) > unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PMAXU.W computes the unsigned maximum of corresponding packed 32-bit word
+elements of `rs1` and `rs2` and writes the packed word results to `rd`.
+Available only in RV64.
 
 ==== PMIN.DB
 
-TODO: Add missing PMIN.DB
+===== Encoding
+
+PMIN.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xc, attr: ['PMIN.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMIN.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    b = signed(s2_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a < b) ? a : b
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    b = signed(s2_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a < b) ? a : b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMIN.DB performs packed signed 8-bit byte minimum on double-wide (register-pair)
+operands. It is equivalent to two PMIN.B operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 
 ==== PMIN.DH
 
-TODO: Add missing PMIN.DH
+===== Encoding
+
+PMIN.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xc, attr: ['PMIN.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMIN.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    b = signed(s2_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a < b) ? a : b
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    b = signed(s2_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a < b) ? a : b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMIN.DH performs packed signed 16-bit halfword minimum on double-wide
+(register-pair) operands. It is equivalent to two PMIN.H operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMIN.DW
 
-TODO: Add missing PMIN.DW
+===== Encoding
+
+PMIN.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xc, attr: ['PMIN.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two signed MIN operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = (signed(s1_lo) < signed(s2_lo)) ? s1_lo : s2_lo
+d_hi = (signed(s1_hi) < signed(s2_hi)) ? s1_hi : s2_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMIN.DW performs signed 32-bit word minimum on double-wide (register-pair)
+operands. It is equivalent to two signed MIN operations: one on the even
+registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMINU.DB
 
-TODO: Add missing PMINU.DB
+===== Encoding
+
+PMINU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xd, attr: ['PMINU.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMINU.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_lo[(8*i+7):(8*i)])
+    b = unsigned(s2_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a < b) ? a : b
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_hi[(8*i+7):(8*i)])
+    b = unsigned(s2_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a < b) ? a : b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMINU.DB performs packed unsigned 8-bit byte minimum on double-wide
+(register-pair) operands. It is equivalent to two PMINU.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMINU.DH
 
-TODO: Add missing PMINU.DH
+===== Encoding
+
+PMINU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xd, attr: ['PMINU.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMINU.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1_lo[(16*i+15):(16*i)])
+    b = unsigned(s2_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a < b) ? a : b
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1_hi[(16*i+15):(16*i)])
+    b = unsigned(s2_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a < b) ? a : b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMINU.DH performs packed unsigned 16-bit halfword minimum on double-wide
+(register-pair) operands. It is equivalent to two PMINU.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMINU.DW
 
-TODO: Add missing PMINU.DW
+===== Encoding
+
+PMINU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xd, attr: ['PMINU.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two unsigned MIN operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = (unsigned(s1_lo) < unsigned(s2_lo)) ? s1_lo : s2_lo
+d_hi = (unsigned(s1_hi) < unsigned(s2_hi)) ? s1_hi : s2_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMINU.DW performs unsigned 32-bit word minimum on double-wide (register-pair)
+operands. It is equivalent to two unsigned MIN operations: one on the even
+registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMAX.DB
 
-TODO: Add missing PMAX.DB
+===== Encoding
+
+PMAX.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xe, attr: ['PMAX.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMAX.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    b = signed(s2_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a > b) ? a : b
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    b = signed(s2_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a > b) ? a : b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMAX.DB performs packed signed 8-bit byte maximum on double-wide (register-pair)
+operands. It is equivalent to two PMAX.B operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 
 ==== PMAX.DH
 
-TODO: Add missing PMAX.DH
+===== Encoding
+
+PMAX.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xe, attr: ['PMAX.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMAX.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    b = signed(s2_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a > b) ? a : b
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    b = signed(s2_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a > b) ? a : b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMAX.DH performs packed signed 16-bit halfword maximum on double-wide
+(register-pair) operands. It is equivalent to two PMAX.H operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMAX.DW
 
-TODO: Add missing PMAX.DW
+===== Encoding
+
+PMAX.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['PMAX.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two signed MAX operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = (signed(s1_lo) > signed(s2_lo)) ? s1_lo : s2_lo
+d_hi = (signed(s1_hi) > signed(s2_hi)) ? s1_hi : s2_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMAX.DW performs signed 32-bit word maximum on double-wide (register-pair)
+operands. It is equivalent to two signed MAX operations: one on the even
+registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMAXU.DB
 
-TODO: Add missing PMAXU.DB
+===== Encoding
+
+PMAXU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMAXU.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_lo[(8*i+7):(8*i)])
+    b = unsigned(s2_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a > b) ? a : b
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_hi[(8*i+7):(8*i)])
+    b = unsigned(s2_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a > b) ? a : b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMAXU.DB performs packed unsigned 8-bit byte maximum on double-wide
+(register-pair) operands. It is equivalent to two PMAXU.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMAXU.DH
 
-TODO: Add missing PMAXU.DH
+===== Encoding
+
+PMAXU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMAXU.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1_lo[(16*i+15):(16*i)])
+    b = unsigned(s2_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a > b) ? a : b
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1_hi[(16*i+15):(16*i)])
+    b = unsigned(s2_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a > b) ? a : b
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMAXU.DH performs packed unsigned 16-bit halfword maximum on double-wide
+(register-pair) operands. It is equivalent to two PMAXU.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PMAXU.DW
 
-TODO: Add missing PMAXU.DW
+===== Encoding
+
+PMAXU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two unsigned MAX operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = (unsigned(s1_lo) > unsigned(s2_lo)) ? s1_lo : s2_lo
+d_hi = (unsigned(s1_hi) > unsigned(s2_hi)) ? s1_hi : s2_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMAXU.DW performs unsigned 32-bit word maximum on double-wide (register-pair)
+operands. It is equivalent to two unsigned MAX operations: one on the even
+registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 === Comparison
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 24 Min/Max instructions

## Instructions
- PMIN.B
- PMIN.H
- PMIN.W
- PMINU.B
- PMINU.H
- PMINU.W
- PMAX.B
- PMAX.H
- PMAX.W
- PMAXU.B
- PMAXU.H
- PMAXU.W
- PMIN.DB
- PMIN.DH
- PMIN.DW
- PMINU.DB
- PMINU.DH
- PMINU.DW
- PMAX.DB
- PMAX.DH
- PMAX.DW
- PMAXU.DB
- PMAXU.DH
- PMAXU.DW
