### PR TITLE
P-ext: add Pair Operations instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -3079,7 +3079,47 @@ halfword element of `rs1` as the low byte.
 
 ==== PPAIRE.H
 
-TODO: Add missing PPAIRE.H
+===== Encoding
+
+PPAIRE.H is encoded in the OP-32 major opcode with packed halfword elements.
+On RV32, PPAIRE.H is a pseudoinstruction aliased to PACK.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PPAIRE.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PPAIRE.H (Pack Pair Even Halfwords) extracts the even (lower) halfword from
+each 32-bit word of `rs1` and `rs2`, and packs them together into the
+corresponding 32-bit word of `rd`. Within each 32-bit group, the lower halfword
+comes from `rs1` and the upper halfword comes from `rs2`. On RV32, this
+instruction is an alias for PACK.
 
 ==== PPAIREO.B
 
@@ -3115,11 +3155,87 @@ the low byte of the corresponding halfword element of `rs1`, producing packed ha
 
 ==== PPAIREO.H
 
-TODO: Add missing PPAIREO.H
+===== Encoding
+
+PPAIREO.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PPAIREO.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PPAIREO.H (Pack Pair Even-Odd Halfwords) extracts the even (lower) halfword
+from each 32-bit word of `rs1` and the odd (upper) halfword from each 32-bit
+word of `rs2`, and packs them together into the corresponding 32-bit word of
+`rd`. Within each 32-bit group, the lower halfword comes from the even position
+of `rs1` and the upper halfword comes from the odd position of `rs2`.
 
 ==== PPAIREO.W
 
