### PR TITLE
Correct encodings

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -5473,7 +5473,8 @@ register-pair format. Available only in RV32.
     { bits: 4, name: 'rs1_p' },
     { bits: 1, name: 0x1 },
     { bits: 4, name: 'rs2_p' },
-    { bits: 3, name: '0,w=00' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x0 },
     { bits: 3, name: 0x2, attr: ['PSH1ADD.DH'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -5534,7 +5535,8 @@ register-pair format. Available only in RV32.
     { bits: 4, name: 'rs1_p' },
     { bits: 1, name: 0x1 },
     { bits: 4, name: 'rs2_p' },
-    { bits: 3, name: '0,w=01' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 3, name: 0x2, attr: ['PSH1ADD.DW'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -5588,7 +5590,8 @@ register-pair format. Available only in RV32.
     { bits: 4, name: 'rs1_p' },
     { bits: 1, name: 0x1 },
     { bits: 4, name: 'rs2_p' },
-    { bits: 3, name: '0,w=00' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x0 },
     { bits: 3, name: 0x3, attr: ['PSSH1SADD.DH'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -5669,7 +5672,8 @@ register-pair format. Available only in RV32.
     { bits: 4, name: 'rs1_p' },
     { bits: 1, name: 0x1 },
     { bits: 4, name: 'rs2_p' },
-    { bits: 3, name: '0,w=01' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 3, name: 0x3, attr: ['PSSH1SADD.DW'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -10253,7 +10257,7 @@ PSEXT.W.B is available only in RV64.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 0x4, attr: ['PSEXT.W.B'] },
-    { bits: 2, name: 0x2 },
+    { bits: 2, name: 0x1 },
     { bits: 5, name: 0x1c },
 ]}
 ....
@@ -10290,7 +10294,7 @@ PSEXT.W.H is available only in RV64.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 0x5, attr: ['PSEXT.W.H'] },
-    { bits: 2, name: 0x2 },
+    { bits: 2, name: 0x1 },
     { bits: 5, name: 0x1c },
 ]}
 ....
@@ -13353,12 +13357,12 @@ PSSHA.WS is available only in RV64.
 [wavedrom, ,svg]
 ....
 {reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits: 5, name: 'rd' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
+    { bits: 2, name: 0x1 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x6, attr: ['PSSHA.WS'] },
     { bits: 1, name: 0x1 },
@@ -13460,12 +13464,12 @@ PSSHAR.WS is available only in RV64.
 [wavedrom, ,svg]
 ....
 {reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits: 5, name: 'rd' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
+    { bits: 2, name: 0x1 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x7, attr: ['PSSHAR.WS'] },
     { bits: 1, name: 0x1 },
@@ -13864,7 +13868,7 @@ SHA is encoded in the OP-32 major opcode and is available only in RV64.
 [wavedrom, ,svg]
 ....
 {reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits: 5, name: 'rd' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -13917,7 +13921,7 @@ SHAR is encoded in the OP-32 major opcode and is available only in RV64.
 [wavedrom, ,svg]
 ....
 {reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits: 5, name: 'rd' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17453,7 +17457,7 @@ field. The destination is a register pair `rd_p`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17501,7 +17505,7 @@ PWSLL.BS is available only in RV32. The shift amount is taken from `rs2`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17549,7 +17553,7 @@ PWSLAI.B is available only in RV32. The shift amount is encoded in `uimm4`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17597,7 +17601,7 @@ PWSLA.BS is available only in RV32. The shift amount is taken from `rs2`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17645,7 +17649,7 @@ PWSLLI.H is available only in RV32. The shift amount is encoded in `uimm5`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17692,7 +17696,7 @@ PWSLL.HS is available only in RV32. The shift amount is taken from `rs2`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17739,7 +17743,7 @@ PWSLAI.H is available only in RV32. The shift amount is encoded in `uimm5`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17786,7 +17790,7 @@ PWSLA.HS is available only in RV32. The shift amount is taken from `rs2`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17833,12 +17837,12 @@ WSLL is available only in RV32. The shift amount is taken from `rs2`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
+    { bits: 2, name: 0x3 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x0, attr: ['WSLL'] },
     { bits: 1, name: 0x0 },
@@ -17877,7 +17881,7 @@ WSLLI is available only in RV32. The shift amount is encoded in `uimm6`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -17921,12 +17925,12 @@ WSLA is available only in RV32. The shift amount is taken from `rs2`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
+    { bits: 2, name: 0x3 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x4, attr: ['WSLA'] },
     { bits: 1, name: 0x0 },
@@ -17965,7 +17969,7 @@ WSLAI is available only in RV32. The shift amount is encoded in `uimm6`.
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
@@ -18014,12 +18018,12 @@ It is encoded in the RV32 register-pair OP-IMM-32 format with `f=111` and `w=10`
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
+    { bits: 2, name: 0x0 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x7, attr: ['WZIP8P'] },
     { bits: 1, name: 0x0 },
@@ -18065,12 +18069,12 @@ It is encoded in the RV32 register-pair OP-IMM-32 format with `f=111` and `w=11`
 ....
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
     { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
+    { bits: 2, name: 0x1 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x7, attr: ['WZIP16P'] },
     { bits: 1, name: 0x0 },
@@ -18125,9 +18129,10 @@ set to 1, and `rs1_p` selecting the source register pair.
     { bits: 3, name: 0x4 },
     { bits: 4, name: 'rs1_p' },
     { bits: 6, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x2 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x1, attr: ['PREDSUM.DBS'] },
+    { bits: 1, name: 0x0 },
 ]}
 ....
 
@@ -18174,9 +18179,10 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
     { bits: 3, name: 0x4 },
     { bits: 4, name: 'rs1_p' },
     { bits: 6, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x2 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x3, attr: ['PREDSUMU.DBS'] },
+    { bits: 1, name: 0x0 },
 ]}
 ....
 
@@ -18226,6 +18232,7 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
     { bits: 2, name: 0x0 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x1, attr: ['PREDSUM.DHS'] },
+    { bits: 1, name: 0x0 },
 ]}
 ....
 
@@ -18275,6 +18282,7 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
     { bits: 2, name: 0x0 },
     { bits: 1, name: 0x1 },
     { bits: 3, name: 0x3, attr: ['PREDSUMU.DHS'] },
+    { bits: 1, name: 0x0 },
 ]}
 ....
 
