### PR TITLE
Add Mnemonic section to instructions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -763,6 +763,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pli.b _rd_, _imm8_
+
 ===== Description
 
 PLI.B (Packed Load Immediate, Byte) loads an 8-bit immediate into every
@@ -798,6 +802,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pli.h _rd_, _simm10_
 
 ===== Description
 
@@ -835,6 +843,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pli.w _rd_, _simm10_
+
 ===== Description
 
 PLI.W (Packed Load Immediate, Word) sign-extends a 10-bit signed immediate
@@ -871,6 +883,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+plui.h _rd_, _simm10_
 
 ===== Description
 
@@ -910,6 +926,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+plui.w _rd_, _simm10_
 
 ===== Description
 
@@ -951,6 +971,10 @@ if (rd_p != 0):
     X[2*rd_p] = d_lo
     X[2*rd_p+1] = d_hi
 ----
+
+===== Mnemonic
+
+pli.db _rd_p_, _imm8_
 
 ===== Description
 
@@ -995,6 +1019,10 @@ if (rd_p != 0):
     X[2*rd_p] = d_lo
     X[2*rd_p+1] = d_hi
 ----
+
+===== Mnemonic
+
+pli.dh _rd_p_, _simm10_
 
 ===== Description
 
@@ -1042,6 +1070,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+plui.dh _rd_p_, _simm10_
+
 ===== Description
 
 PLUI.DH (Packed Load Upper Immediate, Double-wide Halfword) loads a 10-bit
