### PR TITLE
Removing useless text

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -13978,7 +13978,7 @@ numbers. If any result overflows the signed 32-bit range, it is saturated and th
 
 ===== Encoding
 
-PPAIRE.B is encoded in the OP-32 major opcode with packed-byte pairing. :contentReference[oaicite:0]{index=0}
+PPAIRE.B is encoded in the OP-32 major opcode with packed-byte pairing.
 
 [wavedrom, ,svg]
 ....
@@ -14072,7 +14072,7 @@ instruction is an alias for PACK.
 
 ===== Encoding
 
-PPAIREO.B is encoded in the OP-32 major opcode with packed-byte pairing. :contentReference[oaicite:1]{index=1}
+PPAIREO.B is encoded in the OP-32 major opcode with packed-byte pairing.
 
 [wavedrom, ,svg]
 ....
@@ -14209,7 +14209,7 @@ comes from the odd position of `rs2`. Available only in RV64.
 
 ===== Encoding
 
-PPAIROE.B is encoded in the OP-32 major opcode with packed-byte pairing. :contentReference[oaicite:2]{index=2}
+PPAIROE.B is encoded in the OP-32 major opcode with packed-byte pairing.
 
 [wavedrom, ,svg]
 ....
@@ -14346,7 +14346,7 @@ comes from the even position of `rs2`. Available only in RV64.
 
 ===== Encoding
 
-PPAIRO.B is encoded in the OP-32 major opcode with packed-byte pairing. :contentReference[oaicite:3]{index=3}
+PPAIRO.B is encoded in the OP-32 major opcode with packed-byte pairing.
 
 [wavedrom, ,svg]
 ....
@@ -14950,7 +14950,7 @@ numbers. Available only in RV32.
 
 ===== Encoding
 
-ZIP8P is encoded in the OP-32 major opcode and is available only in RV64. :contentReference[oaicite:5]{index=5}
+ZIP8P is encoded in the OP-32 major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -14992,7 +14992,7 @@ for each byte position, the corresponding byte from `rs2` is placed above the by
 
 ===== Encoding
 
-ZIP8HP is encoded in the OP-32 major opcode and is available only in RV64. :contentReference[oaicite:1]{index=1}
+ZIP8HP is encoded in the OP-32 major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -15034,7 +15034,7 @@ The ZIP8HP instruction interleaves bytes from the high 32-bit halves of `rs2` an
 
 ===== Encoding
 
-UNZIP8P is encoded in the OP-32 major opcode and is available only in RV64. :contentReference[oaicite:2]{index=2}
+UNZIP8P is encoded in the OP-32 major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -15076,7 +15076,7 @@ result containing selected byte lanes from each source.
 
 ===== Encoding
 
-UNZIP8HP is encoded in the OP-32 major opcode and is available only in RV64. :contentReference[oaicite:3]{index=3}
+UNZIP8HP is encoded in the OP-32 major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -15118,7 +15118,7 @@ high-part byte selection pattern and forms a 64-bit result.
 
 ===== Encoding
 
-ZIP16P is encoded in the OP-32 major opcode and is available only in RV64. :contentReference[oaicite:4]{index=4}
+ZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -15158,7 +15158,7 @@ The ZIP16P instruction interleaves 16-bit chunks from `rs2` and `rs1` to form a
 
 ===== Encoding
 
-ZIP16HP is encoded in the OP-32 major opcode and is available only in RV64. :contentReference[oaicite:5]{index=5}
+ZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -15198,7 +15198,7 @@ The ZIP16HP instruction interleaves 16-bit chunks from the high 32-bit halves of
 
 ===== Encoding
 
-UNZIP16P is encoded in the OP-32 major opcode and is available only in RV64. :contentReference[oaicite:6]{index=6}
+UNZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -15238,7 +15238,7 @@ forms a 64-bit result.
 
 ===== Encoding
 
-UNZIP16HP is encoded in the OP-32 major opcode and is available only in RV64. :contentReference[oaicite:7]{index=7}
+UNZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -15278,7 +15278,7 @@ of `rs2` and `rs1` and forms a 64-bit result.
 
 ===== Encoding
 
-REV16 is a scalar instruction encoded in the OP-IMM major opcode and is available only in RV64. :contentReference[oaicite:4]{index=4}
+REV16 is a scalar instruction encoded in the OP-IMM major opcode and is available only in RV64.
 
 [wavedrom, ,svg]
 ....
@@ -16206,7 +16206,6 @@ of the destination register pair.
 
 PWADD.H is available only in RV32. It writes results to an even-odd register
 pair specified by `rd_p`.
-:contentReference[oaicite:3]{index=3}
 
 [wavedrom, ,svg]
 ....
@@ -16251,7 +16250,6 @@ and writes two 32-bit results to the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 PWADDA.H is available only in RV32 and accumulates into the destination register pair.
-:contentReference[oaicite:4]{index=4}
 
 [wavedrom, ,svg]
 ....
