### PR TITLE
P-ext: add Saturation/Clipping instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -2239,19 +2239,209 @@ TODO: Add missing PSEXT.DW.H
 
 ==== PSATI.H
 
-TODO: Add missing PSATI.H
+===== Encoding
+
+PSATI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format for
+packed halfword elements with a 4-bit unsigned immediate.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: 'w-uimm=001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['PSATI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n = uimm[3:0]
+minval_h = sign_extend(16, 0xFFFF << n)
+maxval_h = ~minval_h
+
+for i = 0 .. (XLEN/16 - 1):
+    e = signed(s1[(16*i+15):(16*i)])
+    if e < signed(minval_h):
+        d[(16*i+15):(16*i)] = minval_h
+        vxsat = 1
+    else if e > signed(maxval_h):
+        d[(16*i+15):(16*i)] = maxval_h
+        vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = s1[(16*i+15):(16*i)]
+
+X[rd] = d
+----
+
+===== Description
+
+PSATI.H saturates each packed 16-bit halfword element of `rs1` to the signed
+range [-(2^n), 2^n - 1], where n is specified by the 4-bit unsigned immediate.
+If an element exceeds the range, the result is clamped to the nearest bound and
+the `vxsat` overflow flag is set. Elements already within range are passed
+through unchanged.
 
 ==== PSATI.W
 
-TODO: Add missing PSATI.W
+===== Encoding
+
+PSATI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format for
+packed word elements with a 5-bit unsigned immediate. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: 'w-uimm=01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['PSATI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n = uimm[4:0]
+minval_w = sign_extend(32, 0xFFFFFFFF << n)
+maxval_w = ~minval_w
+
+for i = 0 .. (XLEN/32 - 1):
+    e = signed(s1[(32*i+31):(32*i)])
+    if e < signed(minval_w):
+        d[(32*i+31):(32*i)] = minval_w
+        vxsat = 1
+    else if e > signed(maxval_w):
+        d[(32*i+31):(32*i)] = maxval_w
+        vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = s1[(32*i+31):(32*i)]
+
+X[rd] = d
+----
+
+===== Description
+
+PSATI.W saturates each packed 32-bit word element of `rs1` to the signed range
+[-(2^n), 2^n - 1], where n is specified by the 5-bit unsigned immediate. If an
+element exceeds the range, the result is clamped to the nearest bound and the
+`vxsat` overflow flag is set. Elements already within range are passed through
+unchanged. Available only in RV64.
 
 ==== PUSATI.H
 
-TODO: Add missing PUSATI.H
+===== Encoding
+
+PUSATI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format for
+packed halfword elements with a 4-bit unsigned immediate.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: 'w-uimm=001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PUSATI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n = uimm[3:0]
+maxval_h = ~(0xFFFF << n) & 0xFFFF
+
+for i = 0 .. (XLEN/16 - 1):
+    e = signed(s1[(16*i+15):(16*i)])
+    if e < 0:
+        d[(16*i+15):(16*i)] = 0x0000
+        vxsat = 1
+    else if e > signed(maxval_h):
+        d[(16*i+15):(16*i)] = maxval_h
+        vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = s1[(16*i+15):(16*i)]
+
+X[rd] = d
+----
+
+===== Description
+
+PUSATI.H performs unsigned saturation on each packed 16-bit halfword element of
+`rs1` to the range [0, 2^n - 1], where n is specified by the 4-bit unsigned
+immediate. Negative values are clamped to zero and values exceeding the maximum
+are clamped to 2^n - 1. When clamping occurs, the `vxsat` overflow flag is set.
+Elements already within range are passed through unchanged.
 
 ==== PUSATI.W
 
-TODO: Add missing PUSATI.W
+===== Encoding
+
+PUSATI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format for
+packed word elements with a 5-bit unsigned immediate. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: 'w-uimm=01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PUSATI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n = uimm[4:0]
+maxval_w = ~(0xFFFFFFFF << n) & 0xFFFFFFFF
+
+for i = 0 .. (XLEN/32 - 1):
+    e = signed(s1[(32*i+31):(32*i)])
+    if e < 0:
+        d[(32*i+31):(32*i)] = 0x00000000
+        vxsat = 1
+    else if e > signed(maxval_w):
+        d[(32*i+31):(32*i)] = maxval_w
+        vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = s1[(32*i+31):(32*i)]
+
+X[rd] = d
+----
+
+===== Description
+
+PUSATI.W performs unsigned saturation on each packed 32-bit word element of `rs1`
+to the range [0, 2^n - 1], where n is specified by the 5-bit unsigned immediate.
+Negative values are clamped to zero and values exceeding the maximum are clamped
+to 2^n - 1. When clamping occurs, the `vxsat` overflow flag is set. Elements
+already within range are passed through unchanged. Available only in RV64.
 
 ==== SATI (RV64)
 
@@ -2337,19 +2527,255 @@ determined by the immediate `n` and writes the result to `rd`.
 
 ==== PSATI.DH
 
