### PR TITLE
P-ext: add Double-wide Scalar Add/Subtract instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -3729,11 +3729,92 @@ MERGE uses the prior value of `rd` as the mask to select between `rs1` and `rs2`
 
 ==== ADDD
 
-TODO: Add missing ADDD
+===== Encoding
+
+ADDD is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['ADDD'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// 64-bit addition using register pairs (RV32 only)
+s1 = X[rs1_p * 2 + 1] @ X[rs1_p * 2]   // 64-bit value from register pair
+s2 = X[rs2_p * 2 + 1] @ X[rs2_p * 2]   // 64-bit value from register pair
+
+d = s1 + s2                              // 64-bit addition, wraps modulo 2^64
+
+X[rd_p * 2]     = d[31:0]
+X[rd_p * 2 + 1] = d[63:32]
+----
+
+===== Description
+
+ADDD (Add Doubleword) performs a 64-bit addition of two register-pair operands
+on RV32. The 64-bit source values are formed by concatenating the odd (high) and
+even (low) registers of each pair. The 64-bit sum wraps modulo 2^64 and is
+written back to the register pair designated by `rd_p`. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 
 ==== SUBD
 
-TODO: Add missing SUBD
+===== Encoding
+
+SUBD is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 8, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 4, name: 'rd_p' },
+    { bits: 4, name: 0x6 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x8, attr: ['SUBD'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// 64-bit subtract using register pairs (RV32 only)
+s1 = X[rs1_p * 2 + 1] @ X[rs1_p * 2]   // 64-bit source from pair
+s2 = X[rs2_p * 2 + 1] @ X[rs2_p * 2]   // 64-bit source from pair
+
+d = s1 - s2                              // 64-bit subtraction
+
+X[rd_p * 2]     = d[31:0]
+X[rd_p * 2 + 1] = d[63:32]
+----
+
+===== Description
+
+SUBD performs a 64-bit integer subtraction using register pairs on RV32.
+The source operands `rs1_p` and `rs2_p` each designate a register pair
+forming a 64-bit value (even register = low word, odd register = high word).
+The 64-bit difference is written to the register pair designated by `rd_p`.
+All pair operands must specify even register numbers. Available only in RV32.
 
 === Widening Add/Subtract
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 2 Double-wide Scalar Add/Subtract instructions

## Instructions
- ADDD
- SUBD
