### PR TITLE
P-ext: add Cross-element Multiply instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -8711,15 +8711,111 @@ as unsigned 8-bit values, producing packed 16-bit products in `rd`.
 
 ==== MUL.H00
 
-TODO: Add missing MUL.H00
+===== Encoding
+
+MUL.H00 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['MUL.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV32
+s1_h0 = X[rs1][15:0]
+s2_h0 = X[rs2][15:0]
+X[rd] = signed(s1_h0) * signed(s2_h0)
+----
+
+===== Description
+
+MUL.H00 multiplies the low 16-bit halfword (h0) of `rs1` by the low 16-bit
+halfword (h0) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
 
 ==== MUL.H01
 
-TODO: Add missing MUL.H01
+===== Encoding
+
+MUL.H01 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['MUL.H01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV32
+s1_h0 = X[rs1][15:0]
+s2_h1 = X[rs2][31:16]
+X[rd] = signed(s1_h0) * signed(s2_h1)
+----
+
+===== Description
+
+MUL.H01 multiplies the low 16-bit halfword (h0) of `rs1` by the high 16-bit
+halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
 
 ==== MUL.H11
 
-TODO: Add missing MUL.H11
+===== Encoding
+
+MUL.H11 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['MUL.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV32
+s1_h1 = X[rs1][31:16]
+s2_h1 = X[rs2][31:16]
+X[rd] = signed(s1_h1) * signed(s2_h1)
+----
+
+===== Description
+
+MUL.H11 multiplies the high 16-bit halfword (h1) of `rs1` by the high 16-bit
+halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
 
 ==== MULSU.H00 (RV32)
 
@@ -8858,15 +8954,121 @@ writes the 32-bit product to `rd`.
 
 ==== PMUL.W.H00
 
-TODO: Add missing PMUL.W.H00
+===== Encoding
+
+PMUL.W.H00 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PMUL.W.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = signed(s1[15:0])  * signed(s2[15:0])
+d_w1 = signed(s1[47:32]) * signed(s2[47:32])
+X[rd] = d_w1 @ d_w0
+----
+
+===== Description
+
+PMUL.W.H00 multiplies the low halfword (h0) of each packed 32-bit word element
+in `rs1` by the low halfword (h0) of the corresponding word element in `rs2`,
+both treated as signed, producing a 32-bit product per element that is written
+to the corresponding word of `rd`. This instruction is available only on RV64.
 
 ==== PMUL.W.H01
 
-TODO: Add missing PMUL.W.H01
+===== Encoding
+
+PMUL.W.H01 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PMUL.W.H01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = signed(s1[15:0])  * signed(s2[31:16])
+d_w1 = signed(s1[47:32]) * signed(s2[63:48])
+X[rd] = d_w1 @ d_w0
+----
+
+===== Description
+
+PMUL.W.H01 multiplies the low halfword (h0) of each packed 32-bit word element
+in `rs1` by the high halfword (h1) of the corresponding word element in `rs2`,
+both treated as signed, producing a 32-bit product per element that is written
+to the corresponding word of `rd`. This instruction is available only on RV64.
 
 ==== PMUL.W.H11
 
-TODO: Add missing PMUL.W.H11
+===== Encoding
+
+PMUL.W.H11 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PMUL.W.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = signed(s1[31:16]) * signed(s2[31:16])
+d_w1 = signed(s1[63:48]) * signed(s2[63:48])
+X[rd] = d_w1 @ d_w0
+----
+
+===== Description
+
+PMUL.W.H11 multiplies the high halfword (h1) of each packed 32-bit word
+element in `rs1` by the high halfword (h1) of the corresponding word element in
+`rs2`, both treated as signed, producing a 32-bit product per element that is
+written to the corresponding word of `rd`. This instruction is available only
+on RV64.
 
 ==== PMULSU.W.H00 (RV64)
 
@@ -9025,15 +9227,111 @@ as unsigned values and writes packed 32-bit products to `rd`.
 
 ==== MUL.W00
 
-TODO: Add missing MUL.W00
+===== Encoding
+
+MUL.W00 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['MUL.W00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1_w0 = X[rs1][31:0]
+s2_w0 = X[rs2][31:0]
+X[rd] = signed(s1_w0) * signed(s2_w0)
+----
+
+===== Description
+
+MUL.W00 multiplies the low 32-bit word (w0) of `rs1` by the low 32-bit word
+(w0) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
 
 ==== MUL.W01
 
-TODO: Add missing MUL.W01
+===== Encoding
+
+MUL.W01 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x2, attr: ['MUL.W01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1_w0 = X[rs1][31:0]
+s2_w1 = X[rs2][63:32]
+X[rd] = signed(s1_w0) * signed(s2_w1)
+----
+
+===== Description
+
+MUL.W01 multiplies the low 32-bit word (w0) of `rs1` by the high 32-bit word
+(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
 
 ==== MUL.W11
 
-TODO: Add missing MUL.W11
+===== Encoding
+
+MUL.W11 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x2, attr: ['MUL.W11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1_w1 = X[rs1][63:32]
+s2_w1 = X[rs2][63:32]
+X[rd] = signed(s1_w1) * signed(s2_w1)
+----
+
+===== Description
+
+MUL.W11 multiplies the high 32-bit word (w1) of `rs1` by the high 32-bit word
+(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
 
 ==== MULSU.W00 (RV64)
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 9 Cross-element Multiply instructions

## Instructions
- MUL.H00
- MUL.H01
- MUL.H11
- PMUL.W.H00
- PMUL.W.H01
- PMUL.W.H11
- MUL.W00
- MUL.W01
- MUL.W11
