### PR TITLE
P-ext: add Q-format Multiply instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -6766,7 +6766,49 @@ The MULHRU instruction multiplie
 
 ==== PMULQ.H
 
-TODO: Add missing PMULQ.H
+===== Encoding
+
+PMULQ.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xa, attr: ['PMULQ.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    if (a == 0x8000) & (b == 0x8000):
+        d[(16*i+15):(16*i)] = 0x7FFF
+        vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = (signed(a) * signed(b))[30:15]
+
+X[rd] = d
+----
+
+===== Description
+
+PMULQ.H performs a Q-format multiply on corresponding signed packed 16-bit
+halfword elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
+upper 16 bits. When both inputs are the most negative value (0x8000), the
+result saturates to 0x7FFF and the `vxsat` overflow flag is set.
 
 ==== PMULQR.H
 
@@ -6820,19 +6862,201 @@ right shift by 15). If both inputs are `0x8000`, the result saturates to
 
 ==== PMULQ.W
 
-TODO: Add missing PMULQ.W
+===== Encoding
+
+PMULQ.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['PMULQ.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    if (a == 0x80000000) & (b == 0x80000000):
+        d[(32*i+31):(32*i)] = 0x7FFFFFFF
+        vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = (signed(a) * signed(b))[62:31]
+
+X[rd] = d
+----
+
+===== Description
+
+PMULQ.W performs a Q-format multiply on corresponding signed packed 32-bit
+word elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
+upper 32 bits. When both inputs are the most negative value (0x80000000), the
+result saturates to 0x7FFFFFFF and the `vxsat` overflow flag is set. This
+instruction is available only on RV64.
 
 ==== PMULQR.W
 
-TODO: Add missing PMULQR.W
+===== Encoding
+
+PMULQR.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xa, attr: ['PMULQR.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    if (a == 0x80000000) & (b == 0x80000000):
+        d[(32*i+31):(32*i)] = 0x7FFFFFFF
+        vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = (signed(a) * signed(b) + 2^30)[62:31]
+
+X[rd] = d
+----
+
+===== Description
+
+PMULQR.W performs a rounding Q-format multiply on corresponding signed packed
+32-bit word elements of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a
+rounding constant of 2^30 before the shift, and keeps the upper 32 bits. When
+both inputs are the most negative value (0x80000000), the result saturates to
+0x7FFFFFFF and the `vxsat` overflow flag is set. This instruction is available
+only on RV64.
 
 ==== MULQ
 
-TODO: Add missing MULQ
+===== Encoding
+
+MULQ is encoded in the OP-32 major opcode as an XLEN-wide operation.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['MULQ'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV32
+a = X[rs1]
+b = X[rs2]
+if (a == 0x80000000) & (b == 0x80000000):
+    X[rd] = 0x7FFFFFFF
+    vxsat = 1
+else:
+    X[rd] = (signed(a) * signed(b))[62:31]
+
+# RV64
+a = X[rs1]
+b = X[rs2]
+if (a == 0x8000000000000000) & (b == 0x8000000000000000):
+    X[rd] = 0x7FFFFFFFFFFFFFFF
+    vxsat = 1
+else:
+    X[rd] = (signed(a) * signed(b))[126:63]
+----
+
+===== Description
+
+MULQ performs a Q-format multiply on the full signed XLEN-bit values of `rs1`
+and `rs2`. It computes `(a * b) << 1` and keeps the upper XLEN bits. When both
+inputs are the most negative value, the result saturates to the most positive
+value and the `vxsat` overflow flag is set.
 
 ==== MULQR
 
-TODO: Add missing MULQR
+===== Encoding
+
+MULQR is encoded in the OP-32 major opcode as an XLEN-wide operation.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xa, attr: ['MULQR'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV32
+a = X[rs1]
+b = X[rs2]
+if (a == 0x80000000) & (b == 0x80000000):
+    X[rd] = 0x7FFFFFFF
+    vxsat = 1
+else:
+    X[rd] = (signed(a) * signed(b) + 2^30)[62:31]
+
+# RV64
+a = X[rs1]
+b = X[rs2]
+if (a == 0x8000000000000000) & (b == 0x8000000000000000):
+    X[rd] = 0x7FFFFFFFFFFFFFFF
+    vxsat = 1
+else:
+    X[rd] = (signed(a) * signed(b) + 2^62)[126:63]
+----
+
+===== Description
+
+MULQR performs a rounding Q-format multiply on the full signed XLEN-bit values
+of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a rounding constant of
+2^(XLEN-2) before the shift, and keeps the upper XLEN bits. When both inputs
+are the most negative value, the result saturates to the most positive value
+and the `vxsat` overflow flag is set.
 
 === Multiply-High Accumulate
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 5 Q-format Multiply instructions

## Instructions
- PMULQ.H
- PMULQ.W
- PMULQR.W
- MULQ
- MULQR
