### PR TITLE
P-ext: add Mixed-width Multiply-High instruction definitions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -11290,11 +11290,75 @@ the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
 
 ==== MULH.H0
 
-TODO: Add missing MULH.H0
+===== Encoding
+
+MULH.H0 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using a halfword.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['MULH.H0'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV32
+s2_h0 = X[rs2][15:0]
+X[rd] = (signed(X[rs1]) * signed(s2_h0))[47:16]
+----
+
+===== Description
+
+MULH.H0 multiplies the full signed XLEN-bit value of `rs1` by the low 16-bit
+halfword (h0) of `rs2` treated as signed, producing a (XLEN+16)-bit
+intermediate product, and writes bits [47:16] to `rd`, effectively providing
+the upper XLEN bits of the product after discarding the low 16 bits.
 
 ==== MULH.H1
 
-TODO: Add missing MULH.H1
+===== Encoding
+
+MULH.H1 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using a halfword.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['MULH.H1'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV32
+s2_h1 = X[rs2][31:16]
+X[rd] = (signed(X[rs1]) * signed(s2_h1))[47:16]
+----
+
+===== Description
+
+MULH.H1 multiplies the full signed XLEN-bit value of `rs1` by the high 16-bit
+halfword (h1) of `rs2` treated as signed, producing a (XLEN+16)-bit
+intermediate product, and writes bits [47:16] to `rd`, effectively providing
+the upper XLEN bits of the product after discarding the low 16 bits.
 
 ==== MULHSU.H0 (RV32)
 
@@ -11490,11 +11554,83 @@ accumulates the extracted value into `rd`.
 
 ==== PMULH.W.H0
 
-TODO: Add missing PMULH.W.H0
+===== Encoding
+
+PMULH.W.H0 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['PMULH.W.H0'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = (signed(s1[31:0])  * signed(s2[15:0]) )[47:16]
+d_w1 = (signed(s1[63:32]) * signed(s2[47:32]))[47:16]
+X[rd] = d_w1 @ d_w0
+----
+
+===== Description
+
+PMULH.W.H0 multiplies each signed packed 32-bit word element of `rs1` by the
+low halfword (h0) of the corresponding word element of `rs2` treated as signed,
+producing a 48-bit intermediate product per element, and writes bits [47:16] of
+each product to the corresponding word of `rd`. This instruction is available
+only on RV64.
 
 ==== PMULH.W.H1
 
-TODO: Add missing PMULH.W.H1
+===== Encoding
+
+PMULH.W.H1 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PMULH.W.H1'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+===== Operation
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = (signed(s1[31:0])  * signed(s2[31:16]))[47:16]
+d_w1 = (signed(s1[63:32]) * signed(s2[63:48]))[47:16]
+X[rd] = d_w1 @ d_w0
+----
+
+===== Description
+
+PMULH.W.H1 multiplies each signed packed 32-bit word element of `rs1` by the
+high halfword (h1) of the corresponding word element of `rs2` treated as
+signed, producing a 48-bit intermediate product per element, and writes bits
+[47:16] of each product to the corresponding word of `rd`. This instruction is
+available only on RV64.
 
 ==== PMULHSU.W.H0 (RV64)
 


### PR DESCRIPTION
## Summary
- Add encoding, operation, and description for 4 Mixed-width Multiply-High instructions

## Instructions
- MULH.H0
- MULH.H1
- PMULH.W.H0
- PMULH.W.H1