@@ -16300,7 +16298,6 @@ PWADDA.H performs PWADD.H and adds each 32-bit result into the corresponding
 ===== Encoding
 
 PWADDU.H is available only in RV32.
-:contentReference[oaicite:5]{index=5}
 
 [wavedrom, ,svg]
 ....
@@ -16345,7 +16342,6 @@ and writes two 32-bit results to the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 PWADDAU.H is available only in RV32 and accumulates into the destination register pair.
-:contentReference[oaicite:6]{index=6}
 
 [wavedrom, ,svg]
 ....
@@ -16394,7 +16390,6 @@ destination register pair.
 ===== Encoding
 
 PWSUB.H is available only in RV32.
-:contentReference[oaicite:7]{index=7}
 
 [wavedrom, ,svg]
 ....
@@ -16439,7 +16434,6 @@ writes two 32-bit results to the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 PWSUBA.H is available only in RV32 and accumulates into the destination register pair.
-:contentReference[oaicite:8]{index=8}
 
 [wavedrom, ,svg]
 ....
@@ -16488,7 +16482,6 @@ destination register pair.
 ===== Encoding
 
 PWSUBU.H is available only in RV32.
-:contentReference[oaicite:9]{index=9}
 
 [wavedrom, ,svg]
 ....
@@ -16534,7 +16527,6 @@ when `rd_p != 0`.
 ===== Encoding
 
 PWSUBAU.H is available only in RV32 and accumulates into the destination register pair.
-:contentReference[oaicite:10]{index=10}
 
 [wavedrom, ,svg]
 ....
@@ -16583,7 +16575,6 @@ destination register pair.
 ===== Encoding
 
 WADD is available only in RV32 and writes a 64-bit result to register pair `rd_p`.
-:contentReference[oaicite:16]{index=16}
 
 [wavedrom, ,svg]
 ....
@@ -16625,7 +16616,6 @@ destination register pair when `rd_p != 0`.
 ===== Encoding
 
 WADDA is available only in RV32 and accumulates into the destination register pair.
-:contentReference[oaicite:17]{index=17}
 
 [wavedrom, ,svg]
 ....
@@ -16668,7 +16658,6 @@ register pair.
 ===== Encoding
 
 WADDU is available only in RV32.
-:contentReference[oaicite:18]{index=18}
 
 [wavedrom, ,svg]
 ....
@@ -16710,7 +16699,6 @@ the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 WADDAU is available only in RV32 and accumulates into the destination register pair.
-:contentReference[oaicite:19]{index=19}
 
 [wavedrom, ,svg]
 ....
@@ -16753,7 +16741,6 @@ register pair.
 ===== Encoding
 
 WSUB is available only in RV32.
-:contentReference[oaicite:20]{index=20}
 
 [wavedrom, ,svg]
 ....
@@ -16795,7 +16782,6 @@ difference to the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 WSUBA is available only in RV32 and accumulates into the destination register pair.
-:contentReference[oaicite:21]{index=21}
 
 [wavedrom, ,svg]
 ....
@@ -16838,7 +16824,6 @@ register pair.
 ===== Encoding
 
 WSUBU is available only in RV32.
-:contentReference[oaicite:22]{index=22}
 
 [wavedrom, ,svg]
 ....
@@ -16880,7 +16865,6 @@ difference to the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 WSUBAU is available only in RV32 and accumulates into the destination register pair.
-:contentReference[oaicite:23]{index=23}
 
 [wavedrom, ,svg]
 ....
@@ -16927,7 +16911,6 @@ register pair.
 
 PWSLLI.B is available only in RV32. The shift amount is encoded in the `w_uimm`
 field (element width plus immediate). The destination is a register pair `rd_p`.
-:contentReference[oaicite:3]{index=3}
 
 [wavedrom, ,svg]
 ....
@@ -16974,7 +16957,6 @@ shifts left by an immediate amount, producing four 16-bit results.
 ===== Encoding
 
 PWSLL.BS is available only in RV32. The shift amount is taken from `rs2`.
-:contentReference[oaicite:4]{index=4}
 
 [wavedrom, ,svg]
 ....
@@ -17022,7 +17004,6 @@ shifts left by the amount in `rs2` (low 5 bits), producing four 16-bit results.
 ===== Encoding
 
 PWSLAI.B is available only in RV32. The shift amount is encoded in `w_uimm`.
-:contentReference[oaicite:5]{index=5}
 
 [wavedrom, ,svg]
 ....
@@ -17069,7 +17050,6 @@ shifts left by an immediate amount, producing four 16-bit results.
 ===== Encoding
 
 PWSLA.BS is available only in RV32. The shift amount is taken from `rs2`.
-:contentReference[oaicite:6]{index=6}
 
 [wavedrom, ,svg]
 ....
