### PR TITLE
P-ext: add Shift Operations instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -2413,7 +2413,44 @@ shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 
 ==== PSLL.WS
 
-TODO: Add missing PSLL.WS
+===== Encoding
+
+PSLL.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
+and word elements. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSLL.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (zero_extend(64, w) << shamt)[31:0]
+X[rd] = d
+----
+
+===== Description
+
+PSLL.WS shifts each packed 32-bit element of `rs1` left by the scalar shift
+amount in `rs2[4:0]` and writes the packed word result to `rd`. Bits shifted
+out are discarded and vacated bit positions are filled with zeros. Available
+only in RV64.
 
 ==== PSRL.BS
 
@@ -2475,7 +2512,44 @@ right by the shift amount in `rs2[4:0]` and writes the packed halfword result to
 
 ==== PSRL.WS
 
-TODO: Add missing PSRL.WS
+===== Encoding
+
+PSRL.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
+and word elements. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSRL.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (zero_extend(64, w) >> shamt)[31:0]
+X[rd] = d
+----
+
+===== Description
+
+PSRL.WS logically shifts each packed 32-bit element of `rs1` right by the
+scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV64.
 
 ==== PSRA.BS
 
@@ -2538,131 +2612,1541 @@ right by the shift amount in `rs2[4:0]` and writes the packed halfword result to
 
 ==== PSRA.WS
 
