### PR TITLE
P-ext: add Narrowing Clip instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -5819,7 +5819,55 @@ When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
 ==== PNCLIP.BS
 
-TODO: Add missing PNCLIP.BS
+===== Encoding
+
+PNCLIP.BS is encoded in the OP-IMM-32 major opcode with a scalar shift amount
+and packed byte narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['PNCLIP.BS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][4:0]
+
+for i = 0 .. 3:
+    s1_h = s1[(16*i+15):(16*i)]
+    shx  = sign_extend(48, s1_h) >> shamt    // arithmetic shift, take low 16 bits
+    if (shx <s 0xFF80):
+        d[(8*i+7):(8*i)] = 0x80; vxsat = 1
+    else if (shx >s 0x007F):
+        d[(8*i+7):(8*i)] = 0x7F; vxsat = 1
+    else:
+        d[(8*i+7):(8*i)] = shx[7:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PNCLIP.BS performs a packed narrowing signed clip from 16-bit halfword elements
+to 8-bit byte elements with a scalar shift amount. The 64-bit source is read
+from the register pair designated by `rs1_p`. Each 16-bit element is
+arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
+signed 8-bit range [-128, 127]. Four byte results are packed into `rd`. If any
+element saturates, `vxsat` is set. Available only in RV32.
 
 ==== PNCLIPRI.B (RV32)
 
@@ -6122,19 +6170,214 @@ flag is set if any lane saturates.
 
 ==== PNCLIPI.H
 
-TODO: Add missing PNCLIPI.H
+===== Encoding
+
+PNCLIPI.H is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount and packed halfword narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['PNCLIPI.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = w_uimm[4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    shx  = sign_extend(64, s1_w) >> shamt    // arithmetic shift, take low 32 bits
+    if (shx <s 0xFFFF8000):
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if (shx >s 0x00007FFF):
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = shx[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PNCLIPI.H performs a packed narrowing signed clip from 32-bit word elements
+to 16-bit halfword elements with an immediate shift amount. The 64-bit source
+is read from the register pair designated by `rs1_p`. Each 32-bit element is
+arithmetically right-shifted by the 5-bit immediate, then clamped to the signed
+16-bit range [-32768, 32767]. Two halfword results are packed into `rd`. If any
+element saturates, `vxsat` is set. Available only in RV32.
 
 ==== PNCLIP.HS
 
-TODO: Add missing PNCLIP.HS
+===== Encoding
+
+PNCLIP.HS is encoded in the OP-IMM-32 major opcode with a scalar shift amount
+and packed halfword narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['PNCLIP.HS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    shx  = sign_extend(64, s1_w) >> shamt    // arithmetic shift, take low 32 bits
+    if (shx <s 0xFFFF8000):
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if (shx >s 0x00007FFF):
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = shx[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PNCLIP.HS performs a packed narrowing signed clip from 32-bit word elements
+to 16-bit halfword elements with a scalar shift amount. The 64-bit source is
+read from the register pair designated by `rs1_p`. Each 32-bit element is
+arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
+signed 16-bit range [-32768, 32767]. Two halfword results are packed into `rd`.
+If any element saturates, `vxsat` is set. Available only in RV32.
 
 ==== PNCLIPRI.H
 
-TODO: Add missing PNCLIPRI.H
+===== Encoding
+
+PNCLIPRI.H is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount, rounding, and packed halfword narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x7, attr: ['PNCLIPRI.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = w_uimm[4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    // Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
+    shx       = (sign_extend(64, s1_w) @ 0b0) >> shamt   // 33-bit result
+    round_shx = (shx + 1)[32:1]                           // round to nearest, ties up
+    if (round_shx <s 0xFFFF8000):
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if (round_shx >s 0x00007FFF):
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = round_shx[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PNCLIPRI.H performs a packed narrowing signed clip with rounding from 32-bit
+word elements to 16-bit halfword elements using an immediate shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is arithmetically right-shifted with round-to-nearest-up, then clamped
+to the signed 16-bit range [-32768, 32767]. Two halfword results are packed
+into `rd`. If any element saturates, `vxsat` is set. Available only in RV32.
 
 ==== PNCLIPR.HS
 
-TODO: Add missing PNCLIPR.HS
+===== Encoding
+
+PNCLIPR.HS is encoded in the OP-IMM-32 major opcode with a scalar shift
+amount, rounding, and packed halfword narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['PNCLIPR.HS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    // Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
+    shx       = (sign_extend(64, s1_w) @ 0b0) >> shamt   // 33-bit result
+    round_shx = (shx + 1)[32:1]                           // round to nearest, ties up
+    if (round_shx <s 0xFFFF8000):
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if (round_shx >s 0x00007FFF):
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = round_shx[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PNCLIPR.HS performs a packed narrowing signed clip with rounding from 32-bit
+word elements to 16-bit halfword elements using a scalar shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is arithmetically right-shifted with round-to-nearest-up by the amount
+in `rs2[4:0]`, then clamped to the signed 16-bit range [-32768, 32767]. Two
+halfword results are packed into `rd`. If any element saturates, `vxsat` is
+set. Available only in RV32.
 
 ==== PNCLIPIU.H (RV32)
 
@@ -6218,31 +6461,350 @@ packs the results into `rd`. The `vxsat` sticky flag is set on saturation.
 
 ==== PNCLIPRIU.H
 
-TODO: Add missing PNCLIPRIU.H
+===== Encoding
+
+PNCLIPRIU.H is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount, rounding, and unsigned packed halfword narrowing. Available only in
+RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x3, attr: ['PNCLIPRIU.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = w_uimm[4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    // Unsigned shift right with rounding: append guard bit, shift, add 1, drop LSB
+    shx       = (s1_w @ 0b0) >> shamt        // 33-bit logical shift
+    round_shx = (shx + 1)[32:1]              // round to nearest, ties up
+    if (round_shx >u 0x0000FFFF):
+        d[(16*i+15):(16*i)] = 0xFFFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = round_shx[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PNCLIPRIU.H performs a packed narrowing unsigned clip with rounding from 32-bit
+word elements to 16-bit halfword elements using an immediate shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is logically right-shifted with round-to-nearest-up, then clamped to
+the unsigned 16-bit range [0, 65535]. Two halfword results are packed into
+`rd`. If any element saturates, `vxsat` is set. Available only in RV32.
 
 ==== PNCLIPRU.HS
 
-TODO: Add missing PNCLIPRU.HS
+===== Encoding
+
+PNCLIPRU.HS is encoded in the OP-IMM-32 major opcode with a scalar shift
+amount, rounding, and unsigned packed halfword narrowing. Available only in
+RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['PNCLIPRU.HS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    // Unsigned shift right with rounding: append guard bit, shift, add 1, drop LSB
+    shx       = (zero_extend(64, s1_w) @ 0b0) >> shamt   // 33-bit logical shift
+    round_shx = (shx + 1)[32:1]                           // round to nearest, ties up
+    if (round_shx >u 0x0000FFFF):
+        d[(16*i+15):(16*i)] = 0xFFFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = round_shx[15:0]
+
+X[rd] = d
+----
+
+===== Description
+
+PNCLIPRU.HS performs a packed narrowing unsigned clip with rounding from 32-bit
+word elements to 16-bit halfword elements using a scalar shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is logically right-shifted with round-to-nearest-up by the amount in
+`rs2[4:0]`, then clamped to the unsigned 16-bit range [0, 65535]. Two halfword
+results are packed into `rd`. If any element saturates, `vxsat` is set.
+Available only in RV32.
 
 ==== NCLIPI
 
-TODO: Add missing NCLIPI
+===== Encoding
+
+NCLIPI is encoded in the OP-IMM-32 major opcode with an immediate shift amount
+and XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '1xxxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['NCLIPI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = w_uimm[5:0]
+
+shx = sign_extend(128, s1) >> shamt    // arithmetic shift, take low 64 bits
+
+if (shx <s 0xFFFFFFFF80000000):
+    X[rd] = 0x80000000; vxsat = 1
+else if (shx >s 0x000000007FFFFFFF):
+    X[rd] = 0x7FFFFFFF; vxsat = 1
+else:
+    X[rd] = shx[31:0]
+----
+
+===== Description
+
+NCLIPI performs an XLEN-wide narrowing signed clip with an immediate shift
+amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is arithmetically right-shifted by the 6-bit immediate, then
+clamped to the signed 32-bit range [-2^31, 2^31 - 1]. The 32-bit result is
+written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
 ==== NCLIP
 
-TODO: Add missing NCLIP
+===== Encoding
+
+NCLIP is encoded in the OP-IMM-32 major opcode with a scalar shift amount and
+XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['NCLIP'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][5:0]
+
+shx = sign_extend(128, s1) >> shamt    // arithmetic shift, take low 64 bits
+
+if (shx <s 0xFFFFFFFF80000000):
+    X[rd] = 0x80000000; vxsat = 1
+else if (shx >s 0x000000007FFFFFFF):
+    X[rd] = 0x7FFFFFFF; vxsat = 1
+else:
+    X[rd] = shx[31:0]
+----
+
+===== Description
+
+NCLIP performs an XLEN-wide narrowing signed clip with a scalar shift amount.
+The 64-bit source is read from the register pair designated by `rs1_p`. The
+value is arithmetically right-shifted by the amount in `rs2[5:0]`, then clamped
+to the signed 32-bit range [-2^31, 2^31 - 1]. The 32-bit result is written to
+`rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
 ==== NCLIPRI
 
-TODO: Add missing NCLIPRI
+===== Encoding
+
+NCLIPRI is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount, rounding, and XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '1xxxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x7, attr: ['NCLIPRI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = w_uimm[5:0]
+
+// Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
+shx       = (sign_extend(128, s1) @ 0b0) >> shamt   // 65-bit result
+round_shx = (shx + 1)[64:1]                          // round to nearest, ties up
+
+if (round_shx <s 0xFFFFFFFF80000000):
+    X[rd] = 0x80000000; vxsat = 1
+else if (round_shx >s 0x000000007FFFFFFF):
+    X[rd] = 0x7FFFFFFF; vxsat = 1
+else:
+    X[rd] = round_shx[31:0]
+----
+
+===== Description
+
+NCLIPRI performs an XLEN-wide narrowing signed clip with rounding using an
+immediate shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is arithmetically right-shifted with
+round-to-nearest-up by the 6-bit immediate, then clamped to the signed 32-bit
+range [-2^31, 2^31 - 1]. The 32-bit result is written to `rd`. If saturation
+occurs, `vxsat` is set. Available only in RV32.
 
 ==== NCLIPR
 
-TODO: Add missing NCLIPR
+===== Encoding
+
+NCLIPR is encoded in the OP-IMM-32 major opcode with a scalar shift amount,
+rounding, and XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['NCLIPR'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][5:0]
+
+// Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
+shx       = (sign_extend(128, s1) @ 0b0) >> shamt   // 65-bit result
+round_shx = (shx + 1)[64:1]                          // round to nearest, ties up
+
+if (round_shx <s 0xFFFFFFFF80000000):
+    X[rd] = 0x80000000; vxsat = 1
+else if (round_shx >s 0x000000007FFFFFFF):
+    X[rd] = 0x7FFFFFFF; vxsat = 1
+else:
+    X[rd] = round_shx[31:0]
+----
+
+===== Description
+
+NCLIPR performs an XLEN-wide narrowing signed clip with rounding using a scalar
+shift amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is arithmetically right-shifted with round-to-nearest-up by
+the amount in `rs2[5:0]`, then clamped to the signed 32-bit range
+[-2^31, 2^31 - 1]. The 32-bit result is written to `rd`. If saturation occurs,
+`vxsat` is set. Available only in RV32.
 
 ==== NCLIPIU
 
-TODO: Add missing NCLIPIU
+===== Encoding
+
+NCLIPIU is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount and unsigned XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '1xxxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['NCLIPIU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = w_uimm[5:0]
+
+shx = s1 >> shamt                      // logical shift
+
+if (shx >u 0x00000000FFFFFFFF):
+    X[rd] = 0xFFFFFFFF; vxsat = 1
+else:
+    X[rd] = shx[31:0]
+----
+
+===== Description
+
+NCLIPIU performs an XLEN-wide narrowing unsigned clip with an immediate shift
+amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is logically right-shifted by the 6-bit immediate, then
+clamped to the unsigned 32-bit range [0, 2^32 - 1]. The 32-bit result is
+written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
 ==== NCLIPU (RV32)
 
@@ -6282,11 +6844,100 @@ the result to 32-bit unsigned. The `vxsat` sticky flag is set if clipping occurs
 
 ==== NCLIPRIU
 
-TODO: Add missing NCLIPRIU
+===== Encoding
+
+NCLIPRIU is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount, rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 7, name: '1xxxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x3, attr: ['NCLIPRIU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = w_uimm[5:0]
+
+// Unsigned shift right with rounding: append guard bit, shift, add 1, drop LSB
+shx       = (s1 @ 0b0) >> shamt              // 65-bit logical shift
+round_shx = (shx + 1)[64:1]                  // round to nearest, ties up
+
+if (round_shx >u 0x00000000FFFFFFFF):
+    X[rd] = 0xFFFFFFFF; vxsat = 1
+else:
+    X[rd] = round_shx[31:0]
+----
+
+===== Description
+
+NCLIPRIU performs an XLEN-wide narrowing unsigned clip with rounding using an
+immediate shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is logically right-shifted with
+round-to-nearest-up by the 6-bit immediate, then clamped to the unsigned
+32-bit range [0, 2^32 - 1]. The 32-bit result is written to `rd`. If
+saturation occurs, `vxsat` is set. Available only in RV32.
 
 ==== NCLIPRU
 
-TODO: Add missing NCLIPRU
+===== Encoding
+
+NCLIPRU is encoded in the OP-IMM-32 major opcode with a scalar shift amount,
+rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 4, name: 0xc },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['NCLIPRU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][5:0]
+
+// Unsigned shift right with rounding: append guard bit, shift, add 1, drop LSB
+shx       = (s1 @ 0b0) >> shamt              // 65-bit logical shift
+round_shx = (shx + 1)[64:1]                  // round to nearest, ties up
+
+if (round_shx >u 0x00000000FFFFFFFF):
+    X[rd] = 0xFFFFFFFF; vxsat = 1
+else:
+    X[rd] = round_shx[31:0]
+----
+
+===== Description
+
+NCLIPRU performs an XLEN-wide narrowing unsigned clip with rounding using a
+scalar shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is logically right-shifted with
+round-to-nearest-up by the amount in `rs2[5:0]`, then clamped to the unsigned
+32-bit range [0, 2^32 - 1]. The 32-bit result is written to `rd`. If
+saturation occurs, `vxsat` is set. Available only in RV32.
 
 === Multiply High (same-width)
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 14 Narrowing Clip instructions

## Instructions
- PNCLIP.BS
- PNCLIPI.H
- PNCLIP.HS
- PNCLIPRI.H
- PNCLIPR.HS
- PNCLIPRIU.H
- PNCLIPRU.HS
- NCLIPI
- NCLIP
- NCLIPRI
- NCLIPR
- NCLIPIU
- NCLIPRIU
- NCLIPRU
