### PR TITLE
P-ext: add Saturating/Rounding Shift instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -2829,11 +2829,105 @@ rounded, and left shifts saturate to the signed 32-bit range.
 
 ==== PSSLAI.H
 
-TODO: Add missing PSSLAI.H
+===== Encoding
+
+PSSLAI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format
+and packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSSLAI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [3:0] encode the 4-bit shift amount for halfword elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+shamt = w-uimm[3:0]          // 4-bit shift amount for halfwords
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    result = a << shamt
+    if result < -2^15:
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if result > 2^15 - 1:
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = result[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSLAI.H (Packed Saturating Shift Left Arithmetic Immediate, Halfword) shifts
+each packed signed 16-bit element of `rs1` left by a 4-bit unsigned immediate.
+If the shifted result overflows the signed 16-bit range [-2^15, 2^15-1], the
+result is saturated to the nearest boundary and the `vxsat` flag is set. The
+packed halfword results are written to `rd`.
 
 ==== PSSLAI.W
 
-TODO: Add missing PSSLAI.W
+===== Encoding
+
+PSSLAI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format
+and word elements. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSSLAI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount for word elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+shamt = w-uimm[4:0]          // 5-bit shift amount for words
+
+for i = 0 .. (XLEN/32 - 1):
+    a = signed(s1[(32*i+31):(32*i)])
+    result = a << shamt
+    if result < -2^31:
+        d[(32*i+31):(32*i)] = 0x80000000; vxsat = 1
+    else if result > 2^31 - 1:
+        d[(32*i+31):(32*i)] = 0x7FFFFFFF; vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = result[31:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PSSLAI.W (Packed Saturating Shift Left Arithmetic Immediate, Word) shifts each
+packed signed 32-bit element of `rs1` left by a 5-bit unsigned immediate. If
+the shifted result overflows the signed 32-bit range [-2^31, 2^31-1], the
+result is saturated to the nearest boundary and the `vxsat` flag is set. The
+packed word results are written to `rd`. Available only in RV64.
 
 ==== SSHA (RV32)
 
@@ -2933,11 +3027,122 @@ to the signed 32-bit range.
 
 ==== SSLAI
 
-TODO: Add missing SSLAI
+===== Encoding
+
+SSLAI is encoded in the OP-IMM-32 major opcode with the w-uimm format as
+a scalar XLEN-wide saturating shift left arithmetic immediate. In RV32 the
+shift amount is 5 bits.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['SSLAI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount.
+
+===== Operation
+
+[source,pseudocode]
+----
+a = signed(X[rs1])
+shamt = w_uimm[4:0]
+
+result = a << shamt
+
+if result < -(2^(XLEN-1)):
+    d = to_bits(XLEN, -(2^(XLEN-1))); vxsat = 1
+else if result > 2^(XLEN-1) - 1:
+    d = to_bits(XLEN, 2^(XLEN-1) - 1); vxsat = 1
+else:
+    d = to_bits(XLEN, result)
+
+X[rd] = d
+----
+
+===== Description
+
+SSLAI shifts the signed XLEN-wide value in `rs1` left by the immediate
+shift amount and writes the result to `rd` with signed saturation. If the
+shifted result overflows the signed XLEN-wide range, the result is clamped
+to the nearest boundary and the `vxsat` overflow flag is set.
 
 ==== SRARI
 
-TODO: Add missing SRARI
+===== Encoding
+
+SRARI is encoded in the OP-IMM-32 major opcode with the w-uimm format as
+a scalar XLEN-wide shift right arithmetic with rounding. In RV32 the shift
+amount is 5 bits; in RV64 the shift amount is 6 bits.
+
+RV32:
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['SRARI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount for RV32.
+
+RV64:
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '1xxxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['SRARI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The w-uimm field bits [5:0] encode the 6-bit shift amount for RV64.
+
+===== Operation
+
+[source,pseudocode]
+----
+a = X[rs1]
+shamt = w_uimm[log2(XLEN)-1:0]
+
+if shamt == 0:
+    d = a
+else:
+    // Append rounding bit, shift, then extract rounded result
+    shx[(XLEN+1):0] = ((sign_extend(2*XLEN, a) @ 0b0) >> shamt)[(XLEN+1):0]
+    d = (shx + 1)[XLEN:1]
+
+X[rd] = d
+----
+
+===== Description
+
+SRARI arithmetically shifts the XLEN-wide value in `rs1` right by the
+immediate shift amount with rounding and writes the result to `rd`. A
+rounding bit is added before the final shift so that the result is rounded
+to the nearest integer (round-to-nearest, ties round up). When the shift
+amount is zero the source value is written unchanged.
 
 ==== SHA (RV64)
 
@@ -3020,27 +3225,438 @@ shift amounts it performs a rounding right shift as specified in the Sail code.
 
 ==== PSSHA.DHS
 
-TODO: Add missing PSSHA.DHS
+===== Encoding
+
+PSSHA.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['PSSHA.DHS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSSHA.HS operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    if sshamt < 0:
+        // Right shift
+        d_lo[(16*i+15):(16*i)] = (a >> (-sshamt))[15:0]
+    else:
+        // Left shift with saturation
+        result = a << sshamt
+        if result < -2^15:
+            d_lo[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+        else if result > 2^15 - 1:
+            d_lo[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+        else:
+            d_lo[(16*i+15):(16*i)] = result[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    if sshamt < 0:
+        d_hi[(16*i+15):(16*i)] = (a >> (-sshamt))[15:0]
+    else:
+        result = a << sshamt
+        if result < -2^15:
+            d_hi[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+        else if result > 2^15 - 1:
+            d_hi[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+        else:
+            d_hi[(16*i+15):(16*i)] = result[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSSHA.DHS (Packed Saturating Shift Halfword Arithmetic, Double-wide, Scalar)
+performs a signed shift on each packed 16-bit element across a double-wide
+(register-pair) source using a scalar shift amount from `rs2`. When the shift
+amount is positive, elements are shifted left with signed saturation to the
+range [-2^15, 2^15-1]; on saturation the `vxsat` flag is set. When negative,
+elements are arithmetically shifted right. It is equivalent to two PSSHA.HS
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
+and must specify even register numbers; `rs2` is a single register. Available
+only in RV32.
 
 ==== PSSHA.DWS
 
-TODO: Add missing PSSHA.DWS
+===== Encoding
+
+PSSHA.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['PSSHA.DWS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SSHA operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+if sshamt < 0:
+    // Right shift
+    d_lo = (signed(s1_lo) >> (-sshamt))[31:0]
+    d_hi = (signed(s1_hi) >> (-sshamt))[31:0]
+else:
+    // Left shift with saturation
+    result_lo = signed(s1_lo) << sshamt
+    if result_lo < -2^31:
+        d_lo = 0x80000000; vxsat = 1
+    else if result_lo > 2^31 - 1:
+        d_lo = 0x7FFFFFFF; vxsat = 1
+    else:
+        d_lo = result_lo[31:0]
+
+    result_hi = signed(s1_hi) << sshamt
+    if result_hi < -2^31:
+        d_hi = 0x80000000; vxsat = 1
+    else if result_hi > 2^31 - 1:
+        d_hi = 0x7FFFFFFF; vxsat = 1
+    else:
+        d_hi = result_hi[31:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSSHA.DWS (Packed Saturating Shift Word Arithmetic, Double-wide, Scalar)
+performs a signed shift on each 32-bit word element across a double-wide
+(register-pair) source using a scalar shift amount from `rs2`. When the shift
+amount is positive, elements are shifted left with signed saturation to the
+range [-2^31, 2^31-1]; on saturation the `vxsat` flag is set. When negative,
+elements are arithmetically shifted right. It is equivalent to two SSHA
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
+and must specify even register numbers; `rs2` is a single register. Available
+only in RV32.
 
 ==== PSSHAR.DHS
 
-TODO: Add missing PSSHAR.DHS
+===== Encoding
+
+PSSHAR.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['PSSHAR.DHS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSSHAR.HS operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_lo[(16*i+15):(16*i)])
+    if sshamt < 0:
+        // Right shift with rounding
+        xa = a << 1
+        shifted = xa >> (-sshamt)
+        d_lo[(16*i+15):(16*i)] = ((shifted + 1) >> 1)[15:0]
+    else:
+        // Left shift with saturation
+        result = a << sshamt
+        if result < -2^15:
+            d_lo[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+        else if result > 2^15 - 1:
+            d_lo[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+        else:
+            d_lo[(16*i+15):(16*i)] = result[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1_hi[(16*i+15):(16*i)])
+    if sshamt < 0:
+        xa = a << 1
+        shifted = xa >> (-sshamt)
+        d_hi[(16*i+15):(16*i)] = ((shifted + 1) >> 1)[15:0]
+    else:
+        result = a << sshamt
+        if result < -2^15:
+            d_hi[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+        else if result > 2^15 - 1:
+            d_hi[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+        else:
+            d_hi[(16*i+15):(16*i)] = result[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSSHAR.DHS (Packed Saturating Shift Halfword Arithmetic Rounding, Double-wide,
+Scalar) performs a signed shift on each packed 16-bit element across a
+double-wide (register-pair) source using a scalar shift amount from `rs2`.
+When the shift amount is positive, elements are shifted left with signed
+saturation to the range [-2^15, 2^15-1]; on saturation the `vxsat` flag is
+set. When negative, elements are arithmetically shifted right with rounding
+(the shifted-out bit below the LSB is added). It is equivalent to two
+PSSHAR.HS operations: one on the even registers and one on the odd registers
+of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register.
+Available only in RV32.
 
 ==== PSSHAR.DWS
 
-TODO: Add missing PSSHAR.DWS
+===== Encoding
+
+PSSHAR.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
+scalar format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['PSSHAR.DWS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SSHAR operations on even/odd register pairs
+s1_lo  = X[rs1_p * 2]
+s1_hi  = X[rs1_p * 2 + 1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+if sshamt < 0:
+    // Right shift with rounding
+    xa_lo = signed(s1_lo) << 1
+    shifted_lo = xa_lo >> (-sshamt)
+    d_lo = ((shifted_lo + 1) >> 1)[31:0]
+
+    xa_hi = signed(s1_hi) << 1
+    shifted_hi = xa_hi >> (-sshamt)
+    d_hi = ((shifted_hi + 1) >> 1)[31:0]
+else:
+    // Left shift with saturation
+    result_lo = signed(s1_lo) << sshamt
+    if result_lo < -2^31:
+        d_lo = 0x80000000; vxsat = 1
+    else if result_lo > 2^31 - 1:
+        d_lo = 0x7FFFFFFF; vxsat = 1
+    else:
+        d_lo = result_lo[31:0]
+
+    result_hi = signed(s1_hi) << sshamt
+    if result_hi < -2^31:
+        d_hi = 0x80000000; vxsat = 1
+    else if result_hi > 2^31 - 1:
+        d_hi = 0x7FFFFFFF; vxsat = 1
+    else:
+        d_hi = result_hi[31:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSSHAR.DWS (Packed Saturating Shift Word Arithmetic Rounding, Double-wide,
+Scalar) performs a signed shift on each 32-bit word element across a
+double-wide (register-pair) source using a scalar shift amount from `rs2`.
+When the shift amount is positive, elements are shifted left with signed
+saturation to the range [-2^31, 2^31-1]; on saturation the `vxsat` flag is
+set. When negative, elements are arithmetically shifted right with rounding
+(the shifted-out bit below the LSB is added). It is equivalent to two SSHAR
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
+and must specify even register numbers; `rs2` is a single register. Available
+only in RV32.
 
 ==== PSSLAI.DH
 
-TODO: Add missing PSSLAI.DH
+===== Encoding
+
+PSSLAI.DH is encoded in the OP-IMM-32 major opcode using the register-pair
+immediate format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '001xxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSSLAI.DH'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+The w-uimm field bits [3:0] encode the 4-bit shift amount for halfword elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PSSLAI.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+imm = w_uimm[3:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = sign_extend(32, s1_lo[(16*i+15):(16*i)])
+    shx = a << imm
+    if shx < -2^15:
+        d_lo[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if shx > 2^15 - 1:
+        d_lo[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d_lo[(16*i+15):(16*i)] = shx[15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = sign_extend(32, s1_hi[(16*i+15):(16*i)])
+    shx = a << imm
+    if shx < -2^15:
+        d_hi[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if shx > 2^15 - 1:
+        d_hi[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d_hi[(16*i+15):(16*i)] = shx[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSSLAI.DH performs packed 16-bit saturating shift-left arithmetic by an immediate
+on double-wide (register-pair) operands. It is equivalent to two PSSLAI.H
+operations: one on the even registers and one on the odd registers of each pair.
+Both operands (`rd_p`, `rs1_p`) are register pairs and must specify even register
+numbers. If any result overflows the signed 16-bit range, it is saturated and the
+`vxsat` flag is set. Available only in RV32.
 
 ==== PSSLAI.DW
 
-TODO: Add missing PSSLAI.DW
+===== Encoding
+
+PSSLAI.DW is encoded in the OP-IMM-32 major opcode using the register-pair
+immediate format with word elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSSLAI.DW'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+The w-uimm field bits [4:0] encode the 5-bit shift amount for word elements.
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two SSLAI operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+imm = w_uimm[4:0]
+
+a_lo = sign_extend(64, s1_lo)
+shx_lo = a_lo << imm
+if shx_lo < -2^31:
+    d_lo = 0x80000000; vxsat = 1
+else if shx_lo > 2^31 - 1:
+    d_lo = 0x7FFFFFFF; vxsat = 1
+else:
+    d_lo = shx_lo[31:0]
+
+a_hi = sign_extend(64, s1_hi)
+shx_hi = a_hi << imm
+if shx_hi < -2^31:
+    d_hi = 0x80000000; vxsat = 1
+else if shx_hi > 2^31 - 1:
+    d_hi = 0x7FFFFFFF; vxsat = 1
+else:
+    d_hi = shx_hi[31:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PSSLAI.DW performs XLEN-wide saturating shift-left arithmetic by an immediate
+on double-wide (register-pair) operands. It is equivalent to two SSLAI
+operations: one on the even registers and one on the odd registers of each pair.
+Both operands (`rd_p`, `rs1_p`) are register pairs and must specify even register
+numbers. If any result overflows the signed 32-bit range, it is saturated and the
+`vxsat` flag is set. Available only in RV32.
 
 === Pair Operations
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 10 Saturating/Rounding Shift instructions

## Instructions
- PSSLAI.H
- PSSLAI.W
- SSLAI
- SRARI
- PSSHA.DHS
- PSSHA.DWS
- PSSHAR.DHS
- PSSHAR.DWS
- PSSLAI.DH
- PSSLAI.DW