@@ -21015,7 +21023,7 @@ PMULHSU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x4, attr: ['PMULHSU.W'] },
+    { bits: 4, name: 0x8, attr: ['PMULHSU.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -21062,7 +21070,7 @@ with rounding.
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x4, attr: ['PMULHRSU.W'] },
+    { bits: 4, name: 0x8, attr: ['PMULHRSU.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -22575,7 +22583,7 @@ instruction operating on the low halfwords of `rs1` and `rs2`.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x0 },
     { bits: 4, name: 0xd, attr: ['MQACC.H00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -22622,7 +22630,7 @@ instruction operating on the low halfword of `rs1` and the high halfword of
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x0 },
     { bits: 4, name: 0xf, attr: ['MQACC.H01'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -22668,7 +22676,7 @@ instruction operating on the high halfwords of `rs1` and `rs2`.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x0 },
     { bits: 4, name: 0xf, attr: ['MQACC.H11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -22714,7 +22722,7 @@ accumulate instruction operating on the low halfwords of `rs1` and `rs2`.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
+    { bits: 2, name: 0x2 },
     { bits: 4, name: 0xd, attr: ['MQRACC.H00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -22760,7 +22768,7 @@ accumulate instruction operating on `rs1[15:0]` and `rs2[31:16]`.
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
+    { bits: 2, name: 0x2 },
     { bits: 4, name: 0xf, attr: ['MQRACC.H01'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -22806,7 +22814,7 @@ accumulate instruction operating on the high halfwords of `rs1` and `rs2`.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
+    { bits: 2, name: 0x2 },
     { bits: 4, name: 0xf, attr: ['MQRACC.H11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -22852,7 +22860,7 @@ multiply-accumulate instruction producing packed 32-bit elements.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x0 },
     { bits: 4, name: 0xd, attr: ['PMQACC.W.H00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -22905,7 +22913,7 @@ multiply-accumulate instruction producing packed 32-bit elements.
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x0 },
     { bits: 4, name: 0xf, attr: ['PMQACC.W.H01'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -22954,7 +22962,7 @@ multiply-accumulate instruction producing packed 32-bit elements.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x0 },
     { bits: 4, name: 0xf, attr: ['PMQACC.W.H11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -23003,7 +23011,7 @@ multiply-accumulate instruction producing packed 32-bit elements.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
+    { bits: 2, name: 0x2 },
     { bits: 4, name: 0xd, attr: ['PMQRACC.W.H00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -23056,7 +23064,7 @@ multiply-accumulate instruction producing packed 32-bit elements.
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
+    { bits: 2, name: 0x2 },
     { bits: 4, name: 0xf, attr: ['PMQRACC.W.H01'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -23109,7 +23117,7 @@ multiply-accumulate instruction producing packed 32-bit elements.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
+    { bits: 2, name: 0x2 },
     { bits: 4, name: 0xf, attr: ['PMQRACC.W.H11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -23657,11 +23665,11 @@ that sums two word products to produce a scalar XLEN result.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
+    { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xd, attr: ['PMQ2ADD.W'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PMQ2ADD.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -23704,11 +23712,11 @@ PMQ2ADD.W.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
+    { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xd, attr: ['PMQ2ADDA.W'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['PMQ2ADDA.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -23752,11 +23760,11 @@ PMQR2ADD.W is encoded in the OP-32 major opcode as a rounded form of PMQ2ADD.W.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
+    { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xf, attr: ['PMQR2ADD.W'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['PMQR2ADD.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -23803,11 +23811,11 @@ PMQR2ADD.W.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
+    { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xf, attr: ['PMQR2ADDA.W'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x7, attr: ['PMQR2ADDA.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -25020,7 +25028,7 @@ MULSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0xc, attr: ['MULSU.W00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -25060,7 +25068,7 @@ MULSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0xe, attr: ['MULSU.W11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -25100,7 +25108,7 @@ MULU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x4, attr: ['MULU.W00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -25140,7 +25148,7 @@ MULU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
     { bits: 3, name: 0x1 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x6, attr: ['MULU.W01'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -25180,7 +25188,7 @@ MULU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x6, attr: ['MULU.W11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -25968,7 +25976,7 @@ accumulate (signed×signed) producing a 64-bit result.
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x1, attr: ['MACC.W00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -26012,7 +26020,7 @@ accumulate (signed×signed) producing a 64-bit result.
     { bits: 3, name: 0x1 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x3, attr: ['MACC.W01'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -26056,7 +26064,7 @@ accumulate (signed×signed) producing a 64-bit result.
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x3, attr: ['MACC.W11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -26100,7 +26108,7 @@ accumulate (signed×unsigned) producing a 64-bit result.
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0xd, attr: ['MACCSU.W00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -26144,7 +26152,7 @@ accumulate (signed×unsigned) producing a 64-bit result.
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0xf, attr: ['MACCSU.W11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -26188,7 +26196,7 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x5, attr: ['MACCU.W00'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -26232,7 +26240,7 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
     { bits: 3, name: 0x1 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x7, attr: ['MACCU.W01'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -26276,7 +26284,7 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x7, attr: ['MACCU.W11'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -28754,12 +28762,11 @@ halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['MULHSU.H0'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x4, attr: ['MULHSU.H0'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -28798,12 +28805,11 @@ halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['MULHSU.H1'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['MULHSU.H1'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -28841,12 +28847,11 @@ MULH.H0 (signed×signed), producing the high 32 bits of a 48-bit product.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['MHACC.H0'] },
+    { bits: 4, name: 0x5, attr: ['MHACC.H0'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -28888,12 +28893,11 @@ MULH.H1 (signed×signed), producing the high 32 bits of a 48-bit product.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['MHACC.H1'] },
+    { bits: 4, name: 0x7, attr: ['MHACC.H1'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -28935,12 +28939,11 @@ MULHSU.H0 (signed×unsigned), producing the high 32 bits of a 48-bit product.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['MHACCSU.H0'] },
+    { bits: 4, name: 0x5, attr: ['MHACCSU.H0'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -28982,12 +28985,11 @@ MULHSU.H1 (signed×unsigned), producing the high 32 bits of a 48-bit product.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['MHACCSU.H1'] },
+    { bits: 4, name: 0x7, attr: ['MHACCSU.H1'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -29120,11 +29122,11 @@ of each 48-bit product.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xc, attr: ['PMULHSU.W.H0'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x4, attr: ['PMULHSU.W.H0'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -29169,11 +29171,11 @@ of each 48-bit product.
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xc, attr: ['PMULHSU.W.H1'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['PMULHSU.W.H1'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
@@ -29222,7 +29224,7 @@ halfword operands selected from `rs2` (H0 selection per word), producing packed
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
+    { bits: 2, name: 0x1 },
     { bits: 4, name: 0x5, attr: ['PMHACC.W.H0'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -29279,7 +29281,7 @@ halfword operands selected from `rs2` (H1 selection per word), producing packed
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
+    { bits: 2, name: 0x1 },
     { bits: 4, name: 0x7, attr: ['PMHACC.W.H1'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -29336,7 +29338,7 @@ halfword operands selected from `rs2` (H0 selection per word), producing packed
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x5, attr: ['PMHACCSU.W.H0'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -29393,7 +29395,7 @@ halfword operands selected from `rs2` (H1 selection per word), producing packed
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x7, attr: ['PMHACCSU.W.H1'] },
     { bits: 1, name: 0x1 },
 ]}
@@ -30242,12 +30244,12 @@ select the destination register pair `{X[2*rd_p+1], X[2*rd_p]}`.
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits: 1, name: 0x1 },
-    { bits: 5, name: 'rd_p' },
+    { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x0 },
-    { bits: 3, name: 0xf, attr: ['PMQWACC.H'] },
+    { bits: 4, name: 0xf, attr: ['PMQWACC.H'] },
     { bits: 1, name: 0x0 },
 ]}
 ....
@@ -30306,12 +30308,12 @@ but uses the rounded variant.
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits: 1, name: 0x1 },
-    { bits: 5, name: 'rd_p' },
+    { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x2 },
-    { bits: 3, name: 0xf, attr: ['PMQRWACC.H'] },
+    { bits: 4, name: 0xf, attr: ['PMQRWACC.H'] },
     { bits: 1, name: 0x0 },
 ]}
 ....
@@ -30366,12 +30368,12 @@ MQWACC is encoded in a register-pair (rd_p) OP-IMM-32 format and accumulates int
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits: 1, name: 0x1 },
-    { bits: 5, name: 'rd_p' },
+    { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x1 },
-    { bits: 3, name: 0xf, attr: ['MQWACC'] },
+    { bits: 4, name: 0xf, attr: ['MQWACC'] },
     { bits: 1, name: 0x0 },
 ]}
 ....
@@ -30424,12 +30426,12 @@ uses the rounded variant.
 {reg:[
     { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
     { bits: 1, name: 0x1 },
-    { bits: 5, name: 'rd_p' },
+    { bits: 4, name: 'rd_p' },
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x3 },
-    { bits: 3, name: 0xf, attr: ['MQRWACC'] },
+    { bits: 4, name: 0xf, attr: ['MQRWACC'] },
     { bits: 1, name: 0x0 },
 ]}
 ....
@@ -30489,7 +30491,7 @@ sum of two halfword products and writes it to the register pair
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x0, attr: ['PM2WADD.H'] },
     { bits: 1, name: 0x0 },
 ]}
@@ -30544,7 +30546,7 @@ pair selected by `rd_p` when `rd_p != 0`.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0xc, attr: ['PM2WADDSU.H'] },
     { bits: 1, name: 0x0 },
 ]}
@@ -30593,7 +30595,7 @@ form of PM2WADDSU.H.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0xd, attr: ['PM2WADDASU.H'] },
     { bits: 1, name: 0x0 },
 ]}
@@ -30651,7 +30653,7 @@ register pair selected by `rd_p` when `rd_p != 0`.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x4, attr: ['PM2WADDU.H'] },
     { bits: 1, name: 0x0 },
 ]}
@@ -30700,7 +30702,7 @@ form of PM2WADDU.H.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x5, attr: ['PM2WADDAU.H'] },
     { bits: 1, name: 0x0 },
 ]}
@@ -30758,7 +30760,7 @@ selected by `rd_p` when `rd_p != 0`.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
+    { bits: 2, name: 0x3 },
     { bits: 4, name: 0x2, attr: ['PM2WADD.HX'] },
     { bits: 1, name: 0x0 },
 ]}
@@ -30809,8 +30811,8 @@ the register pair selected by `rd_p` when `rd_p != 0`.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x1, attr: ['PM2WSUB.H'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x8, attr: ['PM2WSUB.H'] },
     { bits: 1, name: 0x0 },
 ]}
 ....
@@ -30859,8 +30861,8 @@ register pair selected by `rd_p` when `rd_p != 0`.
     { bits: 3, name: 0x2 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x3, attr: ['PM2WSUB.HX'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xa, attr: ['PM2WSUB.HX'] },
     { bits: 1, name: 0x0 },
 ]}
 ....


### PR DESCRIPTION
I asked AI to write a script to compare the LLVM implementation which was based on https://www.jhauser.us/RISCV/ext-P/ to the adoc. I manually verified and fixed the mismatches.