-TODO: Add missing PSRA.WS
+===== Encoding
+
+PSRA.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
+and word elements. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['PSRA.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (sign_extend(64, w) >> shamt)[31:0]
+X[rd] = d
+----
+
+===== Description
+
+PSRA.WS arithmetically shifts each packed 32-bit element of `rs1` right by the
+scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with copies
+of the sign bit. Available only in RV64.
 
 ==== PSLLI.B
 
-TODO: Add missing PSLLI.B
+===== Encoding
+
+PSLLI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '0001xxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [2:0] encode the 3-bit shift amount for byte elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[2:0]
+for i = 0 .. (XLEN/8 - 1):
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (zero_extend(32, b) << shamt)[7:0]
+X[rd] = d
+----
+
+===== Description
+
+PSLLI.B shifts each packed 8-bit element of `rs1` left by the immediate shift
+amount encoded in w-uimm[2:0] and writes the packed byte result to `rd`. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
 
 ==== PSLLI.H
 
-TODO: Add missing PSLLI.H
+===== Encoding
+
+PSLLI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [3:0] encode the 4-bit shift amount for halfword elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[3:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
+X[rd] = d
+----
+
+===== Description
+
+PSLLI.H shifts each packed 16-bit element of `rs1` left by the immediate shift
+amount encoded in w-uimm[3:0] and writes the packed halfword result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with zeros.
 
 ==== PSLLI.W
 
-TODO: Add missing PSLLI.W
+===== Encoding
+
+PSLLI.W is encoded in the OP-IMM-32 major opcode with packed word elements
+and an immediate shift amount. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount for word elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (zero_extend(64, w) << shamt)[31:0]
+X[rd] = d
+----
+
+===== Description
+
+PSLLI.W shifts each packed 32-bit element of `rs1` left by the immediate shift
+amount encoded in w-uimm[4:0] and writes the packed word result to `rd`. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV64.
 
 ==== PSRLI.B
 
-TODO: Add missing PSRLI.B
+===== Encoding
+
+PSRLI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '0001xxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [2:0] encode the 3-bit shift amount for byte elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[2:0]
+for i = 0 .. (XLEN/8 - 1):
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
+X[rd] = d
+----
+
+===== Description
+
+PSRLI.B logically shifts each packed 8-bit element of `rs1` right by the
+immediate shift amount encoded in w-uimm[2:0] and writes the packed byte result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with zeros.
 
 ==== PSRLI.H
 
-TODO: Add missing PSRLI.H
+===== Encoding
+
+PSRLI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [3:0] encode the 4-bit shift amount for halfword elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[3:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
+X[rd] = d
+----
+
+===== Description
+
+PSRLI.H logically shifts each packed 16-bit element of `rs1` right by the
+immediate shift amount encoded in w-uimm[3:0] and writes the packed halfword
+result to `rd`. Bits shifted out are discarded and vacated bit positions are
+filled with zeros.
 
 ==== PSRLI.W
 
-TODO: Add missing PSRLI.W
+===== Encoding
+
+PSRLI.W is encoded in the OP-IMM-32 major opcode with packed word elements
+and an immediate shift amount. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount for word elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (zero_extend(64, w) >> shamt)[31:0]
+X[rd] = d
+----
+
+===== Description
+
+PSRLI.W logically shifts each packed 32-bit element of `rs1` right by the
+immediate shift amount encoded in w-uimm[4:0] and writes the packed word result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with zeros. Available only in RV64.
 
 ==== PSRAI.B
 
-TODO: Add missing PSRAI.B
+===== Encoding
+
+PSRAI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '0001xxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [2:0] encode the 3-bit shift amount for byte elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[2:0]
+for i = 0 .. (XLEN/8 - 1):
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (sign_extend(40, b) >> shamt)[7:0]
+X[rd] = d
+----
+
+===== Description
+
+PSRAI.B arithmetically shifts each packed 8-bit element of `rs1` right by the
+immediate shift amount encoded in w-uimm[2:0] and writes the packed byte result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with copies of the sign bit.
 
 ==== PSRAI.H
 
-TODO: Add missing PSRAI.H
+===== Encoding
+
+PSRAI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [3:0] encode the 4-bit shift amount for halfword elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[3:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (sign_extend(48, h) >> shamt)[15:0]
+X[rd] = d
+----
+
+===== Description
+
+PSRAI.H arithmetically shifts each packed 16-bit element of `rs1` right by the
+immediate shift amount encoded in w-uimm[3:0] and writes the packed halfword
+result to `rd`. Bits shifted out are discarded and vacated bit positions are
+filled with copies of the sign bit.
 
 ==== PSRAI.W
 
-TODO: Add missing PSRAI.W
+===== Encoding
+
+PSRAI.W is encoded in the OP-IMM-32 major opcode with packed word elements
+and an immediate shift amount. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount for word elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (sign_extend(64, w) >> shamt)[31:0]
+X[rd] = d
+----
+
+===== Description
+
+PSRAI.W arithmetically shifts each packed 32-bit element of `rs1` right by the
+immediate shift amount encoded in w-uimm[4:0] and writes the packed word result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with copies of the sign bit. Available only in RV64.
 
 ==== PSRARI.H
 
-TODO: Add missing PSRARI.H
+===== Encoding
+
+PSRARI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSRARI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [3:0] encode the 4-bit shift amount for halfword elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[3:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    // Append rounding bit, shift, then extract rounded result
+    shx[(16+1):0] = ((sign_extend(48, h) @ 0b0) >> shamt)[(16+1):0]
+    d[(16*i+15):(16*i)] = (shx + 1)[16:1]
+X[rd] = d
+----
+
+===== Description
+
+PSRARI.H arithmetically shifts each packed 16-bit element of `rs1` right by
+the immediate shift amount encoded in w-uimm[3:0] with rounding and writes the
+packed halfword result to `rd`. A rounding bit is added before the shift so that
+the result is rounded to the nearest integer (round-to-nearest, ties round up).
 
 ==== PSRARI.W
 
-TODO: Add missing PSRARI.W
+===== Encoding
+
+PSRARI.W is encoded in the OP-IMM-32 major opcode with packed word elements
+and an immediate shift amount. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSRARI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount for word elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = w_uimm[4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    // Append rounding bit, shift, then extract rounded result
+    shx[(32+1):0] = ((sign_extend(64, w) @ 0b0) >> shamt)[(32+1):0]
+    d[(32*i+31):(32*i)] = (shx + 1)[32:1]
+X[rd] = d
+----
+
+===== Description
+
+PSRARI.W arithmetically shifts each packed 32-bit element of `rs1` right by
+the immediate shift amount encoded in w-uimm[4:0] with rounding and writes the
+packed word result to `rd`. A rounding bit is added before the shift so that the
+result is rounded to the nearest integer (round-to-nearest, ties round up).
+Available only in RV64.
 
 ==== PSLL.DBS
 
-TODO: Add missing PSLL.DBS
+===== Encoding
+
+PSLL.DBS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSLL.DBS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSLL.BS operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = X[rs2][4:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    b = s1_lo[(8*i+7):(8*i)]
+    d_lo[(8*i+7):(8*i)] = (zero_extend(32, b) << shamt)[7:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    b = s1_hi[(8*i+7):(8*i)]
+    d_hi[(8*i+7):(8*i)] = (zero_extend(32, b) << shamt)[7:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSLL.DBS shifts each packed 8-bit element left by the scalar shift amount in
+`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
+PSLL.BS operations: one on the even registers and one on the odd registers of
+each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV32.
 
 ==== PSLL.DHS
 
-TODO: Add missing PSLL.DHS
+===== Encoding
+
+PSLL.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSLL.DHS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSLL.HS operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = X[rs2][4:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSLL.DHS shifts each packed 16-bit element left by the scalar shift amount in
+`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
+PSLL.HS operations: one on the even registers and one on the odd registers of
+each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV32.
 
 ==== PSLL.DWS
 
-TODO: Add missing PSLL.DWS
+===== Encoding
+
+PSLL.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSLL.DWS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SLL operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = X[rs2][4:0]
+
+d_lo = (zero_extend(64, s1_lo) << shamt)[31:0]
+d_hi = (zero_extend(64, s1_hi) << shamt)[31:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSLL.DWS shifts each 32-bit element left by the scalar shift amount in
+`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
+SLL operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs and
+must specify even register numbers; `rs2` is a single register. Bits shifted out
+are discarded and vacated bit positions are filled with zeros. Available only in
+RV32.
 
 ==== PSRL.DBS
 
-TODO: Add missing PSRL.DBS
+===== Encoding
+
+PSRL.DBS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSRL.DBS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRL.BS operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = X[rs2][4:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    b = s1_lo[(8*i+7):(8*i)]
+    d_lo[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    b = s1_hi[(8*i+7):(8*i)]
+    d_hi[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRL.DBS logically shifts each packed 8-bit element right by the scalar shift
+amount in `rs2[4:0]` across a double-wide (register-pair) source. It is
+equivalent to two PSRL.BS operations: one on the even registers and one on the
+odd registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
+are register pairs and must specify even register numbers; `rs2` is a single
+register. Bits shifted out are discarded and vacated bit positions are filled
+with zeros. Available only in RV32.
 
 ==== PSRL.DHS
 
-TODO: Add missing PSRL.DHS
+===== Encoding
+
+PSRL.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSRL.DHS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRL.HS operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = X[rs2][4:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRL.DHS logically shifts each packed 16-bit element right by the scalar shift
+amount in `rs2[4:0]` across a double-wide (register-pair) source. It is
+equivalent to two PSRL.HS operations: one on the even registers and one on the
+odd registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
+are register pairs and must specify even register numbers; `rs2` is a single
+register. Bits shifted out are discarded and vacated bit positions are filled
+with zeros. Available only in RV32.
 
 ==== PSRL.DWS
 
-TODO: Add missing PSRL.DWS
+===== Encoding
+
+PSRL.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSRL.DWS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SRL operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+shamt  = X[rs2][4:0]
+
+d_lo = s1_lo >> shamt
+d_hi = s1_hi >> shamt
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRL.DWS (Packed Shift Right Logical, Double-wide Word, Scalar) performs
+logical right shift on each 32-bit word element across a double-wide
+(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
+to two SRL operations: one on the even registers and one on the odd registers
+of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register.
+Available only in RV32.
 
 ==== PSRA.DBS
 
-TODO: Add missing PSRA.DBS
+===== Encoding
+
+PSRA.DBS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['PSRA.DBS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRA.BS operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+shamt  = X[rs2][4:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRA.DBS (Packed Shift Right Arithmetic, Double-wide Byte, Scalar) performs
+arithmetic right shift on each packed 8-bit element across a double-wide
+(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
+to two PSRA.BS operations: one on the even registers and one on the odd
+registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
+are register pairs and must specify even register numbers; `rs2` is a single
+register. Each element is sign-extended before shifting. Available only in
+RV32.
 
 ==== PSRA.DHS
 
-TODO: Add missing PSRA.DHS
+===== Encoding
+
+PSRA.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['PSRA.DHS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRA.HS operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+shamt  = X[rs2][4:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRA.DHS (Packed Shift Right Arithmetic, Double-wide Halfword, Scalar)
+performs arithmetic right shift on each packed 16-bit element across a
+double-wide (register-pair) source by a scalar shift amount from `rs2`. It is
+equivalent to two PSRA.HS operations: one on the even registers and one on
+the odd registers of each pair. The destination (`rd_p`) and first source
+(`rs1_p`) are register pairs and must specify even register numbers; `rs2` is
+a single register. Each element is sign-extended before shifting. Available
+only in RV32.
 
 ==== PSRA.DWS
 
-TODO: Add missing PSRA.DWS
+===== Encoding
+
+PSRA.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['PSRA.DWS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SRA operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+shamt  = X[rs2][4:0]
+
+d_lo = signed(s1_lo) >> shamt
+d_hi = signed(s1_hi) >> shamt
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRA.DWS (Packed Shift Right Arithmetic, Double-wide Word, Scalar) performs
+arithmetic right shift on each 32-bit word element across a double-wide
+(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
+to two SRA operations: one on the even registers and one on the odd registers
+of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register.
+Each element is sign-extended before shifting. Available only in RV32.
 
 ==== PSLLI.DB
 
-TODO: Add missing PSLLI.DB
+===== Encoding
+
+PSLLI.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.DB'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSLLI.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[2:0]          // 3-bit shift amount for bytes
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_lo[(8*i+7):(8*i)]
+    d_lo[(8*i+7):(8*i)] = (a << shamt)[7:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_hi[(8*i+7):(8*i)]
+    d_hi[(8*i+7):(8*i)] = (a << shamt)[7:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSLLI.DB (Packed Shift Left Logical Immediate, Double-wide Byte) shifts each
+packed 8-bit element left by a 3-bit unsigned immediate across a double-wide
+(register-pair) source. It is equivalent to two PSLLI.B operations: one on
+the even registers and one on the odd registers of each pair. The destination
+(`rd_p`) and source (`rs1_p`) are register pairs and must specify even register
+numbers. Vacated bits are filled with zeros. Available only in RV32.
 
 ==== PSLLI.DH
 
-TODO: Add missing PSLLI.DH
+===== Encoding
+
+PSLLI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.DH'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSLLI.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[3:0]          // 4-bit shift amount for halfwords
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = (a << shamt)[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = (a << shamt)[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSLLI.DH (Packed Shift Left Logical Immediate, Double-wide Halfword) shifts
+each packed 16-bit element left by a 4-bit unsigned immediate across a
+double-wide (register-pair) source. It is equivalent to two PSLLI.H
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
+must specify even register numbers. Vacated bits are filled with zeros.
+Available only in RV32.
 
 ==== PSLLI.DW
 
-TODO: Add missing PSLLI.DW
+===== Encoding
+
+PSLLI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.DW'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SLLI operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[4:0]          // 5-bit shift amount for words
+
+d_lo = s1_lo << shamt
+d_hi = s1_hi << shamt
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSLLI.DW (Packed Shift Left Logical Immediate, Double-wide Word) shifts each
+32-bit word element left by a 5-bit unsigned immediate across a double-wide
+(register-pair) source. It is equivalent to two SLLI operations: one on the
+even registers and one on the odd registers of each pair. The destination
+(`rd_p`) and source (`rs1_p`) are register pairs and must specify even register
+numbers. Vacated bits are filled with zeros. Available only in RV32.
 
 ==== PSRLI.DB
 
-TODO: Add missing PSRLI.DB
+===== Encoding
+
+PSRLI.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.DB'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRLI.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[2:0]          // 3-bit shift amount for bytes
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_lo[(8*i+7):(8*i)]
+    d_lo[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1_hi[(8*i+7):(8*i)]
+    d_hi[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRLI.DB (Packed Shift Right Logical Immediate, Double-wide Byte) shifts each
+packed 8-bit element right logically by a 3-bit unsigned immediate across a
+double-wide (register-pair) source. It is equivalent to two PSRLI.B
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
+must specify even register numbers. Vacated bits are filled with zeros.
+Available only in RV32.
 
 ==== PSRLI.DH
 
-TODO: Add missing PSRLI.DH
+===== Encoding
+
+PSRLI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.DH'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRLI.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[3:0]          // 4-bit shift amount for halfwords
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRLI.DH (Packed Shift Right Logical Immediate, Double-wide Halfword) shifts
+each packed 16-bit element right logically by a 4-bit unsigned immediate
+across a double-wide (register-pair) source. It is equivalent to two PSRLI.H
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
+must specify even register numbers. Vacated bits are filled with zeros.
+Available only in RV32.
 
 ==== PSRLI.DW
 
-TODO: Add missing PSRLI.DW
+===== Encoding
+
+PSRLI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.DW'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SRLI operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[4:0]          // 5-bit shift amount for words
+
+d_lo = s1_lo >> shamt
+d_hi = s1_hi >> shamt
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRLI.DW (Packed Shift Right Logical Immediate, Double-wide Word) shifts each
+32-bit word element right logically by a 5-bit unsigned immediate across a
+double-wide (register-pair) source. It is equivalent to two SRLI operations:
+one on the even registers and one on the odd registers of each pair. The
+destination (`rd_p`) and source (`rs1_p`) are register pairs and must specify
+even register numbers. Vacated bits are filled with zeros. Available only in
+RV32.
 
 ==== PSRAI.DB
 
-TODO: Add missing PSRAI.DB
+===== Encoding
+
+PSRAI.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.DB'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRAI.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[2:0]          // 3-bit shift amount for bytes
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_lo[(8*i+7):(8*i)])
+    d_lo[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1_hi[(8*i+7):(8*i)])
+    d_hi[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRAI.DB (Packed Shift Right Arithmetic Immediate, Double-wide Byte) performs
+arithmetic right shift on each packed 8-bit element by a 3-bit unsigned
+immediate across a double-wide (register-pair) source. It is equivalent to
+two PSRAI.B operations: one on the even registers and one on the odd registers
+of each pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs
+and must specify even register numbers. Each element is sign-extended before
+shifting. Available only in RV32.
 
 ==== PSRAI.DH
 
-TODO: Add missing PSRAI.DH
+===== Encoding
+
+PSRAI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.DH'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRAI.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[3:0]          // 4-bit shift amount for halfwords
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    d_lo[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    d_hi[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRAI.DH (Packed Shift Right Arithmetic Immediate, Double-wide Halfword)
+performs arithmetic right shift on each packed 16-bit element by a 4-bit
+unsigned immediate across a double-wide (register-pair) source. It is
+equivalent to two PSRAI.H operations: one on the even registers and one on
+the odd registers of each pair. The destination (`rd_p`) and source (`rs1_p`)
+are register pairs and must specify even register numbers. Each element is
+sign-extended before shifting. Available only in RV32.
 
 ==== PSRAI.DW
 
-TODO: Add missing PSRAI.DW
+===== Encoding
+
+PSRAI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.DW'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SRAI operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[4:0]          // 5-bit shift amount for words
+
+d_lo = signed(s1_lo) >> shamt
+d_hi = signed(s1_hi) >> shamt
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRAI.DW (Packed Shift Right Arithmetic Immediate, Double-wide Word) performs
+arithmetic right shift on each 32-bit word element by a 5-bit unsigned
+immediate across a double-wide (register-pair) source. It is equivalent to
+two SRAI operations: one on the even registers and one on the odd registers of
+each pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs
+and must specify even register numbers. Each element is sign-extended before
+shifting. Available only in RV32.
 
 ==== PSRARI.DH
 
-TODO: Add missing PSRARI.DH
+===== Encoding
+
+PSRARI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: 'w-uimm' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSRARI.DH'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSRARI.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[3:0]          // 4-bit shift amount for halfwords
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    if shamt == 0:
+        d_lo[(16*i+15):(16*i)] = a[15:0]
+    else:
+        round = a[shamt-1]
+        d_lo[(16*i+15):(16*i)] = ((a >> shamt) + round)[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    if shamt == 0:
+        d_hi[(16*i+15):(16*i)] = a[15:0]
+    else:
+        round = a[shamt-1]
+        d_hi[(16*i+15):(16*i)] = ((a >> shamt) + round)[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRARI.DH (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
+Halfword) performs arithmetic right shift with rounding on each packed 16-bit
+element by a 4-bit unsigned immediate across a double-wide (register-pair)
+source. It is equivalent to two PSRARI.H operations: one on the even
+registers and one on the odd registers of each pair. The destination (`rd_p`)
+and source (`rs1_p`) are register pairs and must specify even register numbers.
+The shifted-out bit immediately below the least-significant result bit is
+added for rounding. Available only in RV32.
 
 ==== PSRARI.DW
 
-TODO: Add missing PSRARI.DW
+===== Encoding
+
+PSRARI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+w-uimm format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSRARI.DW'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount for word elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SRARI operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+shamt = w-uimm[4:0]          // 5-bit shift amount for words
+
+if shamt == 0:
+    d_lo = s1_lo
+    d_hi = s1_hi
+else:
+    round_lo = s1_lo[shamt-1]
+    d_lo = (signed(s1_lo) >> shamt) + round_lo
+    round_hi = s1_hi[shamt-1]
+    d_hi = (signed(s1_hi) >> shamt) + round_hi
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSRARI.DW (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
+Word) performs arithmetic right shift with rounding on each 32-bit word
+element by a 5-bit unsigned immediate across a double-wide (register-pair)
+source. It is equivalent to two SRARI operations: one on the even registers
+and one on the odd registers of each pair. The destination (`rd_p`) and source
+(`rs1_p`) are register pairs and must specify even register numbers. The
+shifted-out bit immediately below the least-significant result bit is added
+for rounding. Available only in RV32.
 
 === Saturating/Rounding Shift
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 34 Shift Operations instructions

## Instructions
- PSLL.WS
- PSRL.WS
- PSRA.WS
- PSLLI.B
- PSLLI.H
- PSLLI.W
- PSRLI.B
- PSRLI.H
- PSRLI.W
- PSRAI.B
- PSRAI.H
- PSRAI.W
- PSRARI.H
- PSRARI.W
- PSLL.DBS
- PSLL.DHS
- PSLL.DWS
- PSRL.DBS
- PSRL.DHS
- PSRL.DWS
- PSRA.DBS
- PSRA.DHS
- PSRA.DWS
- PSLLI.DB
- PSLLI.DH
- PSLLI.DW
- PSRLI.DB
- PSRLI.DH
- PSRLI.DW
- PSRAI.DB
- PSRAI.DH
- PSRAI.DW
- PSRARI.DH
- PSRARI.DW