@@ -17117,7 +17097,6 @@ shifts left by the amount in `rs2` (low 5 bits), producing four 16-bit results.
 ===== Encoding
 
 PWSLLI.H is available only in RV32. The shift amount is encoded in `w_uimm`.
-:contentReference[oaicite:11]{index=11}
 
 [wavedrom, ,svg]
 ....
@@ -17163,7 +17142,6 @@ shifts left by an immediate amount, producing two 32-bit results.
 ===== Encoding
 
 PWSLL.HS is available only in RV32. The shift amount is taken from `rs2`.
-:contentReference[oaicite:12]{index=12}
 
 [wavedrom, ,svg]
 ....
@@ -17210,7 +17188,6 @@ shifts left by the amount in `rs2` (low 5 bits).
 ===== Encoding
 
 PWSLAI.H is available only in RV32. The shift amount is encoded in `w_uimm`.
-:contentReference[oaicite:13]{index=13}
 
 [wavedrom, ,svg]
 ....
@@ -17256,7 +17233,6 @@ shifts left by an immediate amount.
 ===== Encoding
 
 PWSLA.HS is available only in RV32. The shift amount is taken from `rs2`.
-:contentReference[oaicite:14]{index=14}
 
 [wavedrom, ,svg]
 ....
@@ -17303,7 +17279,6 @@ shifts left by the amount in `rs2` (low 5 bits).
 ===== Encoding
 
 WSLL is available only in RV32. The shift amount is taken from `rs2`.
-:contentReference[oaicite:25]{index=25}
 
 [wavedrom, ,svg]
 ....
@@ -17347,7 +17322,6 @@ and writes the 64-bit result to the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 WSLLI is available only in RV32. The shift amount is encoded in `w_uimm`.
-:contentReference[oaicite:24]{index=24}
 
 [wavedrom, ,svg]
 ....
@@ -17390,7 +17364,6 @@ writes the 64-bit result to the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 WSLA is available only in RV32. The shift amount is taken from `rs2`.
-:contentReference[oaicite:27]{index=27}
 
 [wavedrom, ,svg]
 ....
@@ -17434,7 +17407,6 @@ and writes the 64-bit result to the destination register pair when `rd_p != 0`.
 ===== Encoding
 
 WSLAI is available only in RV32. The shift amount is encoded in `w_uimm`.
-:contentReference[oaicite:26]{index=26}
 
 [wavedrom, ,svg]
 ....
@@ -17482,7 +17454,6 @@ writes the 64-bit result to the destination register pair when `rd_p != 0`.
 WZIP8P is available only in RV32. It writes its 64-bit result to the even-odd
 register pair specified by `rd_p` (no write occurs if `rd_p = 0`).
 It is encoded in the RV32 register-pair OP-IMM-32 format with `f=111` and `w=10`.
-:contentReference[oaicite:1]{index=1}
 
 [wavedrom, ,svg]
 ....
@@ -17533,7 +17504,6 @@ interleaving of bytes [31:16].
 WZIP16P is available only in RV32. It writes its 64-bit result to the even-odd
 register pair specified by `rd_p` (no write occurs if `rd_p = 0`).
 It is encoded in the RV32 register-pair OP-IMM-32 format with `f=111` and `w=11`.
-:contentReference[oaicite:2]{index=2}
 
 [wavedrom, ,svg]
 ....
@@ -17589,7 +17559,6 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
 
 PREDSUM.DBS is encoded in the OP-IMM-32 major opcode with `func3=100`, bit 28
 set to 1, and `rs1_p` selecting the source register pair.
-:contentReference[oaicite:2]{index=2}
 
 [wavedrom, ,svg]
 ....
@@ -17638,7 +17607,6 @@ register pair `rs1_p` to the signed scalar value in `rs2`, and writes the low
 PREDSUMU.DBS is available only in RV32. It reads a 64-bit packed source from the
 even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
 in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
-:contentReference[oaicite:3]{index=3}
 
 [wavedrom, ,svg]
 ....
@@ -17687,7 +17655,6 @@ the low 32 bits of the resulting sum to `rd`.
 PREDSUM.DHS is available only in RV32. It reads a 64-bit packed source from the
 even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
 in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
-:contentReference[oaicite:4]{index=4}
 
 [wavedrom, ,svg]
 ....
@@ -17736,7 +17703,6 @@ register pair `rs1_p` to the signed scalar value in `rs2`, and writes the low
 PREDSUMU.DHS is available only in RV32. It reads a 64-bit packed source from the
 even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
 in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
-:contentReference[oaicite:5]{index=5}
 
 [wavedrom, ,svg]
 ....


### PR DESCRIPTION
It seems that ChatGPT/OpenAI was used heavily in some places of the document. This commit removes "references" that it inserted.

It might be a good idea to thoroughly review the text and make sure that there are no mistakes.