### PR TITLE
P-ext: add Sign Extension instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -2170,7 +2170,44 @@ TODO: Add missing PMSLTU.DW
 
 ==== PSEXT.H.B
 
-TODO: Add missing PSEXT.H.B
+===== Encoding
+
+PSEXT.H.B is encoded in the OP-IMM-32 major opcode as a unary instruction.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 0x4, attr: ['PSEXT.H.B'] },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 0xe },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+
+for i = 0 .. (XLEN/16 - 1):
+    // Sign-extend byte at position 2*i into halfword at position i
+    b = s1[(16*i+7):(16*i)]
+    d[(16*i+15):(16*i)] = sign_extend(16, b)
+
+X[rd] = d
+----
+
+===== Description
+
+PSEXT.H.B sign-extends packed 8-bit byte elements from the lower byte of each
+16-bit halfword position in `rs1` into full 16-bit halfword results in `rd`. The
+upper byte of each halfword input is ignored; only the lower byte is
+sign-extended.
 
 ==== PSEXT.W.B (RV64)
 
@@ -2225,15 +2262,140 @@ them to 32-bit values, and packs them into `rd`.
 
 ==== PSEXT.DH.B
 
-TODO: Add missing PSEXT.DH.B
+===== Encoding
+
+PSEXT.DH.B is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair unary format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 0x4, attr: ['PSEXT.DH.B'] },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 0x6 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSEXT.H.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    b = s1_lo[(16*i+7):(16*i)]
+    d_lo[(16*i+15):(16*i)] = sign_extend(16, b)
+
+for i = 0 .. (XLEN/16 - 1):
+    b = s1_hi[(16*i+7):(16*i)]
+    d_hi[(16*i+15):(16*i)] = sign_extend(16, b)
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSEXT.DH.B performs packed sign-extension of bytes to halfwords on double-wide
+(register-pair) operands. It is equivalent to two PSEXT.H.B operations: one on
+the even registers and one on the odd registers of each pair. Both operands
+(`rd_p`, `rs1_p`) are register pairs and must specify even register numbers.
+Available only in RV32.
 
 ==== PSEXT.DW.B
 
-TODO: Add missing PSEXT.DW.B
+===== Encoding
+
+PSEXT.DW.B is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair unary format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 0x4, attr: ['PSEXT.DW.B'] },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 0x6 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SEXT.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+
+d_lo = sign_extend(XLEN, s1_lo[7:0])
+d_hi = sign_extend(XLEN, s1_hi[7:0])
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSEXT.DW.B performs sign-extension of bytes to words on double-wide
+(register-pair) operands. It is equivalent to two SEXT.B operations: one on the
+even registers and one on the odd registers of each pair. Both operands (`rd_p`,
+`rs1_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 
 ==== PSEXT.DW.H
 
-TODO: Add missing PSEXT.DW.H
+===== Encoding
+
+PSEXT.DW.H is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair unary format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 0x5, attr: ['PSEXT.DW.H'] },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 0x6 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SEXT.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+
+d_lo = sign_extend(XLEN, s1_lo[15:0])
+d_hi = sign_extend(XLEN, s1_hi[15:0])
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSEXT.DW.H performs sign-extension of halfwords to words on double-wide
+(register-pair) operands. It is equivalent to two SEXT.H operations: one on the
+even registers and one on the odd registers of each pair. Both operands (`rd_p`,
+`rs1_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 
 === Saturation/Clipping
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 4 Sign Extension instructions

## Instructions
- PSEXT.H.B
- PSEXT.DH.B
- PSEXT.DW.B
- PSEXT.DW.H
