### PR TITLE
P-ext: add Comparison instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1951,11 +1951,87 @@ TODO: Add missing PMAXU.DW
 
 ==== PMSEQ.B
 
-TODO: Add missing PMSEQ.B
+===== Encoding
+
+PMSEQ.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x8, attr: ['PMSEQ.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1[(8*i+7):(8*i)]
+    b = s2[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (a == b) ? 0xFF : 0x00
+
+X[rd] = d
+----
+
+===== Description
+
+PMSEQ.B (Packed Mask Set-if-Equal, Byte) compares corresponding packed 8-bit
+byte elements of `rs1` and `rs2`. For each element position, if the elements
+are equal the result byte is set to all ones (0xFF); otherwise it is set to
+all zeros (0x00). The packed results are written to `rd`.
 
 ==== PMSEQ.H
 
-TODO: Add missing PMSEQ.H
+===== Encoding
+
+PMSEQ.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x8, attr: ['PMSEQ.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (a == b) ? 0xFFFF : 0x0000
+
+X[rd] = d
+----
+
+===== Description
+
+PMSEQ.H (Packed Mask Set-if-Equal, Halfword) compares corresponding packed
+16-bit halfword elements of `rs1` and `rs2`. For each element position, if the
+elements are equal the result halfword is set to all ones (0xFFFF); otherwise
+it is set to all zeros (0x0000). The packed results are written to `rd`.
 
 ==== PMSEQ.W (RV64)
 
@@ -1987,11 +2063,87 @@ equality and produces a packed word mask in `rd`.
 
 ==== PMSLT.B
 
-TODO: Add missing PMSLT.B
+===== Encoding
+
+PMSLT.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xa, attr: ['PMSLT.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+
+X[rd] = d
+----
+
+===== Description
+
+PMSLT.B performs a signed less-than comparison on corresponding packed 8-bit byte
+elements of `rs1` and `rs2`. For each element, if the signed value of `rs1` is
+less than the signed value of `rs2`, the corresponding byte in `rd` is set to
+all-ones (0xFF); otherwise it is set to all-zeros (0x00).
 
 ==== PMSLT.H
 
-TODO: Add missing PMSLT.H
+===== Encoding
+
+PMSLT.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xa, attr: ['PMSLT.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+
+X[rd] = d
+----
+
+===== Description
+
+PMSLT.H performs a signed less-than comparison on corresponding packed 16-bit
+halfword elements of `rs1` and `rs2`. For each element, if the signed value of
+`rs1` is less than the signed value of `rs2`, the corresponding halfword in `rd`
+is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
 
 ==== PMSLT.W (RV64)
 
@@ -2023,11 +2175,87 @@ packed 32-bit elements and produces a packed word mask in `rd`.
 
 ==== PMSLTU.B
 
-TODO: Add missing PMSLTU.B
+===== Encoding
+
+PMSLTU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xb, attr: ['PMSLTU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+
+X[rd] = d
+----
+
+===== Description
+
+PMSLTU.B performs an unsigned less-than comparison on corresponding packed 8-bit
+byte elements of `rs1` and `rs2`. For each element, if the unsigned value of
+`rs1` is less than the unsigned value of `rs2`, the corresponding byte in `rd` is
+set to all-ones (0xFF); otherwise it is set to all-zeros (0x00).
 
 ==== PMSLTU.H
 
-TODO: Add missing PMSLTU.H
+===== Encoding
+
+PMSLTU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xb, attr: ['PMSLTU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+
+X[rd] = d
+----
+
+===== Description
+
+PMSLTU.H performs an unsigned less-than comparison on corresponding packed 16-bit
+halfword elements of `rs1` and `rs2`. For each element, if the unsigned value of
+`rs1` is less than the unsigned value of `rs2`, the corresponding halfword in
+`rd` is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
 
 ==== PMSLTU.W (RV64)
 
@@ -2132,39 +2360,483 @@ unsigned comparison; otherwise it sets `rd` to zero.
 
 ==== PMSEQ.DB
 
-TODO: Add missing PMSEQ.DB
+===== Encoding
+
+PMSEQ.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x8, attr: ['PMSEQ.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMSEQ.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_lo[(8*i+7):(8*i)]
+    b = s2_lo[(8*i+7):(8*i)]
+    d_lo[(8*i+7):(8*i)] = (a == b) ? 0xFF : 0x00
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_hi[(8*i+7):(8*i)]
+    b = s2_hi[(8*i+7):(8*i)]
+    d_hi[(8*i+7):(8*i)] = (a == b) ? 0xFF : 0x00
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSEQ.DB performs packed 8-bit byte mask-equality comparison on double-wide
+(register-pair) operands. It is equivalent to two PMSEQ.B operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFF) if the elements are
+equal, or all-zeros (0x00) otherwise. Available only in RV32.
 
 ==== PMSEQ.DH
 
-TODO: Add missing PMSEQ.DH
+===== Encoding
+
+PMSEQ.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x8, attr: ['PMSEQ.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMSEQ.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_lo[(16*i+15):(16*i)]
+    b = s2_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = (a == b) ? 0xFFFF : 0x0000
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_hi[(16*i+15):(16*i)]
+    b = s2_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = (a == b) ? 0xFFFF : 0x0000
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSEQ.DH performs packed 16-bit halfword mask-equality comparison on double-wide
+(register-pair) operands. It is equivalent to two PMSEQ.H operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFFFF) if the elements are
+equal, or all-zeros (0x0000) otherwise. Available only in RV32.
 
 ==== PMSEQ.DW
 
-TODO: Add missing PMSEQ.DW
+===== Encoding
+
+PMSEQ.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x8, attr: ['PMSEQ.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two MSEQ operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = (s1_lo == s2_lo) ? 0xFFFFFFFF : 0x00000000
+d_hi = (s1_hi == s2_hi) ? 0xFFFFFFFF : 0x00000000
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSEQ.DW performs 32-bit word mask-equality comparison on double-wide
+(register-pair) operands. It is equivalent to two MSEQ operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFFFFFFFF) if the elements
+are equal, or all-zeros (0x00000000) otherwise. Available only in RV32.
 
 ==== PMSLT.DB
 
-TODO: Add missing PMSLT.DB
+===== Encoding
+
+PMSLT.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xa, attr: ['PMSLT.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMSLT.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    b = signed(s2_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    b = signed(s2_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSLT.DB performs packed 8-bit byte signed less-than mask comparison on
+double-wide (register-pair) operands. It is equivalent to two PMSLT.B operations:
+one on the even registers and one on the odd registers of each pair. All three
+operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even
+register numbers. For each element, the result is all-ones (0xFF) if the signed
+`rs1` element is less than the signed `rs2` element, or all-zeros (0x00)
+otherwise. Available only in RV32.
 
 ==== PMSLT.DH
 
-TODO: Add missing PMSLT.DH
+===== Encoding
+
+PMSLT.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xa, attr: ['PMSLT.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMSLT.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    b = signed(s2_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    b = signed(s2_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSLT.DH performs packed 16-bit halfword signed less-than mask comparison on
+double-wide (register-pair) operands. It is equivalent to two PMSLT.H operations:
+one on the even registers and one on the odd registers of each pair. All three
+operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even
+register numbers. For each element, the result is all-ones (0xFFFF) if the signed
+`rs1` element is less than the signed `rs2` element, or all-zeros (0x0000)
+otherwise. Available only in RV32.
 
 ==== PMSLT.DW
 
-TODO: Add missing PMSLT.DW
+===== Encoding
+
+PMSLT.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['PMSLT.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two MSLT operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = (signed(s1_lo) < signed(s2_lo)) ? 0xFFFFFFFF : 0x00000000
+d_hi = (signed(s1_hi) < signed(s2_hi)) ? 0xFFFFFFFF : 0x00000000
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSLT.DW performs 32-bit word signed less-than mask comparison on double-wide
+(register-pair) operands. It is equivalent to two MSLT operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFFFFFFFF) if the signed
+`rs1` element is less than the signed `rs2` element, or all-zeros (0x00000000)
+otherwise. Available only in RV32.
 
 ==== PMSLTU.DB
 
-TODO: Add missing PMSLTU.DB
+===== Encoding
+
+PMSLTU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xb, attr: ['PMSLTU.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMSLTU.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_lo[(8*i+7):(8*i)])
+    b = unsigned(s2_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1_hi[(8*i+7):(8*i)])
+    b = unsigned(s2_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSLTU.DB performs packed 8-bit byte unsigned less-than mask comparison on
+double-wide (register-pair) operands. It is equivalent to two PMSLTU.B
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify
+even register numbers. For each element, the result is all-ones (0xFF) if the
+unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
+(0x00) otherwise. Available only in RV32.
 
 ==== PMSLTU.DH
 
-TODO: Add missing PMSLTU.DH
+===== Encoding
+
+PMSLTU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xb, attr: ['PMSLTU.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PMSLTU.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1_lo[(16*i+15):(16*i)])
+    b = unsigned(s2_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1_hi[(16*i+15):(16*i)])
+    b = unsigned(s2_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSLTU.DH performs packed 16-bit halfword unsigned less-than mask comparison on
+double-wide (register-pair) operands. It is equivalent to two PMSLTU.H
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify
+even register numbers. For each element, the result is all-ones (0xFFFF) if the
+unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
+(0x0000) otherwise. Available only in RV32.
 
 ==== PMSLTU.DW
 
-TODO: Add missing PMSLTU.DW
+===== Encoding
+
+PMSLTU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['PMSLTU.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two MSLTU operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+d_lo = (unsigned(s1_lo) < unsigned(s2_lo)) ? 0xFFFFFFFF : 0x00000000
+d_hi = (unsigned(s1_hi) < unsigned(s2_hi)) ? 0xFFFFFFFF : 0x00000000
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PMSLTU.DW performs 32-bit word unsigned less-than mask comparison on double-wide
+(register-pair) operands. It is equivalent to two MSLTU operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFFFFFFFF) if the unsigned
+`rs1` element is less than the unsigned `rs2` element, or all-zeros (0x00000000)
+otherwise. Available only in RV32.
 
 === Sign Extension
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 15 Comparison instructions

## Instructions
- PMSEQ.B
- PMSEQ.H
- PMSLT.B
- PMSLT.H
- PMSLTU.B
- PMSLTU.H
- PMSEQ.DB
- PMSEQ.DH
- PMSEQ.DW
- PMSLT.DB
- PMSLT.DH
- PMSLT.DW
- PMSLTU.DB
- PMSLTU.DH
- PMSLTU.DW