-TODO: Add missing PSATI.DH
+===== Encoding
+
+PSATI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair w-uimm format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm=001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 0x6 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSATI.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+n = uimm[3:0]
+minval_h = sign_extend(16, 0xFFFF << n)
+maxval_h = ~minval_h
+
+for i = 0 .. (XLEN/16 - 1):
+    e = signed(s1_lo[(16*i+15):(16*i)])
+    if e < signed(minval_h):
+        d_lo[(16*i+15):(16*i)] = minval_h
+        vxsat = 1
+    else if e > signed(maxval_h):
+        d_lo[(16*i+15):(16*i)] = maxval_h
+        vxsat = 1
+    else:
+        d_lo[(16*i+15):(16*i)] = s1_lo[(16*i+15):(16*i)]
+
+for i = 0 .. (XLEN/16 - 1):
+    e = signed(s1_hi[(16*i+15):(16*i)])
+    if e < signed(minval_h):
+        d_hi[(16*i+15):(16*i)] = minval_h
+        vxsat = 1
+    else if e > signed(maxval_h):
+        d_hi[(16*i+15):(16*i)] = maxval_h
+        vxsat = 1
+    else:
+        d_hi[(16*i+15):(16*i)] = s1_hi[(16*i+15):(16*i)]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSATI.DH performs packed 16-bit halfword signed saturation on double-wide
+(register-pair) operands. It is equivalent to two PSATI.H operations: one on the
+even registers and one on the odd registers of each pair. Both operands (`rd_p`,
+`rs1_p`) are register pairs and must specify even register numbers. Each halfword
+element is saturated to the signed range [-(2^n), 2^n - 1], where n is specified
+by the 4-bit unsigned immediate. When clamping occurs, the `vxsat` overflow flag
+is set. Available only in RV32.
 
 ==== PSATI.DW
 
-TODO: Add missing PSATI.DW
+===== Encoding
+
+PSATI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+immediate format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['PSATI.DW'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SATI operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+n     = w_uimm[4:0]
+
+minval = sign_extend(32, 1 << n)       // -(2^n)
+maxval = (1 << n) - 1                  // 2^n - 1
+
+if (s1_lo <s minval):
+    d_lo = minval; vxsat = 1
+else if (s1_lo >s maxval):
+    d_lo = maxval; vxsat = 1
+else:
+    d_lo = s1_lo
+
+if (s1_hi <s minval):
+    d_hi = minval; vxsat = 1
+else if (s1_hi >s maxval):
+    d_hi = maxval; vxsat = 1
+else:
+    d_hi = s1_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSATI.DW performs signed saturation on each 32-bit element across a double-wide
+(register-pair) source. It is equivalent to two SATI operations: one on the even
+registers and one on the odd registers of each pair. Each element is clamped to
+the range [-2^n, 2^n - 1] where `n` is encoded in the immediate field. If
+saturation occurs, `vxsat` is set. The destination (`rd_p`) and source
+(`rs1_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 
 ==== PUSATI.DH
 
-TODO: Add missing PUSATI.DH
+===== Encoding
+
+PUSATI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+immediate format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PUSATI.DH'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PUSATI.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+n     = w_uimm[3:0]
+
+maxval = (1 << n) - 1                  // 2^n - 1
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1_lo[(16*i+15):(16*i)]
+    if (h <s 0):
+        d_lo[(16*i+15):(16*i)] = 0; vxsat = 1
+    else if (h >s maxval):
+        d_lo[(16*i+15):(16*i)] = maxval; vxsat = 1
+    else:
+        d_lo[(16*i+15):(16*i)] = h
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1_hi[(16*i+15):(16*i)]
+    if (h <s 0):
+        d_hi[(16*i+15):(16*i)] = 0; vxsat = 1
+    else if (h >s maxval):
+        d_hi[(16*i+15):(16*i)] = maxval; vxsat = 1
+    else:
+        d_hi[(16*i+15):(16*i)] = h
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PUSATI.DH performs unsigned saturation on each packed 16-bit element across a
+double-wide (register-pair) source. It is equivalent to two PUSATI.H operations:
+one on the even registers and one on the odd registers of each pair. Each
+element is clamped to the range [0, 2^n - 1] where `n` is encoded in the
+immediate field. If saturation occurs, `vxsat` is set. The destination (`rd_p`)
+and source (`rs1_p`) are register pairs and must specify even register numbers.
+Available only in RV32.
 
 ==== PUSATI.DW
 
-TODO: Add missing PUSATI.DW
+===== Encoding
+
+PUSATI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+immediate format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PUSATI.DW'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two USATI operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+n     = w_uimm[4:0]
+
+maxval = (1 << n) - 1                  // 2^n - 1
+
+if (s1_lo <s 0):
+    d_lo = 0; vxsat = 1
+else if (s1_lo >s maxval):
+    d_lo = maxval; vxsat = 1
+else:
+    d_lo = s1_lo
+
+if (s1_hi <s 0):
+    d_hi = 0; vxsat = 1
+else if (s1_hi >s maxval):
+    d_hi = maxval; vxsat = 1
+else:
+    d_hi = s1_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PUSATI.DW performs unsigned saturation on each 32-bit element across a
+double-wide (register-pair) source. It is equivalent to two USATI operations:
+one on the even registers and one on the odd registers of each pair. Each
+element is clamped to the range [0, 2^n - 1] where `n` is encoded in the
+immediate field. If saturation occurs, `vxsat` is set. The destination (`rd_p`)
+and source (`rs1_p`) are register pairs and must specify even register numbers.
+Available only in RV32.
 
 === Shift Operations
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 8 Saturation/Clipping instructions

## Instructions
- PSATI.H
- PSATI.W
- PUSATI.H
- PUSATI.W
- PSATI.DH
- PSATI.DW
- PUSATI.DH
- PUSATI.DW