@@ -1088,6 +1120,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+padd.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PADD.B adds corresponding packed 8-bit elements of `rs1` and `rs2` and writes
@@ -1128,6 +1164,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+padd.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PADD.H adds corresponding packed 16-bit halfword elements of `rs1` and `rs2`
@@ -1166,6 +1206,10 @@ d[63:32] = s1[63:32] + s2[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+padd.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -1208,6 +1252,10 @@ for i = 0 .. (XLEN/8 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+padd.bs _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -1255,6 +1303,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+padd.hs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PADD.HS instruction adds the least-significant halfword of `rs2` to each
@@ -1293,6 +1345,10 @@ d[63:32] = s1[63:32] + s2_w0
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+padd.ws _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -1345,6 +1401,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+padd.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -1400,6 +1460,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+padd.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PADD.DH performs packed 16-bit halfword addition on double-wide (register-pair)
@@ -1446,6 +1510,10 @@ d_hi = s1_hi + s2_hi
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+padd.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -1497,6 +1565,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+padd.dbs _rd_p_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -1550,6 +1622,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+padd.dhs _rd_p_, _rs1_p_, _rs2_
+
 ===== Description
 
 PADD.DHS adds the least-significant halfword of `rs2` to each packed 16-bit
@@ -1596,6 +1672,10 @@ d_hi = s1_hi + s2_w0
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+padd.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -1644,6 +1724,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psub.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSUB.B subtracts corresponding packed 8-bit elements of `rs2` from `rs1` and
@@ -1685,6 +1769,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psub.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSUB.H subtracts corresponding packed 16-bit halfword elements of `rs2` from
@@ -1723,6 +1811,10 @@ d[63:32] = s1[63:32] - s2[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psub.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -1775,6 +1867,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psub.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -1830,6 +1926,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psub.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSUB.DH performs packed 16-bit halfword subtraction on double-wide
@@ -1876,6 +1976,10 @@ d_hi = s1_hi - s2_hi
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psub.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -1929,6 +2033,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psadd.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSADD.B performs signed saturating addition on packed 8-bit byte elements of
@@ -1975,6 +2083,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psadd.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -2026,6 +2138,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psadd.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSADD.W performs signed saturating addition on packed 32-bit word elements of
@@ -2072,6 +2188,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psaddu.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSADDU.B performs unsigned saturating addition on packed 8-bit byte elements of
@@ -2116,6 +2236,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psaddu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -2165,6 +2289,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psaddu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSADDU.W performs unsigned saturating addition on packed 32-bit word elements of
@@ -2212,6 +2340,10 @@ else:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+sadd _rd_, _rs1_, _rs2_
+
 ===== Description
 
 SADD performs signed saturating addition of the full XLEN-wide values in `rs1`
@@ -2256,6 +2388,10 @@ else:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+saddu _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -2320,6 +2456,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psadd.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -2388,6 +2528,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psadd.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSADD.DH performs signed saturating addition on packed 16-bit halfword elements
@@ -2453,6 +2597,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psadd.dw _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSADD.DW performs signed saturating 32-bit word addition on double-wide
@@ -2515,6 +2663,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psaddu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -2580,6 +2732,10 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+psaddu.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSADDU.DH (Packed Saturating Add Unsigned, Double-wide Halfword) performs
@@ -2632,6 +2788,10 @@ if res_hi > 2^32 - 1:
 X[2*rd_p+1] = res_hi[31:0]
 ----
 
+===== Mnemonic
+
+psaddu.dw _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSADDU.DW (Packed Saturating Add Unsigned, Double-wide Word) performs unsigned
@@ -2683,6 +2843,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pssub.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSSUB.B performs signed saturating subtraction on corresponding packed 8-bit
@@ -2728,6 +2892,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pssub.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -2785,6 +2953,10 @@ d[63:32] = res_hi[31:0]
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pssub.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSSUB.W performs signed saturating subtraction on corresponding packed 32-bit
@@ -2829,6 +3001,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pssubu.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSSUBU.B performs unsigned saturating subtraction on corresponding packed
@@ -2872,6 +3048,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pssubu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -2925,6 +3105,10 @@ d[63:32] = res_hi[31:0]
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pssubu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSSUBU.W performs unsigned saturating subtraction on corresponding packed
@@ -2968,6 +3152,10 @@ else if res < -(2^(XLEN-1)):
 X[rd] = res[XLEN-1:0]
 ----
 
+===== Mnemonic
+
+ssub _rd_, _rs1_, _rs2_
+
 ===== Description
 
 SSUB performs signed saturating subtraction of `rs2` from `rs1`, writing the
@@ -3009,6 +3197,10 @@ if res < 0:
 
 X[rd] = res[XLEN-1:0]
 ----
+
+===== Mnemonic
+
+ssubu _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -3075,6 +3267,10 @@ for i = 0 .. 3:
 X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
+
+===== Mnemonic
+
+pssub.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -3143,6 +3339,10 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+pssub.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSSUB.DH (Packed Signed Saturating Subtract, Double-wide Halfword) performs
@@ -3198,6 +3398,10 @@ else if res_hi < -(2^31):
     res_hi = -(2^31)
 X[2*rd_p+1] = res_hi[31:0]
 ----
+
+===== Mnemonic
+
+pssub.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -3262,6 +3466,10 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+pssubu.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSSUBU.DB (Packed Unsigned Saturating Subtract, Double-wide Byte) performs
@@ -3325,6 +3533,10 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+pssubu.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSSUBU.DH (Packed Unsigned Saturating Subtract, Double-wide Halfword) performs
@@ -3377,6 +3589,10 @@ if res_hi < 0:
 X[2*rd_p+1] = res_hi[31:0]
 ----
 
+===== Mnemonic
+
+pssubu.dw _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSSUBU.DW (Packed Unsigned Saturating Subtract, Double-wide Word) performs
@@ -3424,6 +3640,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+paadd.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PAADD.B performs a signed averaging addition on packed 8-bit elements. For each
@@ -3466,6 +3686,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+paadd.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -3515,6 +3739,10 @@ d[63:32] = to_bits(32, sum_hi >> 1)
 X[rd] = d
 ----
 
+===== Mnemonic
+
+paadd.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PAADD.W performs a signed averaging addition on packed 32-bit word elements.
@@ -3559,6 +3787,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+paaddu.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PAADDU.B performs an unsigned averaging addition on packed 8-bit elements. For
@@ -3601,6 +3833,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+paaddu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -3650,6 +3886,10 @@ d[63:32] = to_bits(32, sum_hi >> 1)
 X[rd] = d
 ----
 
+===== Mnemonic
+
+paaddu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PAADDU.W performs an unsigned averaging addition on packed 32-bit word elements.
@@ -3688,6 +3928,10 @@ sum = s1 + s2
 X[rd] = to_bits(32, sum >> 1)
 ----
 
+===== Mnemonic
+
+aadd _rd_, _rs1_, _rs2_
+
 ===== Description
 
 AADD performs a signed averaging addition on a single XLEN-wide value. It adds
@@ -3725,6 +3969,10 @@ s2 = unsigned(X[rs2])
 sum = s1 + s2
 X[rd] = to_bits(32, sum >> 1)
 ----
+
+===== Mnemonic
+
+aaddu _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -3782,6 +4030,10 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+paadd.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PAADD.DB (Packed Averaging Add, Double-wide Byte) performs a signed averaging
@@ -3838,6 +4090,10 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+paadd.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PAADD.DH (Packed Averaging Add, Double-wide Halfword) performs a signed
@@ -3888,6 +4144,10 @@ d_hi = to_bits(32, sum_hi >> 1)
 X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
+
+===== Mnemonic
+
+paadd.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -3944,6 +4204,10 @@ for i = 0 .. 3:
 X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
+
+===== Mnemonic
+
+paaddu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -4002,6 +4266,10 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+paaddu.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PAADDU.DH (Packed Averaging Add Unsigned, Double-wide Halfword) performs an
@@ -4053,6 +4321,10 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
+===== Mnemonic
+
+paaddu.dw _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PAADDU.DW (Packed Averaging Add Unsigned, Double-wide Word) performs an unsigned
@@ -4099,6 +4371,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pasub.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PASUB.B performs a signed averaging subtraction on packed 8-bit elements. For
@@ -4142,6 +4418,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pasub.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -4192,6 +4472,10 @@ d[63:32] = to_bits(32, diff_hi >> 1)
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pasub.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PASUB.W performs a signed averaging subtraction on packed 32-bit word elements.
@@ -4236,6 +4520,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pasubu.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PASUBU.B performs an unsigned averaging subtraction on packed 8-bit elements.
@@ -4278,6 +4566,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pasubu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -4328,6 +4620,10 @@ d[63:32] = to_bits(32, diff_hi >> 1)
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pasubu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PASUBU.W performs an unsigned averaging subtraction on packed 32-bit word
@@ -4367,6 +4663,10 @@ diff = s1 - s2
 X[rd] = to_bits(32, diff >> 1)
 ----
 
+===== Mnemonic
+
+asub _rd_, _rs1_, _rs2_
+
 ===== Description
 
 ASUB performs a signed averaging subtraction on a single XLEN-wide value. It
@@ -4404,6 +4704,10 @@ s2 = unsigned(X[rs2])
 diff = s1 - s2
 X[rd] = to_bits(32, diff >> 1)
 ----
+
+===== Mnemonic
+
+asubu _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -4459,6 +4763,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pasub.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -4516,6 +4824,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pasub.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PASUB.DH (Packed Averaging Subtract, Double-wide Halfword) performs a signed
@@ -4565,6 +4877,10 @@ d_hi = to_bits(32, diff_hi >> 1)
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pasub.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -4622,6 +4938,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pasubu.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PASUBU.DB (Packed Averaging Subtract Unsigned, Double-wide Byte) performs an
@@ -4678,6 +4998,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pasubu.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PASUBU.DH (Packed Averaging Subtract Unsigned, Double-wide Halfword) performs
@@ -4728,6 +5052,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pasubu.dw _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PASUBU.DW (Packed Averaging Subtract Unsigned, Double-wide Word) performs an
@@ -4774,6 +5102,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psh1add.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PSH1ADD.H instruction computes, for each packed 16-bit element,
@@ -4812,6 +5144,10 @@ d[63:32] = (s1[63:32] << 1) + s2[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psh1add.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -4872,6 +5208,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pssh1sadd.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -4939,6 +5279,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pssh1sadd.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PSSH1SADD.W instruction performs a signed saturating left shift by 1 on each
@@ -4990,6 +5334,10 @@ else if s > 2^31-1:
 else
     X[rd] = to_bits(32, s)
 ----
+
+===== Mnemonic
+
+ssh1sadd _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -5043,6 +5391,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psh1add.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSH1ADD.DH (Packed Shift-left-by-1 and Add, Double-wide Halfword) performs a
@@ -5090,6 +5442,10 @@ d_hi = (s1_hi << 1) + s2_hi
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psh1add.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -5164,6 +5520,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pssh1sadd.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSSH1SADD.DH (Packed Saturating Shift-left-by-1 Saturating Add, Double-wide
@@ -5233,6 +5593,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pssh1sadd.dw _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSSH1SADD.DW (Packed Saturating Shift-left-by-1 Saturating Add, Double-wide
@@ -5289,6 +5653,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pas.hx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PAS.HX (Packed Add-Subtract Cross, Halfword) performs a cross add-subtract on
@@ -5336,6 +5704,10 @@ d[63:32] = a_odd - b_odd
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pas.wx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -5387,6 +5759,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psa.hx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSA.HX (Packed Subtract-Add Cross, Halfword) performs a cross subtract-add on
@@ -5434,6 +5810,10 @@ d[63:32] = a_odd + b_odd
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psa.wx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -5495,6 +5875,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psas.hx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSAS.HX (Packed Saturating Add-Subtract Cross, Halfword) performs a cross
@@ -5553,6 +5937,10 @@ d[63:32] = res_odd[31:0]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psas.wx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -5615,6 +6003,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pssa.hx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSSA.HX (Packed Saturating Subtract-Add Cross, Halfword) performs a cross
@@ -5674,6 +6066,10 @@ d[63:32] = res_odd[31:0]
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pssa.wx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PSSA.WX (Packed Saturating Subtract-Add Cross, Word) performs a cross saturating
@@ -5725,6 +6121,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+paas.hx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -5780,6 +6180,10 @@ d[31:0] = to_bits(32, diff >> 1)
 X[rd] = d
 ----
 
+===== Mnemonic
+
+paas.wx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PAAS.WX (Packed Averaging Add-Subtract, Cross Word) performs a signed averaging
@@ -5832,6 +6236,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pasa.hx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -5887,6 +6295,10 @@ d[31:0] = to_bits(32, sum >> 1)
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pasa.wx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PASA.WX (Packed Averaging Subtract-Add, Cross Word) performs a signed averaging
@@ -5941,6 +6353,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pas.dhx _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PAS.DHX (Packed Add-Subtract, Double-wide Cross Halfword) performs packed
@@ -5994,6 +6410,10 @@ d_hi[15:0]  = s1_hi[15:0]  + s2_hi[31:16]
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -6062,6 +6482,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psas.dhx _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PSAS.DHX (Packed Saturating Add-Subtract, Double-wide Cross Halfword) performs
@@ -6127,6 +6551,10 @@ d_hi[15:0] = SAT16(sum)
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pssa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -6194,6 +6622,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+paas.dhx _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PAAS.DHX (Packed Averaging Add-Subtract, Double-wide Cross Halfword) performs
@@ -6260,6 +6692,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pasa.dhx _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PASA.DHX (Packed Averaging Subtract-Add, Double-wide Cross Halfword) performs
@@ -6307,6 +6743,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pabd.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PABD.B instruction computes the absolute difference of corresponding packed
@@ -6352,6 +6792,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pabd.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PABD.H instruction computes the absolute difference of corresponding packed
@@ -6392,6 +6836,10 @@ for i = 0 .. (XLEN/8 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pabdu.b _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -6438,6 +6886,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pabdu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PABDU.H instruction computes the absolute difference of corresponding packed
@@ -6481,6 +6933,10 @@ for i = 0 .. (XLEN/8 - 1):
 
 X[rd] = to_bits(XLEN, sum)
 ----
+
+===== Mnemonic
+
+pabdsumu.b _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -6527,6 +6983,10 @@ for i = 0 .. (XLEN/8 - 1):
 
 X[rd] = to_bits(XLEN, sum)
 ----
+
+===== Mnemonic
+
+pabdsumau.b _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -6585,6 +7045,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pabd.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PABD.DB (Packed Absolute Difference, Double-wide Byte) computes the signed
@@ -6640,6 +7104,10 @@ for i = 0 .. 1:
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pabd.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -6697,6 +7165,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pabdu.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PABDU.DB (Packed Absolute Difference Unsigned, Double-wide Byte) computes the
@@ -6753,6 +7225,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pabdu.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PABDU.DH (Packed Absolute Difference Unsigned, Double-wide Halfword) computes
@@ -6804,6 +7280,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psabs.b _rd_, _rs1_
+
 ===== Description
 
 PSABS.B (Packed Saturating Absolute Value, Byte) computes the saturating
@@ -6850,6 +7330,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psabs.h _rd_, _rs1_, _uimm1_
 
 ===== Description
 
@@ -6911,6 +7395,10 @@ for i = 0 .. 3:
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psabs.db _rd_p_, _rs1_p_
 
 ===== Description
 
@@ -6974,6 +7462,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psabs.dh _rd_p_, _rs1_p_, _uimm1_
+
 ===== Description
 
 PSABS.DH (Packed Saturating Absolute Value, Double-wide Halfword) computes the
@@ -7021,6 +7513,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = sum
 ----
 
+===== Mnemonic
+
+predsum.bs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PREDSUM.BS instruction computes a signed reduction sum of packed 8-bit
@@ -7062,6 +7558,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = sum
 ----
 
+===== Mnemonic
+
+predsum.hs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PREDSUM.HS instruction computes a signed reduction sum of packed 16-bit
@@ -7097,6 +7597,10 @@ X[rd] = X[rs2]
         + sign_extend(64, s1[31:0])
         + sign_extend(64, s1[63:32])
 ----
+
+===== Mnemonic
+
+predsum.ws _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -7139,6 +7643,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = sum
 ----
 
+===== Mnemonic
+
+predsumu.bs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PREDSUMU.BS instruction computes an unsigned reduction sum of packed 8-bit
@@ -7180,6 +7688,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = sum
 ----
 
+===== Mnemonic
+
+predsumu.hs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PREDSUMU.HS instruction computes an unsigned reduction sum of packed 16-bit
@@ -7215,6 +7727,10 @@ X[rd] = X[rs2]
         + zero_extend(64, s1[31:0])
         + zero_extend(64, s1[63:32])
 ----
+
+===== Mnemonic
+
+predsumu.ws _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -7260,6 +7776,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmin.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMIN.B computes the signed minimum of corresponding packed 8-bit byte elements
@@ -7300,6 +7820,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmin.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMIN.H computes the signed minimum of corresponding packed 16-bit halfword
@@ -7337,6 +7861,10 @@ d[63:32] = (signed(s1[63:32]) < signed(s2[63:32])) ? s1[63:32] : s2[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmin.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -7379,6 +7907,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pminu.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMINU.B computes the unsigned minimum of corresponding packed 8-bit byte
@@ -7419,6 +7951,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pminu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMINU.H computes the unsigned minimum of corresponding packed 16-bit halfword
@@ -7456,6 +7992,10 @@ d[63:32] = (unsigned(s1[63:32]) < unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pminu.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -7498,6 +8038,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmax.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMAX.B computes the signed maximum of corresponding packed 8-bit byte elements
@@ -7538,6 +8082,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmax.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMAX.H computes the signed maximum of corresponding packed 16-bit halfword
@@ -7575,6 +8123,10 @@ d[63:32] = (signed(s1[63:32]) > signed(s2[63:32])) ? s1[63:32] : s2[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmax.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -7617,6 +8169,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmaxu.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMAXU.B computes the unsigned maximum of corresponding packed 8-bit byte
@@ -7657,6 +8213,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmaxu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMAXU.H computes the unsigned maximum of corresponding packed 16-bit halfword
@@ -7694,6 +8254,10 @@ d[63:32] = (unsigned(s1[63:32]) > unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmaxu.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -7746,6 +8310,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pmin.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -7801,6 +8369,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmin.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMIN.DH performs packed signed 16-bit halfword minimum on double-wide
@@ -7847,6 +8419,10 @@ d_hi = (signed(s1_hi) < signed(s2_hi)) ? s1_hi : s2_hi
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pmin.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -7902,6 +8478,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pminu.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMINU.DB performs packed unsigned 8-bit byte minimum on double-wide
@@ -7956,6 +8536,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pminu.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMINU.DH performs packed unsigned 16-bit halfword minimum on double-wide
@@ -8002,6 +8586,10 @@ d_hi = (unsigned(s1_hi) < unsigned(s2_hi)) ? s1_hi : s2_hi
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pminu.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -8057,6 +8645,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmax.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMAX.DB performs packed signed 8-bit byte maximum on double-wide (register-pair)
@@ -8111,6 +8703,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmax.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMAX.DH performs packed signed 16-bit halfword maximum on double-wide
@@ -8157,6 +8753,10 @@ d_hi = (signed(s1_hi) > signed(s2_hi)) ? s1_hi : s2_hi
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pmax.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -8212,6 +8812,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmaxu.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMAXU.DB performs packed unsigned 8-bit byte maximum on double-wide
@@ -8266,6 +8870,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmaxu.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMAXU.DH performs packed unsigned 16-bit halfword maximum on double-wide
@@ -8313,6 +8921,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmaxu.dw _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMAXU.DW performs unsigned 32-bit word maximum on double-wide (register-pair)
@@ -8358,6 +8970,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmseq.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMSEQ.B (Packed Mask Set-if-Equal, Byte) compares corresponding packed 8-bit
@@ -8400,6 +9016,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmseq.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMSEQ.H (Packed Mask Set-if-Equal, Halfword) compares corresponding packed
@@ -8437,6 +9057,10 @@ d0 = (s1[31:0]  == s2[31:0])  ? 0xFFFFFFFF : 0x00000000
 d1 = (s1[63:32] == s2[63:32]) ? 0xFFFFFFFF : 0x00000000
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmseq.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -8477,6 +9101,10 @@ for i = 0 .. (XLEN/8 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmslt.b _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -8520,6 +9148,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmslt.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMSLT.H performs a signed less-than comparison on corresponding packed 16-bit
@@ -8557,6 +9189,10 @@ d0 = (s1[31:0]  <_s s2[31:0])  ? 0xFFFFFFFF : 0x00000000
 d1 = (s1[63:32] <_s s2[63:32]) ? 0xFFFFFFFF : 0x00000000
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmslt.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -8597,6 +9233,10 @@ for i = 0 .. (XLEN/8 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmsltu.b _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -8640,6 +9280,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmsltu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMSLTU.H performs an unsigned less-than comparison on corresponding packed 16-bit
@@ -8678,6 +9322,10 @@ d1 = (s1[63:32] <_u s2[63:32]) ? 0xFFFFFFFF : 0x00000000
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmsltu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMSLTU.W instruction performs unsigned less-than comparisons on corresponding
@@ -8709,6 +9357,10 @@ MSEQ is available only in RV32.
 ----
 X[rd] = (X[rs1] == X[rs2]) ? 0xFFFFFFFF : 0x00000000
 ----
+
+===== Mnemonic
+
+mseq _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -8742,6 +9394,10 @@ MSLT is available only in RV32.
 X[rd] = (X[rs1] <_s X[rs2]) ? 0xFFFFFFFF : 0x00000000
 ----
 
+===== Mnemonic
+
+mslt _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MSLT instruction sets `rd` to all ones if `rs1` is less than `rs2` using
@@ -8773,6 +9429,10 @@ MSLTU is available only in RV32.
 ----
 X[rd] = (X[rs1] <_u X[rs2]) ? 0xFFFFFFFF : 0x00000000
 ----
+
+===== Mnemonic
+
+msltu _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -8825,6 +9485,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pmseq.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -8881,6 +9545,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmseq.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMSEQ.DH performs packed 16-bit halfword mask-equality comparison on double-wide
@@ -8928,6 +9596,10 @@ d_hi = (s1_hi == s2_hi) ? 0xFFFFFFFF : 0x00000000
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pmseq.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -8983,6 +9655,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pmslt.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -9040,6 +9716,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmslt.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMSLT.DH performs packed 16-bit halfword signed less-than mask comparison on
@@ -9088,6 +9768,10 @@ d_hi = (signed(s1_hi) < signed(s2_hi)) ? 0xFFFFFFFF : 0x00000000
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pmslt.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -9145,6 +9829,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmsltu.db _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMSLTU.DB performs packed 8-bit byte unsigned less-than mask comparison on
@@ -9201,6 +9889,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmsltu.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMSLTU.DH performs packed 16-bit halfword unsigned less-than mask comparison on
@@ -9250,6 +9942,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pmsltu.dw _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PMSLTU.DW performs 32-bit word unsigned less-than mask comparison on double-wide
@@ -9296,6 +9992,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psext.h.b _rd_, _rs1_, _uimm1_
+
 ===== Description
 
 PSEXT.H.B sign-extends packed 8-bit byte elements from the lower byte of each
@@ -9330,6 +10030,10 @@ s1 = X[rs1]
 X[rd] = sign_extend(32, s1[39:32]) @ sign_extend(32, s1[7:0])
 ----
 
+===== Mnemonic
+
+psext.w.b _rd_, _rs1_
+
 ===== Description
 
 The PSEXT.W.B instruction extracts byte elements from `rs1`, sign-extends them
@@ -9361,6 +10065,10 @@ PSEXT.W.H is available only in RV64.
 s1 = X[rs1]
 X[rd] = sign_extend(32, s1[47:32]) @ sign_extend(32, s1[15:0])
 ----
+
+===== Mnemonic
+
+psext.w.h _rd_, _rs1_
 
 ===== Description
 
@@ -9409,6 +10117,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psext.dh.b _rd_p_, _rs1_p_, _uimm1_
+
 ===== Description
 
 PSEXT.DH.B performs packed sign-extension of bytes to halfwords on double-wide
@@ -9453,6 +10165,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psext.dw.b _rd_p_, _rs1_p_, _uimm1_
+
 ===== Description
 
 PSEXT.DW.B performs sign-extension of bytes to words on double-wide
@@ -9496,6 +10212,10 @@ d_hi = sign_extend(XLEN, s1_hi[15:0])
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psext.dw.h _rd_p_, _rs1_p_, _uimm1_
 
 ===== Description
 
@@ -9551,6 +10271,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psati.h _rd_, _rs1_, _uimm1_
+
 ===== Description
 
 PSATI.H saturates each packed 16-bit halfword element of `rs1` to the signed
@@ -9603,6 +10327,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psati.w _rd_, _rs1_, _uimm1_
+
 ===== Description
 
 PSATI.W saturates each packed 32-bit word element of `rs1` to the signed range
@@ -9653,6 +10381,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pusati.h _rd_, _rs1_, _uimm1_
 
 ===== Description
 
@@ -9705,6 +10437,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pusati.w _rd_, _rs1_, _uimm1_
+
 ===== Description
 
 PUSATI.W performs unsigned saturation on each packed 32-bit word element of `rs1`
@@ -9753,6 +10489,10 @@ else:
     X[rd] = s1
 ----
 
+===== Mnemonic
+
+sati _rd_, _rs1_, _uimm1_
+
 ===== Description
 
 The SATI instruction saturates `rs1` to a signed range determined by the
@@ -9800,6 +10540,10 @@ else if (s1 >_s maxval):
 else:
     X[rd] = s1
 ----
+
+===== Mnemonic
+
+usati _rd_, _rs1_, _uimm1_
 
 ===== Description
 
@@ -9868,6 +10612,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psati.dh _rd_p_, _rs1_p_, _uimm1_
+
 ===== Description
 
 PSATI.DH performs packed 16-bit halfword signed saturation on double-wide
@@ -9928,6 +10676,10 @@ else:
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psati.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Description
 
@@ -9993,6 +10745,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pusati.dh _rd_p_, _rs1_p_, _uimm4_
+
 ===== Description
 
 PUSATI.DH performs unsigned saturation on each packed 16-bit element across a
@@ -10053,6 +10809,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pusati.dw _rd_p_, _rs1_p_, _uimm5_
+
 ===== Description
 
 PUSATI.DW performs unsigned saturation on each 32-bit element across a
@@ -10098,6 +10858,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psll.bs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PSLL.BS instruction shifts each packed 8-bit element of `rs1` left by the
@@ -10135,6 +10899,10 @@ for i = 0 .. (XLEN/16 - 1):
     d[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psll.hs _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -10174,6 +10942,10 @@ for i = 0 .. (XLEN/32 - 1):
     d[(32*i+31):(32*i)] = (zero_extend(64, w) << shamt)[31:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psll.ws _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -10215,6 +10987,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psrl.bs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PSRL.BS instruction logically shifts each packed 8-bit element of `rs1`
@@ -10252,6 +11028,10 @@ for i = 0 .. (XLEN/16 - 1):
     d[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psrl.hs _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -10291,6 +11071,10 @@ for i = 0 .. (XLEN/32 - 1):
     d[(32*i+31):(32*i)] = (zero_extend(64, w) >> shamt)[31:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psrl.ws _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -10332,6 +11116,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psra.bs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PSRA.BS instruction arithmetically shifts each packed 8-bit element of `rs1`
@@ -10369,6 +11157,10 @@ for i = 0 .. (XLEN/16 - 1):
     d[(16*i+15):(16*i)] = (sign_extend(48, h) >> shamt)[15:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psra.hs _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -10409,6 +11201,10 @@ for i = 0 .. (XLEN/32 - 1):
     d[(32*i+31):(32*i)] = (sign_extend(64, w) >> shamt)[31:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psra.ws _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -10452,6 +11248,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pslli.b _rd_, _rs1_, _uimm3_
+
 ===== Description
 
 PSLLI.B shifts each packed 8-bit element of `rs1` left by the immediate shift
@@ -10493,6 +11293,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pslli.h _rd_, _rs1_, _uimm4_
+
 ===== Description
 
 PSLLI.H shifts each packed 16-bit element of `rs1` left by the immediate shift
@@ -10533,6 +11337,10 @@ for i = 0 .. (XLEN/32 - 1):
     d[(32*i+31):(32*i)] = (zero_extend(64, w) << shamt)[31:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pslli.w _rd_, _rs1_, _uimm5_
 
 ===== Description
 
@@ -10576,6 +11384,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psrli.b _rd_, _rs1_, _uimm3_
+
 ===== Description
 
 PSRLI.B logically shifts each packed 8-bit element of `rs1` right by the
@@ -10617,6 +11429,10 @@ for i = 0 .. (XLEN/16 - 1):
     d[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psrli.h _rd_, _rs1_, _uimm4_
 
 ===== Description
 
@@ -10660,6 +11476,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psrli.w _rd_, _rs1_, _uimm5_
+
 ===== Description
 
 PSRLI.W logically shifts each packed 32-bit element of `rs1` right by the
@@ -10701,6 +11521,10 @@ for i = 0 .. (XLEN/8 - 1):
     d[(8*i+7):(8*i)] = (sign_extend(40, b) >> shamt)[7:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psrai.b _rd_, _rs1_, _uimm3_
 
 ===== Description
 
@@ -10744,6 +11568,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psrai.h _rd_, _rs1_, _uimm4_
+
 ===== Description
 
 PSRAI.H arithmetically shifts each packed 16-bit element of `rs1` right by the
@@ -10785,6 +11613,10 @@ for i = 0 .. (XLEN/32 - 1):
     d[(32*i+31):(32*i)] = (sign_extend(64, w) >> shamt)[31:0]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psrai.w _rd_, _rs1_, _uimm5_
 
 ===== Description
 
@@ -10830,6 +11662,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psrari.h _rd_, _rs1_, _uimm4_
+
 ===== Description
 
 PSRARI.H arithmetically shifts each packed 16-bit element of `rs1` right by
@@ -10873,6 +11709,10 @@ for i = 0 .. (XLEN/32 - 1):
     d[(32*i+31):(32*i)] = (shx + 1)[32:1]
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psrari.w _rd_, _rs1_, _uimm5_
 
 ===== Description
 
@@ -10924,6 +11764,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psll.dbs _rd_p_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -10978,6 +11822,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psll.dhs _rd_p_, _rs1_p_, _rs2_
+
 ===== Description
 
 PSLL.DHS shifts each packed 16-bit element left by the scalar shift amount in
@@ -11025,6 +11873,10 @@ d_hi = (zero_extend(64, s1_hi) << shamt)[31:0]
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psll.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -11079,6 +11931,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psrl.dbs _rd_p_, _rs1_p_, _rs2_
+
 ===== Description
 
 PSRL.DBS logically shifts each packed 8-bit element right by the scalar shift
@@ -11132,6 +11988,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psrl.dhs _rd_p_, _rs1_p_, _rs2_
+
 ===== Description
 
 PSRL.DHS logically shifts each packed 16-bit element right by the scalar shift
@@ -11179,6 +12039,10 @@ d_hi = s1_hi >> shamt
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psrl.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -11232,6 +12096,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psra.dbs _rd_p_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -11287,6 +12155,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psra.dhs _rd_p_, _rs1_p_, _rs2_
+
 ===== Description
 
 PSRA.DHS (Packed Shift Right Arithmetic, Double-wide Halfword, Scalar)
@@ -11335,6 +12207,10 @@ d_hi = signed(s1_hi) >> shamt
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psra.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -11388,6 +12264,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pslli.db _rd_p_, _rs1_p_, _uimm3_
+
 ===== Description
 
 PSLLI.DB (Packed Shift Left Logical Immediate, Double-wide Byte) shifts each
@@ -11439,6 +12319,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pslli.dh _rd_p_, _rs1_p_, _uimm4_
+
 ===== Description
 
 PSLLI.DH (Packed Shift Left Logical Immediate, Double-wide Halfword) shifts
@@ -11485,6 +12369,10 @@ d_hi = s1_hi << shamt
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pslli.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Description
 
@@ -11536,6 +12424,10 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psrli.db _rd_p_, _rs1_p_, _uimm3_
 
 ===== Description
 
@@ -11589,6 +12481,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psrli.dh _rd_p_, _rs1_p_, _uimm4_
+
 ===== Description
 
 PSRLI.DH (Packed Shift Right Logical Immediate, Double-wide Halfword) shifts
@@ -11635,6 +12531,10 @@ d_hi = s1_hi >> shamt
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psrli.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Description
 
@@ -11688,6 +12588,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psrai.db _rd_p_, _rs1_p_, _uimm3_
+
 ===== Description
 
 PSRAI.DB (Packed Shift Right Arithmetic Immediate, Double-wide Byte) performs
@@ -11740,6 +12644,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psrai.dh _rd_p_, _rs1_p_, _uimm4_
+
 ===== Description
 
 PSRAI.DH (Packed Shift Right Arithmetic Immediate, Double-wide Halfword)
@@ -11786,6 +12694,10 @@ d_hi = signed(s1_hi) >> shamt
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psrai.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Description
 
@@ -11847,6 +12759,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psrari.dh _rd_p_, _rs1_p_, _uimm4_
+
 ===== Description
 
 PSRARI.DH (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
@@ -11902,6 +12818,10 @@ else:
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+psrari.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Description
 
@@ -11976,6 +12896,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pssha.hs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PSSHA.HS instruction performs a signed variable shift on each packed 16-bit
@@ -12009,6 +12933,10 @@ PSSHA.WS is available only in RV64.
 
 ===== Operation
 // (use your Sail-derived pseudocode as previously, unchanged)
+
+===== Mnemonic
+
+pssha.ws _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -12073,6 +13001,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+psshar.hs _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PSSHAR.HS instruction performs a signed variable shift on each packed 16-bit
@@ -12106,6 +13038,10 @@ PSSHAR.WS is available only in RV64.
 
 ===== Operation
 // (use your Sail-derived pseudocode as previously, unchanged)
+
+===== Mnemonic
+
+psshar.ws _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -12155,6 +13091,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psslai.h _rd_, _rs1_, _uimm4_
 
 ===== Description
 
@@ -12206,6 +13146,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+psslai.w _rd_, _rs1_, _uimm5_
 
 ===== Description
 
@@ -12264,6 +13208,10 @@ else:
         X[rd] = shx[31:0]
 ----
 
+===== Mnemonic
+
+ssha _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The SSHA instruction performs a signed variable shift of `rs1` using the signed
@@ -12319,6 +13267,10 @@ else:
         X[rd] = shx[31:0]
 ----
 
+===== Mnemonic
+
+sshar _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The SSHAR instruction performs a signed variable shift of `rs1` using the signed
@@ -12371,6 +13323,10 @@ else:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+sslai _rd_, _rs1_, _uimm5_
 
 ===== Description
 
@@ -12440,6 +13396,10 @@ else:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+srari _rd_, _rs1_, _uimm5_
+
 ===== Description
 
 SRARI arithmetically shifts the XLEN-wide value in `rs1` right by the
@@ -12490,6 +13450,10 @@ else:
         X[rd] = s1 << shamt[5:0]
 ----
 
+===== Mnemonic
+
+sha _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The SHA instruction performs a signed variable shift of `rs1` using the signed
@@ -12538,6 +13502,10 @@ else:
     else:
         X[rd] = s1 << shamt[5:0]
 ----
+
+===== Mnemonic
+
+shar _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -12609,6 +13577,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+pssha.dhs _rd_p_, _rs1_p_, _rs2_
+
 ===== Description
 
 PSSHA.DHS (Packed Saturating Shift Halfword Arithmetic, Double-wide, Scalar)
@@ -12679,6 +13651,10 @@ else:
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+pssha.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -12761,6 +13737,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psshar.dhs _rd_p_, _rs1_p_, _rs2_
+
 ===== Description
 
 PSSHAR.DHS (Packed Saturating Shift Halfword Arithmetic Rounding, Double-wide,
@@ -12838,6 +13818,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psshar.dws _rd_p_, _rs1_p_, _rs2_
+
 ===== Description
 
 PSSHAR.DWS (Packed Saturating Shift Word Arithmetic Rounding, Double-wide,
@@ -12908,6 +13892,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psslai.dh _rd_p_, _rs1_p_, _uimm4_
+
 ===== Description
 
 PSSLAI.DH performs packed 16-bit saturating shift-left arithmetic by an immediate
@@ -12971,6 +13959,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+psslai.dw _rd_p_, _rs1_p_, _uimm5_
+
 ===== Description
 
 PSSLAI.DW performs XLEN-wide saturating shift-left arithmetic by an immediate
@@ -13018,6 +14010,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+ppaire.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PPAIRE.B instruction forms packed 16-bit elements by pairing the low byte of each
@@ -13059,6 +14055,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+ppaire.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -13104,6 +14104,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+ppaireo.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PPAIREO.B instruction pairs the high byte of each halfword element of `rs2` with
@@ -13143,6 +14147,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+ppaireo.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -13185,6 +14193,10 @@ d = s2[63:32] @ s1[31:0]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+ppaireo.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -13229,6 +14241,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+ppairoe.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PPAIROE.B instruction pairs the low byte of each halfword element of `rs2` with
@@ -13268,6 +14284,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+ppairoe.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -13310,6 +14330,10 @@ d = s2[31:0] @ s1[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+ppairoe.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -13354,6 +14378,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+ppairo.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PPAIRO.B instruction pairs the high byte of each halfword element of `rs2` with
@@ -13394,6 +14422,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+ppairo.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -13436,6 +14468,10 @@ d = s2[63:32] @ s1[63:32]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+ppairo.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -13489,6 +14525,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+ppaire.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -13544,6 +14584,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+ppaire.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PPAIRE.DH performs packed halfword even-element packing on double-wide
@@ -13597,6 +14641,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+ppaireo.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -13652,6 +14700,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+ppaireo.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PPAIREO.DH performs packed halfword even-odd element packing on double-wide
@@ -13705,6 +14757,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+ppairoe.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -13760,6 +14816,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+ppairoe.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PPAIROE.DH performs packed halfword odd-even element packing on double-wide
@@ -13813,6 +14873,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
+
+===== Mnemonic
+
+ppairo.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -13868,6 +14932,10 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
+===== Mnemonic
+
+ppairo.dh _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 PPAIRO.DH performs packed halfword odd-element packing on double-wide
@@ -13911,6 +14979,10 @@ X[rd] =
   @ s2[15:8]  @ s1[15:8]  @ s2[7:0]   @ s1[7:0]
 ----
 
+===== Mnemonic
+
+zip8p _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The ZIP8P instruction interleaves bytes from `rs2` and `rs1` to form a packed 64-bit result:
@@ -13948,6 +15020,10 @@ X[rd] =
     s2[63:56] @ s1[63:56] @ s2[55:48] @ s1[55:48]
   @ s2[47:40] @ s1[47:40] @ s2[39:32] @ s1[39:32]
 ----
+
+===== Mnemonic
+
+zip8hp _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -13987,6 +15063,10 @@ X[rd] =
   @ s1[55:48] @ s1[39:32] @ s1[23:16] @ s1[7:0]
 ----
 
+===== Mnemonic
+
+unzip8p _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The UNZIP8P instruction de-interleaves bytes from `rs2` and `rs1` to form a 64-bit
@@ -14025,6 +15105,10 @@ X[rd] =
   @ s1[63:56] @ s1[47:40] @ s1[31:24] @ s1[15:8]
 ----
 
+===== Mnemonic
+
+unzip8hp _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The UNZIP8HP instruction de-interleaves bytes from `rs2` and `rs1` using the
@@ -14060,6 +15144,10 @@ s2 = X[rs2]
 
 X[rd] = s2[31:16] @ s1[31:16] @ s2[15:0] @ s1[15:0]
 ----
+
+===== Mnemonic
+
+zip16p _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -14097,6 +15185,10 @@ s2 = X[rs2]
 X[rd] = s2[63:48] @ s1[63:48] @ s2[47:32] @ s1[47:32]
 ----
 
+===== Mnemonic
+
+zip16hp _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The ZIP16HP instruction interleaves 16-bit chunks from the high 32-bit halves of
@@ -14132,6 +15224,10 @@ s2 = X[rs2]
 
 X[rd] = s2[47:32] @ s2[15:0] @ s1[47:32] @ s1[15:0]
 ----
+
+===== Mnemonic
+
+unzip16p _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -14169,6 +15265,10 @@ s2 = X[rs2]
 X[rd] = s2[63:48] @ s2[31:16] @ s1[63:48] @ s1[31:16]
 ----
 
+===== Mnemonic
+
+unzip16hp _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The UNZIP16HP instruction de-interleaves 16-bit chunks from the high 32-bit halves
@@ -14198,6 +15298,10 @@ REV16 is a scalar instruction encoded in the OP-IMM major opcode and is availabl
 s1 = X[rs1]
 X[rd] = s1[15:0] @ s1[31:16] @ s1[47:32] @ s1[63:48]
 ----
+
+===== Mnemonic
+
+rev16 _rd_, _rs1_
 
 ===== Description
 
@@ -14250,6 +15354,10 @@ for i = 0 .. (XLEN - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+rev _rd_, _rs1_
+
 ===== Description
 
 REV reverses the bit order of the full XLEN-wide value in `rs1` and writes
@@ -14283,6 +15391,10 @@ s1 = X[rs1]
 X[rd] = (signed(s1) < 0) ? (0 - s1) : s1
 ----
 
+===== Mnemonic
+
+abs _rd_, _rs1_, _imm12_
+
 ===== Description
 
 ABS writes the absolute value of `X[rs1]` to `rd`.
@@ -14311,6 +15423,10 @@ ABSW is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 w = X[rs1][31:0]
 X[rd] = sign_extend(64, (signed(w) <_s 0) ? (0 - w) : w)
 ----
+
+===== Mnemonic
+
+absw _rd_, _rs1_, _simm12_
 
 ===== Description
 
@@ -14350,6 +15466,10 @@ while (c < XLEN - 1) & (v >=_s lo_bound) & (v <=_s hi_bound) do
 X[rd] = to_bits(XLEN, c)
 ----
 
+===== Mnemonic
+
+cls _rd_, _rs1_, _imm12_
+
 ===== Description
 
 CLS returns the count `c` produced by the Sail reference algorithm.
@@ -14382,6 +15502,10 @@ while (c < 31) & (w >=_s 0xC0000000) & (w <=_s 0x3FFFFFFF) do
     w = w << 1
 X[rd] = to_bits(XLEN, c)
 ----
+
+===== Mnemonic
+
+clsw _rd_, _rs1_, _imm12_
 
 ===== Description
 
@@ -14416,6 +15540,10 @@ shamt = X[rs2][log2(XLEN)-1:0]
 X[rd] = ((X[rd] @ X[rs1]) << shamt)[(2*XLEN-1):XLEN]
 ----
 
+===== Mnemonic
+
+slx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 SLX shifts the 2*XLEN-bit concatenation `X[rd] @ X[rs1]` left by `shamt` and
@@ -14448,6 +15576,10 @@ SRX is encoded in the OP-32 major opcode.
 shamt = X[rs2][log2(XLEN)-1:0]
 X[rd] = ((X[rs1] @ X[rd]) >> shamt)[(XLEN-1):0]
 ----
+
+===== Mnemonic
+
+srx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -14482,6 +15614,10 @@ m = X[rs2]
 X[rd] = (~m & X[rd]) | (m & X[rs1])
 ----
 
+===== Mnemonic
+
+mvm _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MVM merges `rs1` and the prior value of `rd` under control of the mask `rs2`.
@@ -14514,6 +15650,10 @@ m = X[rs2]
 X[rd] = (~m & X[rs1]) | (m & X[rd])
 ----
 
+===== Mnemonic
+
+mvmn _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MVMN is like MVM, but swaps the roles of `rs1` and the prior `rd` value.
@@ -14545,6 +15685,10 @@ MERGE is encoded in the OP-32 major opcode.
 d0 = X[rd]
 X[rd] = (~d0 & X[rs1]) | (d0 & X[rs2])
 ----
+
+===== Mnemonic
+
+merge _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -14590,6 +15734,10 @@ X[rd_p * 2]     = d[31:0]
 X[rd_p * 2 + 1] = d[63:32]
 ----
 
+===== Mnemonic
+
+addd _rd_p_, _rs1_p_, _rs2_p_
+
 ===== Description
 
 ADDD (Add Doubleword) performs a 64-bit addition of two register-pair operands
@@ -14634,6 +15782,10 @@ d = s1 - s2                              // 64-bit subtraction
 X[rd_p * 2]     = d[31:0]
 X[rd_p * 2 + 1] = d[63:32]
 ----
+
+===== Mnemonic
+
+subd _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Description
 
@@ -14684,6 +15836,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwadd.b _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWADD.B sign-extends corresponding packed 8-bit elements of `rs1` and `rs2` to
@@ -14731,6 +15887,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwadda.b _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWADDA.B performs the same packed byte-to-halfword signed additions as PWADD.B,
@@ -14775,6 +15935,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+pwaddu.b _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -14823,6 +15987,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwaddau.b _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWADDAU.B performs the same packed byte-to-halfword unsigned additions as PWADDU.B,
@@ -14867,6 +16035,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+pwsub.b _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -14917,6 +16089,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwsuba.b _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWSUBA.B performs the same packed byte-to-halfword signed subtraction as
@@ -14961,6 +16137,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+pwsubu.b _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15010,6 +16190,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwsubau.b _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWSUBAU.B performs the same packed byte-to-halfword unsigned subtraction as
@@ -15052,6 +16236,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d0
     X[2*rd_p+1] = d1
 ----
+
+===== Mnemonic
+
+pwadd.h _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15098,6 +16286,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
+===== Mnemonic
+
+pwadda.h _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWADDA.H performs PWADD.H and adds each 32-bit result into the corresponding
@@ -15138,6 +16330,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d0
     X[2*rd_p+1] = d1
 ----
+
+===== Mnemonic
+
+pwaddu.h _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15184,6 +16380,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
+===== Mnemonic
+
+pwaddau.h _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWADDAU.H performs PWADDU.H and accumulates the two 32-bit results into the
@@ -15224,6 +16424,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d0
     X[2*rd_p+1] = d1
 ----
+
+===== Mnemonic
+
+pwsub.h _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15270,6 +16474,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
+===== Mnemonic
+
+pwsuba.h _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWSUBA.H performs PWSUB.H and accumulates the two 32-bit results into the
@@ -15310,6 +16518,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d0
     X[2*rd_p+1] = d1
 ----
+
+===== Mnemonic
+
+pwsubu.h _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15357,6 +16569,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
+===== Mnemonic
+
+pwsubau.h _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWSUBAU.H performs PWSUBU.H and accumulates the two 32-bit results into the
@@ -15394,6 +16610,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+wadd _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15434,6 +16654,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
+===== Mnemonic
+
+wadda _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WADDA performs WADD and accumulates the 64-bit result into the destination
@@ -15471,6 +16695,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+waddu _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15511,6 +16739,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
+===== Mnemonic
+
+waddau _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WADDAU performs WADDU and accumulates the 64-bit result into the destination
@@ -15548,6 +16780,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+wsub _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15588,6 +16824,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
+===== Mnemonic
+
+wsuba _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WSUBA performs WSUB and accumulates the 64-bit result into the destination
@@ -15625,6 +16865,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+wsubu _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15664,6 +16908,10 @@ if (rd_p != 0):
     X[2*rd_p]   = acc[31:0]
     X[2*rd_p+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+wsubau _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -15712,6 +16960,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwslli.b _rd_p_, _rs1_, _uimm4_
+
 ===== Description
 
 PWSLLI.B widens each 8-bit element of `rs1` to 16 bits by zero-extension, then
@@ -15756,6 +17008,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwsll.bs _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWSLL.BS widens each 8-bit element of `rs1` to 16 bits by zero-extension, then
@@ -15798,6 +17054,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+pwslai.b _rd_p_, _rs1_, _uimm4_
 
 ===== Description
 
@@ -15843,6 +17103,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwsla.bs _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWSLA.BS widens each 8-bit element of `rs1` to 16 bits by sign-extension, then
@@ -15884,6 +17148,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d0
     X[2*rd_p+1] = d1
 ----
+
+===== Mnemonic
+
+pwslli.h _rd_p_, _rs1_, _uimm5_
 
 ===== Description
 
@@ -15928,6 +17196,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
+===== Mnemonic
+
+pwsll.hs _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWSLL.HS widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
@@ -15969,6 +17241,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d0
     X[2*rd_p+1] = d1
 ----
+
+===== Mnemonic
+
+pwslai.h _rd_p_, _rs1_, _uimm5_
 
 ===== Description
 
@@ -16013,6 +17289,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
+===== Mnemonic
+
+pwsla.hs _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWSLA.HS widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
@@ -16053,6 +17333,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+wsll _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WSLL zero-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
@@ -16091,6 +17375,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+wslli _rd_p_, _rs1_, _uimm6_
 
 ===== Description
 
@@ -16132,6 +17420,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+wsla _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WSLA sign-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
@@ -16170,6 +17462,10 @@ if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
     X[2*rd_p+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+wslai _rd_p_, _rs1_, _uimm6_
 
 ===== Description
 
@@ -16219,6 +17515,10 @@ if (rd_p != 0):
     X[2*rd_p+1] = hi
 ----
 
+===== Mnemonic
+
+wzip8p _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WZIP8P interleaves the low four bytes of `rs1` and `rs2` into a 64-bit result,
@@ -16265,6 +17565,10 @@ if (rd_p != 0):
     X[2*rd_p]   = lo
     X[2*rd_p+1] = hi
 ----
+
+===== Mnemonic
+
+wzip16p _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -16317,6 +17621,10 @@ for i = 0 .. 7:
 X[rd] = to_bits(32, sum)
 ----
 
+===== Mnemonic
+
+predsum.dbs _rd_, _rs1_p_, _rs2_
+
 ===== Description
 
 PREDSUM.DBS adds the eight signed 8-bit elements contained in the 64-bit source
@@ -16361,6 +17669,10 @@ for i = 0 .. 7:
 
 X[rd] = to_bits(32, sum)
 ----
+
+===== Mnemonic
+
+predsumu.dbs _rd_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -16407,6 +17719,10 @@ for i = 0 .. 3:
 X[rd] = to_bits(32, sum)
 ----
 
+===== Mnemonic
+
+predsum.dhs _rd_, _rs1_p_, _rs2_
+
 ===== Description
 
 PREDSUM.DHS adds the four signed 16-bit elements contained in the 64-bit source
@@ -16451,6 +17767,10 @@ for i = 0 .. 3:
 
 X[rd] = to_bits(32, sum)
 ----
+
+===== Mnemonic
+
+predsumu.dhs _rd_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -16500,6 +17820,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnsrli.b _rd_, _rs1p_, _uimm4_
+
 ===== Description
 
 PNSRLI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
@@ -16541,6 +17865,10 @@ for i = 0 .. 3:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnsrl.bs _rd_, _rs1p_, _rs2_
 
 ===== Description
 
@@ -16587,6 +17915,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnsrai.b _rd_, _rs1p_, _uimm4_
+
 ===== Description
 
 PNSRAI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
@@ -16628,6 +17960,10 @@ for i = 0 .. 3:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnsra.bs _rd_, _rs1p_, _rs2_
 
 ===== Description
 
@@ -16675,6 +18011,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnsrari.b _rd_, _rs1p_, _uimm4_
+
 ===== Description
 
 PNSRARI.B performs a per-lane rounded arithmetic right shift of four 16-bit lanes
@@ -16717,6 +18057,10 @@ for i = 0 .. 3:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnsrar.bs _rd_, _rs1p_, _rs2_
 
 ===== Description
 
@@ -16762,6 +18106,10 @@ d[31:16] = (s1[63:32] >> shamt)[15:0]
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnsrli.h _rd_, _rs1p_, _uimm5_
+
 ===== Description
 
 PNSRLI.H performs a logical right shift of each 32-bit word lane in a 64-bit
@@ -16803,6 +18151,10 @@ d[31:16] = (s1[63:32] >> shamt)[15:0]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnsrl.hs _rd_, _rs1p_, _rs2_
 
 ===== Description
 
@@ -16847,6 +18199,10 @@ d[31:16] = (sext_48(s1[63:32]) >> shamt)[15:0]
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnsrai.h _rd_, _rs1p_, _uimm5_
+
 ===== Description
 
 PNSRAI.H performs an arithmetic right shift of each 32-bit word lane in a 64-bit
@@ -16888,6 +18244,10 @@ d[31:16] = (sext_48(s1[63:32]) >> shamt)[15:0]
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnsra.hs _rd_, _rs1p_, _rs2_
 
 ===== Description
 
@@ -16932,6 +18292,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnsrari.h _rd_, _rs1p_, _uimm5_
+
 ===== Description
 
 PNSRARI.H performs a per-word *rounded* arithmetic right shift of the 64-bit
@@ -16975,6 +18339,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnsrar.hs _rd_, _rs1p_, _rs2_
+
 ===== Description
 
 PNSRAR.HS performs a per-word *rounded* arithmetic right shift of a 64-bit
@@ -17015,6 +18383,10 @@ shamt = w_uimm[5:0]
 X[rd] = (s1 >> shamt)[31:0]
 ----
 
+===== Mnemonic
+
+nsrli _rd_, _rs1p_, _uimm6_
+
 ===== Description
 
 NSRLI performs a 64-bit logical right shift of the register-pair source by an
@@ -17050,6 +18422,10 @@ s1    = (rs1p == 0) ? 0 : (X[2*rs1p+1] @ X[2*rs1p])
 shamt = X[rs2][5:0]
 X[rd] = (s1 >> shamt)[31:0]
 ----
+
+===== Mnemonic
+
+nsrl _rd_, _rs1p_, _rs2_
 
 ===== Description
 
@@ -17087,6 +18463,10 @@ shamt = w_uimm[5:0]
 X[rd] = (sext_96(s1) >> shamt)[31:0]
 ----
 
+===== Mnemonic
+
+nsrai _rd_, _rs1p_, _uimm6_
+
 ===== Description
 
 NSRAI performs a 64-bit arithmetic right shift of the register-pair source by an
@@ -17122,6 +18502,10 @@ s1    = (rs1p == 0) ? 0 : (X[2*rs1p+1] @ X[2*rs1p])
 shamt = X[rs2][5:0]
 X[rd] = (sext_96(s1) >> shamt)[31:0]
 ----
+
+===== Mnemonic
+
+nsra _rd_, _rs1p_, _rs2_
 
 ===== Description
 
@@ -17160,6 +18544,10 @@ shx = ((sext_96(s1) @ 0b0) >> shamt)[32:0]
 X[rd] = (shx + 1)[32:1]
 ----
 
+===== Mnemonic
+
+nsrari _rd_, _rs1p_, _uimm6_
+
 ===== Description
 
 NSRARI performs a 64-bit *rounded* arithmetic right shift of the register-pair
@@ -17197,6 +18585,10 @@ shamt = X[rs2][5:0]
 shx = ((sext_96(s1) @ 0b0) >> shamt)[32:0]
 X[rd] = (shx + 1)[32:1]
 ----
+
+===== Mnemonic
+
+nsrar _rd_, _rs1p_, _rs2_
 
 ===== Description
 
@@ -17254,6 +18646,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipi.b _rd_, _rs1p_, _uimm4_
+
 ===== Description
 
 PNCLIPI.B performs a per-lane arithmetic right shift of four 16-bit lanes from a
@@ -17310,6 +18706,10 @@ for i = 0 .. 3:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnclip.bs _rd_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -17372,6 +18772,10 @@ for i = 0 .. 3:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnclipri.b _rd_, _rs1p_, _uimm4_
 
 ===== Description
 
@@ -17439,6 +18843,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipr.bs _rd_, _rs1p_, _rs2_
+
 ===== Description
 
 PNCLIPR.BS performs a per-lane *rounded* arithmetic right shift of four 16-bit
@@ -17499,6 +18907,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipiu.b _rd_, _rs1p_, _uimm4_
+
 ===== Description
 
 PNCLIPIU.B performs a per-lane logical right shift of four 16-bit lanes from a
@@ -17556,6 +18968,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipu.bs _rd_, _rs1p_, _rs2_
+
 ===== Description
 
 PNCLIPU.BS performs a per-lane logical right shift of four 16-bit lanes from a
@@ -17611,6 +19027,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipriu.b _rd_, _rs1p_, _uimm4_
+
 ===== Description
 
 PNCLIPRIU.B performs a per-lane *rounded* logical right shift of four 16-bit lanes
@@ -17663,6 +19083,10 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipru.bs _rd_, _rs1p_, _rs2_
+
 ===== Description
 
 PNCLIPRU.BS performs a per-lane *rounded* logical right shift of four 16-bit lanes
@@ -17711,6 +19135,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnclipi.h _rd_, _rs1_p_, _uimm5_
 
 ===== Description
 
@@ -17764,6 +19192,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclip.hs _rd_, _rs1_p_, _rs2_
+
 ===== Description
 
 PNCLIP.HS performs a packed narrowing signed clip from 32-bit word elements
@@ -17816,6 +19248,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnclipri.h _rd_, _rs1_p_, _uimm5_
 
 ===== Description
 
@@ -17871,6 +19307,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipr.hs _rd_, _rs1_p_, _rs2_
+
 ===== Description
 
 PNCLIPR.HS performs a packed narrowing signed clip with rounding from 32-bit
@@ -17923,6 +19363,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipiu.h _rd_, _rs1p_, _uimm5_
+
 ===== Description
 
 PNCLIPIU.H shifts each 32-bit word lane of the 64-bit register-pair source right
@@ -17972,6 +19416,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipu.hs _rd_, _rs1p_, _rs2_
+
 ===== Description
 
 PNCLIPU.HS performs a per-word logical right shift of a 64-bit register-pair
@@ -18020,6 +19468,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pnclipriu.h _rd_, _rs1_p_, _uimm5_
 
 ===== Description
 
@@ -18074,6 +19526,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pnclipru.hs _rd_, _rs1_p_, _rs2_
+
 ===== Description
 
 PNCLIPRU.HS performs a packed narrowing unsigned clip with rounding from 32-bit
@@ -18123,6 +19579,10 @@ else:
     X[rd] = shx[31:0]
 ----
 
+===== Mnemonic
+
+nclipi _rd_, _rs1_p_, _uimm6_
+
 ===== Description
 
 NCLIPI performs an XLEN-wide narrowing signed clip with an immediate shift
@@ -18170,6 +19630,10 @@ else if (shx >s 0x000000007FFFFFFF):
 else:
     X[rd] = shx[31:0]
 ----
+
+===== Mnemonic
+
+nclip _rd_, _rs1_p_, _rs2_
 
 ===== Description
 
@@ -18219,6 +19683,10 @@ else if (round_shx >s 0x000000007FFFFFFF):
 else:
     X[rd] = round_shx[31:0]
 ----
+
+===== Mnemonic
+
+nclipri _rd_, _rs1_p_, _uimm6_
 
 ===== Description
 
@@ -18271,6 +19739,10 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
+===== Mnemonic
+
+nclipr _rd_, _rs1_p_, _rs2_
+
 ===== Description
 
 NCLIPR performs an XLEN-wide narrowing signed clip with rounding using a scalar
@@ -18316,6 +19788,10 @@ if (shx >u 0x00000000FFFFFFFF):
 else:
     X[rd] = shx[31:0]
 ----
+
+===== Mnemonic
+
+nclipiu _rd_, _rs1_p_, _uimm6_
 
 ===== Description
 
@@ -18364,6 +19840,10 @@ else:
     X[rd] = shx[31:0]
 ----
 
+===== Mnemonic
+
+nclipu _rd_, _rs1p_, _rs2_
+
 ===== Description
 
 NCLIPU performs a 64-bit logical right shift of the register-pair source and clips
@@ -18408,6 +19888,10 @@ if (round_shx >u 0x00000000FFFFFFFF):
 else:
     X[rd] = round_shx[31:0]
 ----
+
+===== Mnemonic
+
+nclipriu _rd_, _rs1_p_, _uimm6_
 
 ===== Description
 
@@ -18458,6 +19942,10 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
+===== Mnemonic
+
+nclipru _rd_, _rs1_p_, _rs2_
+
 ===== Description
 
 NCLIPRU performs an XLEN-wide narrowing unsigned clip with rounding using a
@@ -18505,6 +19993,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulh.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -18555,6 +20047,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulhr.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -18607,6 +20103,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulhsu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULHSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
@@ -18658,6 +20158,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulhrsu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -18748,6 +20252,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulhu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULHU.H multiplies corresponding unsigned packed 16-bit halfword elements of
@@ -18791,6 +20299,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulhru.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -18841,6 +20353,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulh.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULH.W multiplies corresponding signed packed 32-bit word elements of `rs1`
@@ -18884,6 +20400,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulhr.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULHR.W multiplies corresponding signed packed 32-bit word elements of `rs1`
@@ -18926,6 +20446,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulhsu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMULHSU.W instruction multiplies corresponding 32-bit elements of `rs1`
@@ -18967,6 +20491,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulhrsu.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19013,6 +20541,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulhu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMULHU.W instruction multiplies corresponding unsigned 32-bit elements of
@@ -19054,6 +20586,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulhru.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMULHRU.W instruction multiplies corresponding unsigned 32-bit elements,
@@ -19094,6 +20630,10 @@ X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^31)[63:32]
 X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^63)[127:64]
 ----
 
+===== Mnemonic
+
+mulhr _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULHR multiplies the full signed XLEN-bit values of `rs1` and `rs2`, producing
@@ -19130,6 +20670,10 @@ b64 = zext_64(X[rs2])
 prod = a64 * b64
 X[rd] = (prod + 2^31)[63:32]
 ----
+
+===== Mnemonic
+
+mulhrsu _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19171,6 +20715,10 @@ b64 = zext_64(X[rs2])
 prod = a64 * b64
 X[rd] = (prod + 2^31)[63:32]
 ----
+
+===== Mnemonic
+
+mulhru _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19217,6 +20765,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulq.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19267,6 +20819,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulqr.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19323,6 +20879,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulq.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULQ.W performs a Q-format multiply on corresponding signed packed 32-bit
@@ -19370,6 +20930,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulqr.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19423,6 +20987,10 @@ else:
     X[rd] = (signed(a) * signed(b))[126:63]
 ----
 
+===== Mnemonic
+
+mulq _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULQ performs a Q-format multiply on the full signed XLEN-bit values of `rs1`
@@ -19472,6 +21040,10 @@ if (a == 0x8000000000000000) & (b == 0x8000000000000000):
 else:
     X[rd] = (signed(a) * signed(b) + 2^62)[126:63]
 ----
+
+===== Mnemonic
+
+mulqr _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19523,6 +21095,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmhacc.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19576,6 +21152,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmhracc.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19631,6 +21211,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhaccsu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMHACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
@@ -19684,6 +21268,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmhraccsu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19740,6 +21328,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhaccu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMHACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
@@ -19793,6 +21385,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhraccu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMHRACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
@@ -19844,6 +21440,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhacc.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHACC.W instruction multiplies signed packed 32-bit elements and
@@ -19891,6 +21491,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhracc.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHRACC.W instruction performs signed packed multiplication with rounding
@@ -19933,6 +21537,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmhaccsu.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -19977,6 +21585,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhraccsu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHRACCSU.W instruction performs signed×unsigned packed multiplication with
@@ -20019,6 +21631,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmhaccu.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20063,6 +21679,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhraccu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHRACCU.W instruction multiplies unsigned packed 32-bit elements with
@@ -20098,6 +21718,10 @@ b64 = sext_64(X[rs2])
 hi  = (a64 * b64)[63:32]
 X[rd] = X[rd] + hi
 ----
+
+===== Mnemonic
+
+mhacc _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20138,6 +21762,10 @@ b64 = sext_64(X[rs2])
 hi_rnd = (a64 * b64 + 2^31)[63:32]
 X[rd] = X[rd] + hi_rnd
 ----
+
+===== Mnemonic
+
+mhracc _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20180,6 +21808,10 @@ hi  = (a64 * b64)[63:32]
 X[rd] = X[rd] + hi
 ----
 
+===== Mnemonic
+
+mhaccsu _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MHACCSU instruction multiplies `rs1` as signed by `rs2` as unsigned,
@@ -20215,6 +21847,10 @@ b64 = zext_64(X[rs2])
 hi_rnd = (a64 * b64 + 2^31)[63:32]
 X[rd] = X[rd] + hi_rnd
 ----
+
+===== Mnemonic
+
+mhraccsu _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20252,6 +21888,10 @@ hi  = (a64 * b64)[63:32]
 X[rd] = X[rd] + hi
 ----
 
+===== Mnemonic
+
+mhaccu _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MHACCU instruction multiplies `rs1` and `rs2` as unsigned values and
@@ -20287,6 +21927,10 @@ b64 = zext_64(X[rs2])
 hi_rnd = (a64 * b64 + 2^31)[63:32]
 X[rd] = X[rd] + hi_rnd
 ----
+
+===== Mnemonic
+
+mhraccu _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20326,6 +21970,10 @@ b = sext_47(X[rs2][15:0])
 q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
+
+===== Mnemonic
+
+mqacc.h00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20369,6 +22017,10 @@ q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
 
+===== Mnemonic
+
+mqacc.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MQACC.H01 instruction multiplies `rs1[15:0]` by `rs2[31:16]` as signed
@@ -20409,6 +22061,10 @@ b = sext_47(X[rs2][31:16])
 q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
+
+===== Mnemonic
+
+mqacc.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20451,6 +22107,10 @@ q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
 
+===== Mnemonic
+
+mqracc.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MQRACC.H00 instruction is like MQACC.H00 but applies rounding by adding
@@ -20492,6 +22152,10 @@ q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
 
+===== Mnemonic
+
+mqracc.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MQRACC.H01 instruction is like MQACC.H01 but applies rounding by adding
@@ -20532,6 +22196,10 @@ b = sext_47(X[rs2][31:16])
 q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
+
+===== Mnemonic
+
+mqracc.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20581,6 +22249,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmqacc.w.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMQACC.W.H00 instruction, for each 32-bit lane, multiplies the low 16-bit
@@ -20629,6 +22301,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmqacc.w.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMQACC.W.H01 instruction, for each 32-bit lane, multiplies the low halfword
@@ -20673,6 +22349,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmqacc.w.h11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMQACC.W.H11 instruction, for each 32-bit lane, multiplies the high 16-bit
@@ -20716,6 +22396,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmqracc.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20765,6 +22449,10 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmqracc.w.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMQRACC.W.H01 instruction is like PMQACC.W.H01 but applies rounding by
@@ -20812,6 +22500,10 @@ for i = 0 .. 1:
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmqracc.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20864,6 +22556,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmq2add.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMQ2ADD.H instruction computes, for each 32-bit lane, the sum of two
@@ -20911,6 +22607,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmq2adda.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -20961,6 +22661,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmqr2add.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21014,6 +22718,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmqr2adda.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMQR2ADDA.H instruction adds the PMQR2ADD.H result into the corresponding
@@ -21054,6 +22762,10 @@ b = sext_95(X[rs2][31:0])
 q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
+
+===== Mnemonic
+
+mqacc.w00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21096,6 +22808,10 @@ q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
+===== Mnemonic
+
+mqacc.w01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MQACC.W01 instruction multiplies `rs1[31:0]` by `rs2[63:32]` as signed
@@ -21137,6 +22853,10 @@ q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
+===== Mnemonic
+
+mqacc.w11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MQACC.W11 instruction multiplies `rs1[63:32]` and `rs2[63:32]` as signed
@@ -21177,6 +22897,10 @@ b = sext_95(X[rs2][31:0])
 q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
+
+===== Mnemonic
+
+mqracc.w00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21220,6 +22944,10 @@ q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
 
+===== Mnemonic
+
+mqracc.w01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The MQRACC.W01 instruction is like MQACC.W01 but applies rounding by adding 2^30
@@ -21260,6 +22988,10 @@ b = sext_95(X[rs2][63:32])
 q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
+
+===== Mnemonic
+
+mqracc.w11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21307,6 +23039,10 @@ q1 = (a1 * b1)[94:31]
 X[rd] = q0 + q1
 ----
 
+===== Mnemonic
+
+pmq2add.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMQ2ADD.W instruction multiplies the low words and the high words of `rs1`
@@ -21348,6 +23084,10 @@ q1 = (a1 * b1)[94:31]
 
 X[rd] = X[rd] + q0 + q1
 ----
+
+===== Mnemonic
+
+pmq2adda.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21391,6 +23131,10 @@ q1 = (a1 * b1 + 2^30)[94:31]
 
 X[rd] = q0 + q1
 ----
+
+===== Mnemonic
+
+pmqr2add.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21437,6 +23181,10 @@ q1 = (a1 * b1 + 2^30)[94:31]
 
 X[rd] = X[rd] + q0 + q1
 ----
+
+===== Mnemonic
+
+pmqr2adda.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21485,6 +23233,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmul.h.b00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMUL.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` and `rs2` as
@@ -21524,6 +23276,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmul.h.b01 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21566,6 +23322,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmul.h.b11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMUL.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` and `rs2`
@@ -21605,6 +23365,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulsu.h.b00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21646,6 +23410,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulsu.h.b11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULSU.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` (signed) and
@@ -21686,6 +23454,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulu.h.b00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULU.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` and `rs2`
@@ -21725,6 +23497,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulu.h.b01 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21767,6 +23543,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulu.h.b11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULU.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` and `rs2`
@@ -21801,6 +23581,10 @@ s1_h0 = X[rs1][15:0]
 s2_h0 = X[rs2][15:0]
 X[rd] = signed(s1_h0) * signed(s2_h0)
 ----
+
+===== Mnemonic
+
+mul.h00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21838,6 +23622,10 @@ s2_h1 = X[rs2][31:16]
 X[rd] = signed(s1_h0) * signed(s2_h1)
 ----
 
+===== Mnemonic
+
+mul.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MUL.H01 multiplies the low 16-bit halfword (h0) of `rs1` by the high 16-bit
@@ -21873,6 +23661,10 @@ s1_h1 = X[rs1][31:16]
 s2_h1 = X[rs2][31:16]
 X[rd] = signed(s1_h1) * signed(s2_h1)
 ----
+
+===== Mnemonic
+
+mul.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21910,6 +23702,10 @@ b = zext_32(X[rs2][15:0])
 X[rd] = to_bits(32, a * b)
 ----
 
+===== Mnemonic
+
+mulsu.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and writes
@@ -21944,6 +23740,10 @@ a = sext_32(X[rs1][31:16])
 b = zext_32(X[rs2][31:16])
 X[rd] = to_bits(32, a * b)
 ----
+
+===== Mnemonic
+
+mulsu.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -21980,6 +23780,10 @@ b = zext_32(X[rs2][15:0])
 X[rd] = to_bits(32, a * b)
 ----
 
+===== Mnemonic
+
+mulu.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and writes
@@ -22015,6 +23819,10 @@ b = zext_32(X[rs2][31:16])
 X[rd] = to_bits(32, a * b)
 ----
 
+===== Mnemonic
+
+mulu.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and writes
@@ -22049,6 +23857,10 @@ a = zext_32(X[rs1][31:16])
 b = zext_32(X[rs2][31:16])
 X[rd] = to_bits(32, a * b)
 ----
+
+===== Mnemonic
+
+mulu.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22086,6 +23898,10 @@ d_w0 = signed(s1[15:0])  * signed(s2[15:0])
 d_w1 = signed(s1[47:32]) * signed(s2[47:32])
 X[rd] = d_w1 @ d_w0
 ----
+
+===== Mnemonic
+
+pmul.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22126,6 +23942,10 @@ d_w1 = signed(s1[47:32]) * signed(s2[63:48])
 X[rd] = d_w1 @ d_w0
 ----
 
+===== Mnemonic
+
+pmul.w.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMUL.W.H01 multiplies the low halfword (h0) of each packed 32-bit word element
@@ -22164,6 +23984,10 @@ d_w0 = signed(s1[31:16]) * signed(s2[31:16])
 d_w1 = signed(s1[63:48]) * signed(s2[63:48])
 X[rd] = d_w1 @ d_w0
 ----
+
+===== Mnemonic
+
+pmul.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22207,6 +24031,10 @@ d1 = to_bits(32, sext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmulsu.w.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
@@ -22245,6 +24073,10 @@ d1 = to_bits(32, sext_32(s1[63:48]) * zext_32(s2[63:48]))
 
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmulsu.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22285,6 +24117,10 @@ d1 = to_bits(32, zext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmulu.w.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2` as
@@ -22323,6 +24159,10 @@ d1 = to_bits(32, zext_32(s1[47:32]) * zext_32(s2[63:48]))
 
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmulu.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22363,6 +24203,10 @@ d1 = to_bits(32, zext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmulu.w.h11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
@@ -22397,6 +24241,10 @@ s1_w0 = X[rs1][31:0]
 s2_w0 = X[rs2][31:0]
 X[rd] = signed(s1_w0) * signed(s2_w0)
 ----
+
+===== Mnemonic
+
+mul.w00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22434,6 +24282,10 @@ s2_w1 = X[rs2][63:32]
 X[rd] = signed(s1_w0) * signed(s2_w1)
 ----
 
+===== Mnemonic
+
+mul.w01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MUL.W01 multiplies the low 32-bit word (w0) of `rs1` by the high 32-bit word
@@ -22469,6 +24321,10 @@ s1_w1 = X[rs1][63:32]
 s2_w1 = X[rs2][63:32]
 X[rd] = signed(s1_w1) * signed(s2_w1)
 ----
+
+===== Mnemonic
+
+mul.w11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22506,6 +24362,10 @@ b = zext_64(X[rs2][31:0])
 X[rd] = to_bits(64, a * b)
 ----
 
+===== Mnemonic
+
+mulsu.w00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and writes
@@ -22540,6 +24400,10 @@ a = sext_64(X[rs1][63:32])
 b = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a * b)
 ----
+
+===== Mnemonic
+
+mulsu.w11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22576,6 +24440,10 @@ b = zext_64(X[rs2][31:0])
 X[rd] = to_bits(64, a * b)
 ----
 
+===== Mnemonic
+
+mulu.w00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
@@ -22611,6 +24479,10 @@ b = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a * b)
 ----
 
+===== Mnemonic
+
+mulu.w01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
@@ -22645,6 +24517,10 @@ a = zext_64(X[rs1][63:32])
 b = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a * b)
 ----
+
+===== Mnemonic
+
+mulu.w11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22683,6 +24559,10 @@ a = sext_32(X[rs1][15:0])
 b = sext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
+
+===== Mnemonic
+
+macc.h00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22723,6 +24603,10 @@ b = sext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
+===== Mnemonic
+
+macc.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MACC.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as signed halfwords and adds the
@@ -22761,6 +24645,10 @@ a = sext_32(X[rs1][31:16])
 b = sext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
+
+===== Mnemonic
+
+macc.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22801,6 +24689,10 @@ b = zext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
+===== Mnemonic
+
+maccsu.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MACCSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and adds
@@ -22839,6 +24731,10 @@ a = sext_32(X[rs1][31:16])
 b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
+
+===== Mnemonic
+
+maccsu.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -22879,6 +24775,10 @@ b = zext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
+===== Mnemonic
+
+maccu.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MACCU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and adds
@@ -22918,6 +24818,10 @@ b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
+===== Mnemonic
+
+maccu.h01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MACCU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and adds
@@ -22956,6 +24860,10 @@ a = zext_32(X[rs1][31:16])
 b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
+
+===== Mnemonic
+
+maccu.h11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23001,6 +24909,10 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * sext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmacc.w.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMACC.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2` as
@@ -23044,6 +24956,10 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * sext_32(s2[63:48]))
 
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmacc.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23089,6 +25005,10 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[63:48]) * sext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmacc.w.h11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMACC.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
@@ -23132,6 +25052,10 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * zext_32(s2[47:32]))
 
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmaccsu.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23177,6 +25101,10 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmaccsu.w.h11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMACCSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
@@ -23221,6 +25149,10 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmaccu.w.h00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMACCU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2`
@@ -23264,6 +25196,10 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[47:32]) * zext_32(s2[63:48]))
 
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmaccu.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23310,6 +25246,10 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmaccu.w.h11 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMACCU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
@@ -23348,6 +25288,10 @@ a = sext_64(X[rs1][31:0])
 b = sext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
+
+===== Mnemonic
+
+macc.w00 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23388,6 +25332,10 @@ b = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
+===== Mnemonic
+
+macc.w01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MACC.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as signed 32-bit values and adds
@@ -23426,6 +25374,10 @@ a = sext_64(X[rs1][63:32])
 b = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
+
+===== Mnemonic
+
+macc.w11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23466,6 +25418,10 @@ b = zext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
+===== Mnemonic
+
+maccsu.w00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MACCSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and adds the
@@ -23504,6 +25460,10 @@ a = sext_64(X[rs1][63:32])
 b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
+
+===== Mnemonic
+
+maccsu.w11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23544,6 +25504,10 @@ b = zext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
+===== Mnemonic
+
+maccu.w00 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MACCU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
@@ -23583,6 +25547,10 @@ b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
+===== Mnemonic
+
+maccu.w01 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MACCU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
@@ -23621,6 +25589,10 @@ a = zext_64(X[rs1][63:32])
 b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
+
+===== Mnemonic
+
+maccu.w11 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23674,6 +25646,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm2add.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM2ADD.H instruction multiplies corresponding packed halfwords in each
@@ -23720,6 +25696,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pm2adda.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23770,6 +25750,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm2addsu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM2ADDSU.H instruction performs signed×unsigned halfword multiplications
@@ -23816,6 +25800,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pm2addasu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23866,6 +25854,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm2addu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM2ADDU.H instruction performs unsigned×unsigned halfword multiplications
@@ -23912,6 +25904,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pm2addau.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -23962,6 +25958,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm2add.hx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM2ADD.HX instruction multiplies cross halfword pairs within each 32-bit
@@ -24008,6 +26008,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pm2adda.hx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24058,6 +26062,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pm2suba.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24110,6 +26118,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm2suba.hx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM2SUBA.HX instruction updates each packed 32-bit element of `rd` by adding
@@ -24160,6 +26172,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm2sub.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2SUB.H multiplies two pairs of signed 16-bit halfword elements from `rs1` and
@@ -24208,6 +26224,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pm2sub.hx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24259,6 +26279,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm2sadd.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2SADD.H multiplies two pairs of signed 16-bit halfword elements from `rs1`
@@ -24307,6 +26331,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm2sadd.hx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2SADD.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
@@ -24349,6 +26377,10 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
+===== Mnemonic
+
+pm2add.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2ADD.W multiplies the low words and high words of `rs1` and `rs2` as signed
@@ -24387,6 +26419,10 @@ X[rd] = X[rd]
       + sext64(signed(s1[31:0])  * signed(s2[31:0]))
       + sext64(signed(s1[63:32]) * signed(s2[63:32]))
 ----
+
+===== Mnemonic
+
+pm2adda.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24427,6 +26463,10 @@ b1 = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
+===== Mnemonic
+
+pm2addsu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2ADDSU.W multiplies corresponding word pairs as signed×unsigned (low×low and
@@ -24464,6 +26504,10 @@ b1 = zext_64(X[rs2][63:32])
 
 X[rd] = X[rd] + to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
+
+===== Mnemonic
+
+pm2addasu.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24506,6 +26550,10 @@ b1 = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
+===== Mnemonic
+
+pm2addu.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2ADDU.W multiplies corresponding word pairs as unsigned×unsigned and adds the
@@ -24544,6 +26592,10 @@ X[rd] = X[rd]
       + zext64(unsigned(s1[31:0])  * unsigned(s2[31:0]))
       + zext64(unsigned(s1[63:32]) * unsigned(s2[63:32]))
 ----
+
+===== Mnemonic
+
+pm2addau.w _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24584,6 +26636,10 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
 ----
 
+===== Mnemonic
+
+pm2add.wx _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2ADD.WX multiplies cross word pairs (low of `rs1` × high of `rs2`, and high of
@@ -24621,6 +26677,10 @@ b1 = sext_64(X[rs2][63:32])
 
 X[rd] = X[rd] + to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
 ----
+
+===== Mnemonic
+
+pm2adda.wx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24663,6 +26723,10 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b0) - to_bits(64, a1 * b1)
 ----
 
+===== Mnemonic
+
+pm2suba.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2SUBA.W updates `rd` by adding the low×low signed word product and subtracting
@@ -24704,6 +26768,10 @@ b1 = sext_64(X[rs2][63:32])
 
 X[rd] = X[rd] + to_bits(64, a0 * b1) - to_bits(64, a1 * b0)
 ----
+
+===== Mnemonic
+
+pm2suba.wx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24748,6 +26816,10 @@ X[rd] = sext64(signed(s1[31:0])  * signed(s2[31:0]))
       - sext64(signed(s1[63:32]) * signed(s2[63:32]))
 ----
 
+===== Mnemonic
+
+pm2sub.w _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM2SUB.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
@@ -24787,6 +26859,10 @@ s2 = X[rs2]
 X[rd] = sext64(signed(s1[31:0])  * signed(s2[63:32]))
       - sext64(signed(s1[63:32]) * signed(s2[31:0]))
 ----
+
+===== Mnemonic
+
+pm2sub.wx _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24842,6 +26918,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm4add.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM4ADD.B instruction multiplies corresponding packed bytes within each
@@ -24893,6 +26973,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm4addsu.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM4ADDSU.B instruction multiplies corresponding packed bytes within each
@@ -24943,6 +27027,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pm4addu.b _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -24998,6 +27086,10 @@ for i = 0 .. (XLEN/32 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pm4adda.b _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25056,6 +27148,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm4addasu.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM4ADDASU.B multiplies four pairs of byte elements from `rs1` (signed) and
@@ -25113,6 +27209,10 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pm4addau.b _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PM4ADDAU.B multiplies four pairs of unsigned 8-bit byte elements from `rs1` and
@@ -25155,6 +27255,10 @@ X[rd] =
     + to_bits(64, sext_64(s1[63:48]) * sext_64(s2[63:48]))
 ----
 
+===== Mnemonic
+
+pm4add.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM4ADD.H instruction multiplies the four packed 16-bit halfwords of `rs1`
@@ -25195,6 +27299,10 @@ X[rd] =
     + to_bits(64, sext_64(s1[47:32]) * zext_64(s2[47:32]))
     + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
+
+===== Mnemonic
+
+pm4addsu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25237,6 +27345,10 @@ X[rd] =
   + to_bits(64, sext_64(s1[47:32]) * zext_64(s2[47:32]))
   + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
+
+===== Mnemonic
+
+pm4addasu.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25281,6 +27393,10 @@ X[rd] =
     + to_bits(64, zext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
 
+===== Mnemonic
+
+pm4addu.h _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PM4ADDU.H instruction multiplies the four packed 16-bit halfwords of `rs1`
@@ -25322,6 +27438,10 @@ X[rd] =
   + to_bits(64, zext_64(s1[47:32]) * zext_64(s2[47:32]))
   + to_bits(64, zext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
+
+===== Mnemonic
+
+pm4addau.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25368,6 +27488,10 @@ X[rd] = X[rd]
       + sext64(signed(s1[47:32])  * signed(s2[47:32]))
       + sext64(signed(s1[63:48])  * signed(s2[63:48]))
 ----
+
+===== Mnemonic
+
+pm4adda.h _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25416,6 +27540,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulh.h.b0 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMULH.H.B0 instruction multiplies each packed 16-bit element of `rs1` by the
@@ -25460,6 +27588,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmulh.h.b1 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25506,6 +27638,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulhsu.h.b0 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMULHSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
@@ -25551,6 +27687,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmulhsu.h.b1 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMULHSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
@@ -25595,6 +27735,10 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
+
+===== Mnemonic
+
+pmhacc.h.b0 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25646,6 +27790,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhacc.h.b1 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHACC.H.B1 instruction multiplies each packed 16-bit element of `rs1` by
@@ -25696,6 +27844,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhaccsu.h.b0 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHACCSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
@@ -25745,6 +27897,10 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
+===== Mnemonic
+
+pmhaccsu.h.b1 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHACCSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
@@ -25784,6 +27940,10 @@ s2_h0 = X[rs2][15:0]
 X[rd] = (signed(X[rs1]) * signed(s2_h0))[47:16]
 ----
 
+===== Mnemonic
+
+mulh.h0 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULH.H0 multiplies the full signed XLEN-bit value of `rs1` by the low 16-bit
@@ -25819,6 +27979,10 @@ MULH.H1 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using
 s2_h1 = X[rs2][31:16]
 X[rd] = (signed(X[rs1]) * signed(s2_h1))[47:16]
 ----
+
+===== Mnemonic
+
+mulh.h1 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25860,6 +28024,10 @@ p  = a * b0
 X[rd] = to_bits(48, p)[47:16]
 ----
 
+===== Mnemonic
+
+mulhsu.h0 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULHSU.H0 multiplies the 32-bit signed value in `rs1` by the low halfword of
@@ -25899,6 +28067,10 @@ p  = a * b1
 X[rd] = to_bits(48, p)[47:16]
 ----
 
+===== Mnemonic
+
+mulhsu.h1 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MULHSU.H1 multiplies the 32-bit signed value in `rs1` by the high halfword of
@@ -25936,6 +28108,10 @@ b0 = sext_48(X[rs2][15:0])
 p  = a * b0
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
+
+===== Mnemonic
+
+mhacc.h0 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -25979,6 +28155,10 @@ p  = a * b1
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
+===== Mnemonic
+
+mhacc.h1 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MHACC.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
@@ -26020,6 +28200,10 @@ b0 = zext_48(X[rs2][15:0])
 p  = a * b0
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
+
+===== Mnemonic
+
+mhaccsu.h0 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26063,6 +28247,10 @@ p  = a * b1
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
+===== Mnemonic
+
+mhaccsu.h1 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 MHACCSU.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
@@ -26105,6 +28293,10 @@ d_w1 = (signed(s1[63:32]) * signed(s2[47:32]))[47:16]
 X[rd] = d_w1 @ d_w0
 ----
 
+===== Mnemonic
+
+pmulh.w.h0 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULH.W.H0 multiplies each signed packed 32-bit word element of `rs1` by the
@@ -26144,6 +28336,10 @@ d_w0 = (signed(s1[31:0])  * signed(s2[31:16]))[47:16]
 d_w1 = (signed(s1[63:32]) * signed(s2[63:48]))[47:16]
 X[rd] = d_w1 @ d_w0
 ----
+
+===== Mnemonic
+
+pmulh.w.h1 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26191,6 +28387,10 @@ d1 = to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmulhsu.w.h0 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 PMULHSU.W.H0 multiplies each 32-bit word of `rs1` (signed) by the low halfword of
@@ -26234,6 +28434,10 @@ d1 = to_bits(48, p1)[47:16]
 
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmulhsu.w.h1 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26281,6 +28485,10 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmhacc.w.h0 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26334,6 +28542,10 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmhacc.w.h1 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHACC.W.H1 instruction multiplies each signed 32-bit word of `rs1` by the
@@ -26386,6 +28598,10 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
+===== Mnemonic
+
+pmhaccsu.w.h0 _rd_, _rs1_, _rs2_
+
 ===== Description
 
 The PMHACCSU.W.H0 instruction multiplies each signed 32-bit word of `rs1` by the
@@ -26437,6 +28653,10 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 
 X[rd] = d1 @ d0
 ----
+
+===== Mnemonic
+
+pmhaccsu.w.h1 _rd_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26493,6 +28713,10 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwmul.b _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWMUL.B (RV32 only) performs packed widening signed multiplication of four 8-bit
@@ -26537,6 +28761,10 @@ if (rdp != 0):
     X[2*rdp]   = d[31:0]
     X[2*rdp+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+pwmulsu.b _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26591,6 +28819,10 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pwmulu.b _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWMULU.B (RV32 only) performs packed widening unsigned multiplication of four
@@ -26638,6 +28870,10 @@ if (rd_p != 0):
     X[rd_p*2+1] = d_w1[31:0]
 ----
 
+===== Mnemonic
+
+pwmul.h _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWMUL.H (RV32 only) performs packed widening signed multiplication of two 16-bit
@@ -26680,6 +28916,10 @@ if (rdp != 0):
     X[2*rdp]   = d0
     X[2*rdp+1] = d1
 ----
+
+===== Mnemonic
+
+pwmulsu.h _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26732,6 +28972,10 @@ if (rd_p != 0):
     X[rd_p*2+1] = d_w1[31:0]
 ----
 
+===== Mnemonic
+
+pwmulu.h _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 PWMULU.H (RV32 only) performs packed widening unsigned multiplication of two
@@ -26774,6 +29018,10 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+wmul _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WMUL (RV32 only) performs a widening signed multiplication of the full 32-bit
@@ -26813,6 +29061,10 @@ if (rdp != 0):
     X[2*rdp]   = p[31:0]
     X[2*rdp+1] = p[63:32]
 ----
+
+===== Mnemonic
+
+wmulsu _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26861,6 +29113,10 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+wmulu _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WMULU (RV32 only) performs a widening unsigned multiplication of the full 32-bit
@@ -26908,6 +29164,10 @@ if (rdp != 0):
     X[2*rdp]   = acc0
     X[2*rdp+1] = acc1
 ----
+
+===== Mnemonic
+
+pwmacc.h _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -26960,6 +29220,10 @@ if (rdp != 0):
     X[2*rdp+1] = acc1
 ----
 
+===== Mnemonic
+
+pwmaccsu.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 The PWMACCSU.H instruction performs signed×unsigned halfword multiplications
@@ -27011,6 +29275,10 @@ if (rdp != 0):
     X[2*rdp+1] = acc1
 ----
 
+===== Mnemonic
+
+pwmaccu.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 The PWMACCU.H instruction multiplies corresponding unsigned 16-bit halfwords of
@@ -27061,6 +29329,10 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+wmacc _rd_p_, _rs1_, _rs2_
+
 ===== Description
 
 WMACC (RV32 only) performs a widening signed multiply-accumulate. It multiplies
@@ -27103,6 +29375,10 @@ if (rdp != 0):
     X[2*rdp]   = acc[31:0]
     X[2*rdp+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+wmaccsu _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27153,6 +29429,10 @@ if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+wmaccu _rd_p_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27207,6 +29487,10 @@ if (rdp != 0):
     X[2*rdp]   = acc[31:0]
     X[2*rdp+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+pmqwacc.h _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27264,6 +29548,10 @@ if (rdp != 0):
     X[2*rdp+1] = acc[63:32]
 ----
 
+===== Mnemonic
+
+pmqrwacc.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 PMQRWACC.H is the rounded form of PMQWACC.H. It adds a rounding bias of 2^14 to
@@ -27314,6 +29602,10 @@ if (rdp != 0):
     X[2*rdp]   = acc[31:0]
     X[2*rdp+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+mqwacc _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27366,6 +29658,10 @@ if (rdp != 0):
     X[2*rdp]   = acc[31:0]
     X[2*rdp+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+mqrwacc _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27420,6 +29716,10 @@ if (rdp != 0):
     X[2*rdp+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pm2wadd.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 PM2WADD.H multiplies the two signed 16-bit halfwords of `rs1` and `rs2`
@@ -27469,6 +29769,10 @@ if (rdp != 0):
     X[2*rdp+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pm2waddsu.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 PM2WADDSU.H multiplies each signed 16-bit halfword of `rs1` by the corresponding
@@ -27514,6 +29818,10 @@ if (rdp != 0):
     X[2*rdp]   = acc[31:0]
     X[2*rdp+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+pm2waddasu.h _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27564,6 +29872,10 @@ if (rdp != 0):
     X[2*rdp+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pm2waddu.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 PM2WADDU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and `rs2`,
@@ -27609,6 +29921,10 @@ if (rdp != 0):
     X[2*rdp]   = acc[31:0]
     X[2*rdp+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+pm2waddau.h _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27659,6 +29975,10 @@ if (rdp != 0):
     X[2*rdp+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pm2wadd.hx _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 PM2WADD.HX multiplies the low halfword of `rs1` by the high halfword of `rs2` and
@@ -27704,6 +30024,10 @@ if (rdp != 0):
     X[2*rdp+1] = d[63:32]
 ----
 
+===== Mnemonic
+
+pm2wsub.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 PM2WSUB.H multiplies corresponding signed halfwords of `rs1` and `rs2` and
@@ -27747,6 +30071,10 @@ if (rdp != 0):
     X[2*rdp]   = d[31:0]
     X[2*rdp+1] = d[63:32]
 ----
+
+===== Mnemonic
+
+pm2wsub.hx _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27797,6 +30125,10 @@ if (rdp != 0):
     X[2*rdp+1] = acc[63:32]
 ----
 
+===== Mnemonic
+
+pm2wadda.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 PM2WADDA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`
@@ -27845,6 +30177,10 @@ if (rdp != 0):
     X[2*rdp]   = acc[31:0]
     X[2*rdp+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+pm2wadda.hx _rdp_, _rs1_, _rs2_
 
 ===== Description
 
@@ -27895,6 +30231,10 @@ if (rdp != 0):
     X[2*rdp+1] = acc[63:32]
 ----
 
+===== Mnemonic
+
+pm2wsuba.h _rdp_, _rs1_, _rs2_
+
 ===== Description
 
 PM2WSUBA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`,
@@ -27942,6 +30282,10 @@ if (rdp != 0):
     X[2*rdp]   = acc[31:0]
     X[2*rdp+1] = acc[63:32]
 ----
+
+===== Mnemonic
+
+pm2wsuba.hx _rdp_, _rs1_, _rs2_
 
 ===== Description
 


### PR DESCRIPTION
The purpose of this commit is specify the syntax for the instruction, and B-extension in riscv-isa-manual having this, so adding this could make us integrate the instruction into the manual more smoothly.