-TODO: Add missing PPAIREO.W
+===== Encoding
+
+PPAIREO.W is encoded in the OP-32 major opcode with packed word elements.
+Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x2, attr: ['PPAIREO.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+d = s2[63:32] @ s1[31:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PPAIREO.W (Pack Pair Even-Odd Words) extracts the even (lower) 32-bit word from
+`rs1` and the odd (upper) 32-bit word from `rs2`, and packs them into `rd`. The
+lower word of the result comes from the even position of `rs1` and the upper word
+comes from the odd position of `rs2`. Available only in RV64.
 
 ==== PPAIROE.B
 
@@ -3155,11 +3271,87 @@ the high byte of the corresponding halfword element of `rs1`, producing packed h
 
 ==== PPAIROE.H
 
-TODO: Add missing PPAIROE.H
+===== Encoding
+
+PPAIROE.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['PPAIROE.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[31:16]
+
+X[rd] = d
+----
+
+===== Description
+
+PPAIROE.H (Pack Pair Odd-Even Halfwords) extracts the odd (upper) halfword from
+each 32-bit word of `rs1` and the even (lower) halfword from each 32-bit word
+of `rs2`, and packs them together into the corresponding 32-bit word of `rd`.
+Within each 32-bit group, the lower halfword comes from the odd position of
+`rs1` and the upper halfword comes from the even position of `rs2`.
 
 ==== PPAIROE.W
 
-TODO: Add missing PPAIROE.W
+===== Encoding
+
+PPAIROE.W is encoded in the OP-32 major opcode with packed word elements.
+Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x4, attr: ['PPAIROE.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+d = s2[31:0] @ s1[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PPAIROE.W (Pack Pair Odd-Even Words) extracts the odd (upper) 32-bit word from
+`rs1` and the even (lower) 32-bit word from `rs2`, and packs them into `rd`. The
+lower word of the result comes from the odd position of `rs1` and the upper word
+comes from the even position of `rs2`. Available only in RV64.
 
 ==== PPAIRO.B
 
@@ -3196,43 +3388,519 @@ the high byte of the corresponding halfword element of `rs1`, producing packed h
 
 ==== PPAIRO.H
 
-TODO: Add missing PPAIRO.H
+===== Encoding
+
+PPAIRO.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PPAIRO.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[31:16]
+
+X[rd] = d
+----
+
+===== Description
+
+PPAIRO.H (Pack Pair Odd Halfwords) extracts the odd (upper) halfword from each
+32-bit word of `rs1` and `rs2`, and packs them together into the corresponding
+32-bit word of `rd`. Within each 32-bit group, the lower halfword comes from the
+odd position of `rs1` and the upper halfword comes from the odd position of
+`rs2`.
 
 ==== PPAIRO.W
 
-TODO: Add missing PPAIRO.W
+===== Encoding
+
+PPAIRO.W is encoded in the OP-32 major opcode with packed word elements.
+Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['PPAIRO.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+d = s2[63:32] @ s1[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PPAIRO.W (Pack Pair Odd Words) extracts the odd (upper) 32-bit word from both
+`rs1` and `rs2`, and packs them into `rd`. The lower word of the result comes
+from the odd position of `rs1` and the upper word comes from the odd position of
+`rs2`. Available only in RV64.
 
 ==== PPAIRE.DB
 
-TODO: Add missing PPAIRE.DB
+===== Encoding
+
+PPAIRE.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x0, attr: ['PPAIRE.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIRE.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    s1_h = s1_lo[(16*i+15):(16*i)]
+    s2_h = s2_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[7:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    s1_h = s1_hi[(16*i+15):(16*i)]
+    s2_h = s2_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[7:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PPAIRE.DB performs packed byte even-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRE.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PPAIRE.DH
 
-TODO: Add missing PPAIRE.DH
+===== Encoding
+
+PPAIRE.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PPAIRE.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIRE.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1_lo[(32*i+31):(32*i)]
+    s2_w = s2_lo[(32*i+31):(32*i)]
+    d_lo[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[15:0]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1_hi[(32*i+31):(32*i)]
+    s2_w = s2_hi[(32*i+31):(32*i)]
+    d_hi[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PPAIRE.DH performs packed halfword even-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRE.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PPAIREO.DB
 
-TODO: Add missing PPAIREO.DB
+===== Encoding
+
+PPAIREO.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PPAIREO.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIREO.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    s1_h = s1_lo[(16*i+15):(16*i)]
+    s2_h = s2_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[7:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    s1_h = s1_hi[(16*i+15):(16*i)]
+    s2_h = s2_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[7:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PPAIREO.DB performs packed byte even-odd element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIREO.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PPAIREO.DH
 
-TODO: Add missing PPAIREO.DH
+===== Encoding
+
+PPAIREO.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PPAIREO.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIREO.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1_lo[(32*i+31):(32*i)]
+    s2_w = s2_lo[(32*i+31):(32*i)]
+    d_lo[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[15:0]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1_hi[(32*i+31):(32*i)]
+    s2_w = s2_hi[(32*i+31):(32*i)]
+    d_hi[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[15:0]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PPAIREO.DH performs packed halfword even-odd element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIREO.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PPAIROE.DB
 
-TODO: Add missing PPAIROE.DB
+===== Encoding
+
+PPAIROE.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x4, attr: ['PPAIROE.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIROE.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    s1_h = s1_lo[(16*i+15):(16*i)]
+    s2_h = s2_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[15:8]
+
+for i = 0 .. (XLEN/16 - 1):
+    s1_h = s1_hi[(16*i+15):(16*i)]
+    s2_h = s2_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[15:8]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PPAIROE.DB performs packed byte odd-even element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIROE.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PPAIROE.DH
 
-TODO: Add missing PPAIROE.DH
+===== Encoding
+
+PPAIROE.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['PPAIROE.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIROE.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1_lo[(32*i+31):(32*i)]
+    s2_w = s2_lo[(32*i+31):(32*i)]
+    d_lo[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[31:16]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1_hi[(32*i+31):(32*i)]
+    s2_w = s2_hi[(32*i+31):(32*i)]
+    d_hi[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[31:16]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PPAIROE.DH performs packed halfword odd-even element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIROE.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PPAIRO.DB
 
-TODO: Add missing PPAIRO.DB
+===== Encoding
+
+PPAIRO.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x6, attr: ['PPAIRO.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIRO.B operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/16 - 1):
+    s1_h = s1_lo[(16*i+15):(16*i)]
+    s2_h = s2_lo[(16*i+15):(16*i)]
+    d_lo[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[15:8]
+
+for i = 0 .. (XLEN/16 - 1):
+    s1_h = s1_hi[(16*i+15):(16*i)]
+    s2_h = s2_hi[(16*i+15):(16*i)]
+    d_hi[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[15:8]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PPAIRO.DB performs packed byte odd-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRO.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== PPAIRO.DH
 
-TODO: Add missing PPAIRO.DH
+===== Encoding
+
+PPAIRO.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0xe },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PPAIRO.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIRO.H operations on even/odd register pairs
+s1_lo = X[rs1_p * 2]
+s1_hi = X[rs1_p * 2 + 1]
+s2_lo = X[rs2_p * 2]
+s2_hi = X[rs2_p * 2 + 1]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1_lo[(32*i+31):(32*i)]
+    s2_w = s2_lo[(32*i+31):(32*i)]
+    d_lo[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[31:16]
+
+for i = 0 .. (XLEN/32 - 1):
+    s1_w = s1_hi[(32*i+31):(32*i)]
+    s2_w = s2_hi[(32*i+31):(32*i)]
+    d_hi[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[31:16]
+
+X[rd_p * 2]     = d_lo
+X[rd_p * 2 + 1] = d_hi
+----
+
+===== Description
+
+PPAIRO.DH performs packed halfword odd-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRO.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 === Zip/Unzip and Byte-Reverse
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 15 Pair Operations instructions

## Instructions
- PPAIRE.H
- PPAIREO.H
- PPAIREO.W
- PPAIROE.H
- PPAIROE.W
- PPAIRO.H
- PPAIRO.W
- PPAIRE.DB
- PPAIRE.DH
- PPAIREO.DB
- PPAIREO.DH
- PPAIROE.DB
- PPAIROE.DH
- PPAIRO.DB
- PPAIRO.DH
