### PR TITLE
P-ext: add Multiply High instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -6504,7 +6504,44 @@ PMULQR.H:
 
 ==== PMULHU.H
 
-TODO: Add missing PMULHU.H
+===== Encoding
+
+PMULHU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PMULHU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (unsigned(a) * unsigned(b))[31:16]
+
+X[rd] = d
+----
+
+===== Description
+
+PMULHU.H multiplies corresponding unsigned packed 16-bit halfword elements of
+`rs1` and `rs2`, producing 32-bit intermediate products, and writes the upper
+16 bits of each product to the corresponding halfword element of `rd`.
 
 ==== PMULHRU.H
 
@@ -6551,11 +6588,89 @@ element of `rd`, implementing rounding when extracting the high half.
 
 ==== PMULH.W
 
-TODO: Add missing PMULH.W
+===== Encoding
+
+PMULH.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PMULH.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (signed(a) * signed(b))[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PMULH.W multiplies corresponding signed packed 32-bit word elements of `rs1`
+and `rs2`, producing 64-bit intermediate products, and writes the upper 32 bits
+of each product to the corresponding word element of `rd`. This instruction is
+available only on RV64.
 
 ==== PMULHR.W
 
-TODO: Add missing PMULHR.W
+===== Encoding
+
+PMULHR.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['PMULHR.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (signed(a) * signed(b) + 2^31)[63:32]
+
+X[rd] = d
+----
+
+===== Description
+
+PMULHR.W multiplies corresponding signed packed 32-bit word elements of `rs1`
+and `rs2`, producing 64-bit intermediate products, adds a rounding constant
+of 2^31, and writes the upper 32 bits of each rounded product to the
+corresponding word element of `rd`. This instruction is available only on RV64.
 
 ==== PMULHSU.W (RV64)
 
@@ -6699,7 +6814,40 @@ applies rounding, and writes the upper 32 bits of each product to `rd`.
 
 ==== MULHR
 
-TODO: Add missing MULHR
+===== Encoding
+
+MULHR is encoded in the OP-32 major opcode as an XLEN-wide operation.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['MULHR'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV32
+X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^31)[63:32]
+
+# RV64
+X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^63)[127:64]
+----
+
+===== Description
+
+MULHR multiplies the full signed XLEN-bit values of `rs1` and `rs2`, producing
+a 2*XLEN-bit intermediate product, adds a rounding constant of 2^(XLEN-1),
+and writes the upper XLEN bits of the rounded product to `rd`.
 
 ==== MULHRSU (RV32)
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 4 Multiply High instructions

## Instructions
- PMULHU.H
- PMULH.W
- PMULHR.W
- MULHR
