### PR TITLE
Reorg the structure of instruction description

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -730,6 +730,10 @@ corresponding `rd+`, `rs1+`, or `rs2+` also denotes `x0`.
 
 ==== PLI.B
 
+===== Mnemonic
+
+pli.b _rd_, _imm8_
+
 ===== Encoding
 
 PLI.B is encoded in the OP-IMM-32 major opcode with an 8-bit immediate
@@ -746,6 +750,10 @@ and packed byte elements.
 ]}
 ....
 
+===== Description
+
+PLI.B (Packed Load Immediate, Byte) loads an 8-bit immediate into every
+byte element of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -756,17 +764,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pli.b _rd_, _imm8_
-
-===== Description
-
-PLI.B (Packed Load Immediate, Byte) loads an 8-bit immediate into every
-byte element of `rd`.
 
 <<<
 ==== PLI.H
+
+===== Mnemonic
+
+pli.h _rd_, _simm10_
 
 ===== Encoding
 
@@ -785,6 +789,10 @@ and packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PLI.H (Packed Load Immediate, Halfword) sign-extends a 10-bit signed immediate
+to 16 bits and replicates it into every halfword element of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -797,17 +805,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pli.h _rd_, _simm10_
-
-===== Description
-
-PLI.H (Packed Load Immediate, Halfword) sign-extends a 10-bit signed immediate
-to 16 bits and replicates it into every halfword element of `rd`.
 
 <<<
 ==== PLI.W (RV64)
+
+===== Mnemonic
+
+pli.w _rd_, _simm10_
 
 ===== Encoding
 
@@ -826,6 +830,11 @@ and packed word elements. This instruction exists only for RV64.
 ]}
 ....
 
+===== Description
+
+PLI.W (Packed Load Immediate, Word) sign-extends a 10-bit signed immediate
+to 32 bits and replicates it into every word element of `rd`. This instruction
+is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -838,18 +847,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pli.w _rd_, _simm10_
-
-===== Description
-
-PLI.W (Packed Load Immediate, Word) sign-extends a 10-bit signed immediate
-to 32 bits and replicates it into every word element of `rd`. This instruction
-is available only on RV64.
 
 <<<
 ==== PLUI.H
+
+===== Mnemonic
+
+plui.h _rd_, _simm10_
 
 ===== Encoding
 
@@ -868,6 +872,12 @@ loaded into the upper bits of each halfword element.
 ]}
 ....
 
+===== Description
+
+PLUI.H (Packed Load Upper Immediate, Halfword) loads a 10-bit signed immediate
+into the most-significant 10 bits of each 16-bit halfword element, with the
+lower 6 bits set to zero, and replicates the result into every halfword
+element of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -880,19 +890,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-plui.h _rd_, _simm10_
-
-===== Description
-
-PLUI.H (Packed Load Upper Immediate, Halfword) loads a 10-bit signed immediate
-into the most-significant 10 bits of each 16-bit halfword element, with the
-lower 6 bits set to zero, and replicates the result into every halfword
-element of `rd`.
 
 <<<
 ==== PLUI.W (RV64)
+
+===== Mnemonic
+
+plui.w _rd_, _simm10_
 
 ===== Encoding
 
@@ -912,6 +916,12 @@ only for RV64.
 ]}
 ....
 
+===== Description
+
+PLUI.W (Packed Load Upper Immediate, Word) loads a 10-bit signed immediate
+into the most-significant 10 bits of each 32-bit word element, with the
+lower 22 bits set to zero, and replicates the result into every word element
+of `rd`. This instruction is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -924,19 +934,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-plui.w _rd_, _simm10_
-
-===== Description
-
-PLUI.W (Packed Load Upper Immediate, Word) loads a 10-bit signed immediate
-into the most-significant 10 bits of each 32-bit word element, with the
-lower 22 bits set to zero, and replicates the result into every word element
-of `rd`. This instruction is available only on RV64.
 
 <<<
 ==== PLI.DB (RV32)
+
+===== Mnemonic
+
+pli.db _rd_p_, _imm8_
 
 ===== Encoding
 
@@ -956,6 +960,12 @@ only for RV32 and uses a register-pair destination `rd_p`.
 ]}
 ....
 
+===== Description
+
+PLI.DB (Packed Load Immediate, Double-wide Byte) loads an 8-bit immediate
+into every byte element of the register pair designated by `rd_p`. This is
+equivalent to performing PLI.B on both the even and odd registers of the
+pair. This instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -971,19 +981,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-pli.db _rd_p_, _imm8_
-
-===== Description
-
-PLI.DB (Packed Load Immediate, Double-wide Byte) loads an 8-bit immediate
-into every byte element of the register pair designated by `rd_p`. This is
-equivalent to performing PLI.B on both the even and odd registers of the
-pair. This instruction is available only on RV32.
 
 <<<
 ==== PLI.DH (RV32)
+
+===== Mnemonic
+
+pli.dh _rd_p_, _simm10_
 
 ===== Encoding
 
@@ -1004,6 +1008,13 @@ exists only for RV32 and uses a register-pair destination `rd_p`.
 ]}
 ....
 
+===== Description
+
+PLI.DH (Packed Load Immediate, Double-wide Halfword) sign-extends a 10-bit
+signed immediate to 16 bits and replicates it into every halfword element of
+the register pair designated by `rd_p`. This is equivalent to performing
+PLI.H on both the even and odd registers of the pair. This instruction is
+available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1021,20 +1032,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-pli.dh _rd_p_, _simm10_
-
-===== Description
-
-PLI.DH (Packed Load Immediate, Double-wide Halfword) sign-extends a 10-bit
-signed immediate to 16 bits and replicates it into every halfword element of
-the register pair designated by `rd_p`. This is equivalent to performing
-PLI.H on both the even and odd registers of the pair. This instruction is
-available only on RV32.
 
 <<<
 ==== PLUI.DH (RV32)
+
+===== Mnemonic
+
+plui.dh _rd_p_, _simm10_
 
 ===== Encoding
 
@@ -1056,6 +1060,14 @@ This instruction exists only for RV32 and uses a register-pair destination
 ]}
 ....
 
+===== Description
+
+PLUI.DH (Packed Load Upper Immediate, Double-wide Halfword) loads a 10-bit
+signed immediate into the most-significant 10 bits of each 16-bit halfword
+element, with the lower 6 bits set to zero, and replicates the result into
+every halfword element of the register pair designated by `rd_p`. This is
+equivalent to performing PLUI.H on both the even and odd registers of the
+pair. This instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1073,23 +1085,15 @@ if (rd_p != 0):
     X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-plui.dh _rd_p_, _simm10_
-
-===== Description
-
-PLUI.DH (Packed Load Upper Immediate, Double-wide Halfword) loads a 10-bit
-signed immediate into the most-significant 10 bits of each 16-bit halfword
-element, with the lower 6 bits set to zero, and replicates the result into
-every halfword element of the register pair designated by `rd_p`. This is
-equivalent to performing PLUI.H on both the even and odd registers of the
-pair. This instruction is available only on RV32.
 
 <<<
 === Basic Packed Add
 
 ==== PADD.B
+
+===== Mnemonic
+
+padd.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1109,6 +1113,10 @@ PADD.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PADD.B adds corresponding packed 8-bit elements of `rs1` and `rs2` and writes
+the packed byte results to `rd`. Each element addition wraps modulo 2^8.
 ===== Operation
 
 [source,pseudocode]
@@ -1124,17 +1132,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-padd.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PADD.B adds corresponding packed 8-bit elements of `rs1` and `rs2` and writes
-the packed byte results to `rd`. Each element addition wraps modulo 2^8.
 
 <<<
 ==== PADD.H
+
+===== Mnemonic
+
+padd.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1154,6 +1158,11 @@ PADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PADD.H adds corresponding packed 16-bit halfword elements of `rs1` and `rs2`
+and writes the packed halfword results to `rd`. Each element addition wraps
+modulo 2^16.
 ===== Operation
 
 [source,pseudocode]
@@ -1169,18 +1178,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-padd.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PADD.H adds corresponding packed 16-bit halfword elements of `rs1` and `rs2`
-and writes the packed halfword results to `rd`. Each element addition wraps
-modulo 2^16.
 
 <<<
 ==== PADD.W (RV64)
+
+===== Mnemonic
+
+padd.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1200,6 +1204,11 @@ PADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PADD.W adds corresponding packed 32-bit word elements of `rs1` and `rs2` and
+writes the packed word results to `rd`. Each element addition wraps modulo 2^32.
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -1213,18 +1222,13 @@ d[63:32] = s1[63:32] + s2[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-padd.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PADD.W adds corresponding packed 32-bit word elements of `rs1` and `rs2` and
-writes the packed word results to `rd`. Each element addition wraps modulo 2^32.
-Available only in RV64.
 
 <<<
 ==== PADD.BS
+
+===== Mnemonic
+
+padd.bs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1246,6 +1250,11 @@ operand and packed byte elements.
 ]}
 ....
 
+===== Description
+
+The PADD.BS instruction adds the least-significant byte of `rs2` to each packed
+8-bit element of `rs1`, producing a packed byte result in `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -1260,15 +1269,6 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-padd.bs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PADD.BS instruction adds the least-significant byte of `rs2` to each packed
-8-bit element of `rs1`, producing a packed byte result in `rd`.
-
 ===== Notes
 
 * Each 8-bit element addition wraps modulo 2^8.
@@ -1276,6 +1276,10 @@ The PADD.BS instruction adds the least-significant byte of `rs2` to each packed
 
 <<<
 ==== PADD.HS
+
+===== Mnemonic
+
+padd.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1297,6 +1301,10 @@ operand and packed halfword elements.
 ]}
 ....
 
+===== Description
+
+The PADD.HS instruction adds the least-significant halfword of `rs2` to each
+packed 16-bit element of `rs1`, producing a packed halfword result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -1311,17 +1319,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-padd.hs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PADD.HS instruction adds the least-significant halfword of `rs2` to each
-packed 16-bit element of `rs1`, producing a packed halfword result in `rd`.
 
 <<<
 ==== PADD.WS (RV64)
+
+===== Mnemonic
+
+padd.ws _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1342,6 +1346,10 @@ PADD.WS is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The PADD.WS instruction adds the least-significant word of `rs2` to each packed
+32-bit element of `rs1`.
 ===== Operation
 
 [source,pseudocode]
@@ -1355,18 +1363,14 @@ d[63:32] = s1[63:32] + s2_w0
 X[rd] = d
 ----
 
-===== Mnemonic
-
-padd.ws _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PADD.WS instruction adds the least-significant word of `rs2` to each packed
-32-bit element of `rs1`.
 
 
 <<<
 ==== PADD.DB (RV32)
+
+===== Mnemonic
+
+padd.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -1389,6 +1393,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PADD.DB performs packed 8-bit byte addition on double-wide (register-pair)
+operands. It is equivalent to two PADD.B operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Each element
+addition wraps modulo 2^8. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1413,20 +1424,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-padd.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PADD.DB performs packed 8-bit byte addition on double-wide (register-pair)
-operands. It is equivalent to two PADD.B operations: one on the even registers
-and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
-`rs2_p`) are register pairs and must specify even register numbers. Each element
-addition wraps modulo 2^8. Available only in RV32.
 
 <<<
 ==== PADD.DH (RV32)
+
+===== Mnemonic
+
+padd.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -1449,6 +1453,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PADD.DH performs packed 16-bit halfword addition on double-wide (register-pair)
+operands. It is equivalent to two PADD.H operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Each element
+addition wraps modulo 2^16. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1473,20 +1484,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-padd.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PADD.DH performs packed 16-bit halfword addition on double-wide (register-pair)
-operands. It is equivalent to two PADD.H operations: one on the even registers
-and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
-`rs2_p`) are register pairs and must specify even register numbers. Each element
-addition wraps modulo 2^16. Available only in RV32.
 
 <<<
 ==== PADD.DW (RV32)
+
+===== Mnemonic
+
+padd.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -1509,6 +1513,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PADD.DW performs 32-bit word addition on double-wide (register-pair) operands.
+It is equivalent to two ADD operations: one on the even registers and one on
+the odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`)
+are register pairs and must specify even register numbers. Each element addition
+wraps modulo 2^32. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1526,20 +1537,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-padd.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PADD.DW performs 32-bit word addition on double-wide (register-pair) operands.
-It is equivalent to two ADD operations: one on the even registers and one on
-the odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`)
-are register pairs and must specify even register numbers. Each element addition
-wraps modulo 2^32. Available only in RV32.
 
 <<<
 ==== PADD.DBS (RV32)
+
+===== Mnemonic
+
+padd.dbs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -1562,6 +1566,14 @@ scalar format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PADD.DBS adds the least-significant byte of `rs2` to each packed 8-bit element
+across a double-wide (register-pair) source. It is equivalent to two PADD.BS
+operations: one on the even registers and one on the odd registers of each pair.
+The destination (`rd_p`) and first source (`rs1_p`) are register pairs and must
+specify even register numbers; `rs2` is a single register. Each element addition
+wraps modulo 2^8. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1583,21 +1595,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-padd.dbs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PADD.DBS adds the least-significant byte of `rs2` to each packed 8-bit element
-across a double-wide (register-pair) source. It is equivalent to two PADD.BS
-operations: one on the even registers and one on the odd registers of each pair.
-The destination (`rd_p`) and first source (`rs1_p`) are register pairs and must
-specify even register numbers; `rs2` is a single register. Each element addition
-wraps modulo 2^8. Available only in RV32.
 
 <<<
 ==== PADD.DHS (RV32)
+
+===== Mnemonic
+
+padd.dhs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -1620,6 +1624,14 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PADD.DHS adds the least-significant halfword of `rs2` to each packed 16-bit
+element across a double-wide (register-pair) source. It is equivalent to two
+PADD.HS operations: one on the even registers and one on the odd registers of
+each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register. Each
+element addition wraps modulo 2^16. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1641,21 +1653,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-padd.dhs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PADD.DHS adds the least-significant halfword of `rs2` to each packed 16-bit
-element across a double-wide (register-pair) source. It is equivalent to two
-PADD.HS operations: one on the even registers and one on the odd registers of
-each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
-pairs and must specify even register numbers; `rs2` is a single register. Each
-element addition wraps modulo 2^16. Available only in RV32.
 
 <<<
 ==== PADD.DWS (RV32)
+
+===== Mnemonic
+
+padd.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -1678,6 +1682,14 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PADD.DWS adds the least-significant word of `rs2` to each 32-bit element across
+a double-wide (register-pair) source. It is equivalent to two PADD.WS
+operations: one on the even registers and one on the odd registers of each pair.
+The destination (`rd_p`) and first source (`rs1_p`) are register pairs and must
+specify even register numbers; `rs2` is a single register. Each element addition
+wraps modulo 2^32. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1694,24 +1706,16 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-padd.dws _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PADD.DWS adds the least-significant word of `rs2` to each 32-bit element across
-a double-wide (register-pair) source. It is equivalent to two PADD.WS
-operations: one on the even registers and one on the odd registers of each pair.
-The destination (`rd_p`) and first source (`rs1_p`) are register pairs and must
-specify even register numbers; `rs2` is a single register. Each element addition
-wraps modulo 2^32. Available only in RV32.
 
 <<<
 === Basic Packed Subtract
 
 
 ==== PSUB.B
+
+===== Mnemonic
+
+psub.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1731,6 +1735,11 @@ PSUB.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PSUB.B subtracts corresponding packed 8-bit elements of `rs2` from `rs1` and
+writes the packed byte results to `rd`. Each element subtraction wraps modulo
+2^8.
 ===== Operation
 
 [source,pseudocode]
@@ -1746,18 +1755,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psub.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSUB.B subtracts corresponding packed 8-bit elements of `rs2` from `rs1` and
-writes the packed byte results to `rd`. Each element subtraction wraps modulo
-2^8.
 
 <<<
 ==== PSUB.H
+
+===== Mnemonic
+
+psub.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1777,6 +1781,11 @@ PSUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PSUB.H subtracts corresponding packed 16-bit halfword elements of `rs2` from
+`rs1` and writes the packed halfword results to `rd`. Each element subtraction
+wraps modulo 2^16.
 ===== Operation
 
 [source,pseudocode]
@@ -1792,18 +1801,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psub.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSUB.H subtracts corresponding packed 16-bit halfword elements of `rs2` from
-`rs1` and writes the packed halfword results to `rd`. Each element subtraction
-wraps modulo 2^16.
 
 <<<
 ==== PSUB.W (RV64)
+
+===== Mnemonic
+
+psub.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -1823,6 +1827,11 @@ PSUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSUB.W subtracts corresponding packed 32-bit word elements of `rs2` from `rs1`
+and writes the packed word results to `rd`. Each element subtraction wraps
+modulo 2^32. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -1836,18 +1845,13 @@ d[63:32] = s1[63:32] - s2[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psub.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSUB.W subtracts corresponding packed 32-bit word elements of `rs2` from `rs1`
-and writes the packed word results to `rd`. Each element subtraction wraps
-modulo 2^32. Available only in RV64.
 
 <<<
 ==== PSUB.DB (RV32)
+
+===== Mnemonic
+
+psub.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -1870,6 +1874,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSUB.DB performs packed 8-bit byte subtraction on double-wide (register-pair)
+operands. It is equivalent to two PSUB.B operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Each element
+subtraction wraps modulo 2^8. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1894,20 +1905,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psub.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSUB.DB performs packed 8-bit byte subtraction on double-wide (register-pair)
-operands. It is equivalent to two PSUB.B operations: one on the even registers
-and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
-`rs2_p`) are register pairs and must specify even register numbers. Each element
-subtraction wraps modulo 2^8. Available only in RV32.
 
 <<<
 ==== PSUB.DH (RV32)
+
+===== Mnemonic
+
+psub.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -1930,6 +1934,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSUB.DH performs packed 16-bit halfword subtraction on double-wide
+(register-pair) operands. It is equivalent to two PSUB.H operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Each element subtraction wraps modulo 2^16. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -1954,20 +1965,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psub.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSUB.DH performs packed 16-bit halfword subtraction on double-wide
-(register-pair) operands. It is equivalent to two PSUB.H operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Each element subtraction wraps modulo 2^16. Available only in RV32.
 
 <<<
 ==== PSUB.DW (RV32)
+
+===== Mnemonic
+
+psub.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -1990,6 +1994,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSUB.DW performs 32-bit word subtraction on double-wide (register-pair)
+operands. It is equivalent to two SUB operations: one on the even registers and
+one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Each element
+subtraction wraps modulo 2^32. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -2007,23 +2018,16 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psub.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSUB.DW performs 32-bit word subtraction on double-wide (register-pair)
-operands. It is equivalent to two SUB operations: one on the even registers and
-one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
-`rs2_p`) are register pairs and must specify even register numbers. Each element
-subtraction wraps modulo 2^32. Available only in RV32.
 
 <<<
 === Saturating Add
 
 
 ==== PSADD.B
+
+===== Mnemonic
+
+psadd.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2043,6 +2047,11 @@ PSADD.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PSADD.B performs signed saturating addition on packed 8-bit byte elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [-128, 127]. Corresponds to KADD8 in the earlier P extension draft.
 ===== Operation
 
 [source,pseudocode]
@@ -2064,18 +2073,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psadd.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSADD.B performs signed saturating addition on packed 8-bit byte elements of
-`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
-the range [-128, 127]. Corresponds to KADD8 in the earlier P extension draft.
 
 <<<
 ==== PSADD.H
+
+===== Mnemonic
+
+psadd.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2095,6 +2099,12 @@ PSADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PSADD.H performs signed saturating addition on packed 16-bit halfword elements
+of `rs1` and `rs2`, writing the results to `rd`. Each element result is clamped
+to the range [-32768, 32767]. Corresponds to KADD16 in the earlier P extension
+draft.
 ===== Operation
 
 [source,pseudocode]
@@ -2116,19 +2126,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psadd.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSADD.H performs signed saturating addition on packed 16-bit halfword elements
-of `rs1` and `rs2`, writing the results to `rd`. Each element result is clamped
-to the range [-32768, 32767]. Corresponds to KADD16 in the earlier P extension
-draft.
 
 <<<
 ==== PSADD.W (RV64)
+
+===== Mnemonic
+
+psadd.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2149,6 +2153,12 @@ Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSADD.W performs signed saturating addition on packed 32-bit word elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [-(2^31), 2^31-1]. Corresponds to KADD32 in the earlier P extension
+draft. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -2171,19 +2181,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psadd.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSADD.W performs signed saturating addition on packed 32-bit word elements of
-`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
-the range [-(2^31), 2^31-1]. Corresponds to KADD32 in the earlier P extension
-draft. Available only in RV64.
 
 <<<
 ==== PSADDU.B
+
+===== Mnemonic
+
+psaddu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2203,6 +2207,11 @@ PSADDU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PSADDU.B performs unsigned saturating addition on packed 8-bit byte elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [0, 255]. Corresponds to UKADD8 in the earlier P extension draft.
 ===== Operation
 
 [source,pseudocode]
@@ -2222,18 +2231,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psaddu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSADDU.B performs unsigned saturating addition on packed 8-bit byte elements of
-`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
-the range [0, 255]. Corresponds to UKADD8 in the earlier P extension draft.
 
 <<<
 ==== PSADDU.H
+
+===== Mnemonic
+
+psaddu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2253,6 +2257,12 @@ PSADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PSADDU.H performs unsigned saturating addition on packed 16-bit halfword
+elements of `rs1` and `rs2`, writing the results to `rd`. Each element result is
+clamped to the range [0, 65535]. Corresponds to UKADD16 in the earlier P
+extension draft.
 ===== Operation
 
 [source,pseudocode]
@@ -2272,19 +2282,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psaddu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSADDU.H performs unsigned saturating addition on packed 16-bit halfword
-elements of `rs1` and `rs2`, writing the results to `rd`. Each element result is
-clamped to the range [0, 65535]. Corresponds to UKADD16 in the earlier P
-extension draft.
 
 <<<
 ==== PSADDU.W (RV64)
+
+===== Mnemonic
+
+psaddu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2305,6 +2309,12 @@ Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSADDU.W performs unsigned saturating addition on packed 32-bit word elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [0, 2^32-1]. Corresponds to UKADD32 in the earlier P extension draft.
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -2325,19 +2335,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psaddu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSADDU.W performs unsigned saturating addition on packed 32-bit word elements of
-`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
-the range [0, 2^32-1]. Corresponds to UKADD32 in the earlier P extension draft.
-Available only in RV64.
 
 <<<
 ==== SADD (RV32)
+
+===== Mnemonic
+
+sadd _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2358,6 +2362,12 @@ saturating addition. This instruction is available only in RV32.
 ]}
 ....
 
+===== Description
+
+SADD performs signed saturating addition of the full XLEN-wide values in `rs1`
+and `rs2`, writing the result to `rd`. The result is clamped to the range
+[-(2^(XLEN-1)), 2^(XLEN-1)-1]. Corresponds to KADDW in the earlier P extension
+draft.
 ===== Operation
 
 [source,pseudocode]
@@ -2376,19 +2386,13 @@ else:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-sadd _rd_, _rs1_, _rs2_
-
-===== Description
-
-SADD performs signed saturating addition of the full XLEN-wide values in `rs1`
-and `rs2`, writing the result to `rd`. The result is clamped to the range
-[-(2^(XLEN-1)), 2^(XLEN-1)-1]. Corresponds to KADDW in the earlier P extension
-draft.
 
 <<<
 ==== SADDU (RV32)
+
+===== Mnemonic
+
+saddu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2408,6 +2412,11 @@ SADDU is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
+===== Description
+
+SADDU performs unsigned saturating addition of the full XLEN-wide values in
+`rs1` and `rs2`, writing the result to `rd`. The result is clamped to the range
+[0, 2^XLEN-1]. Corresponds to UKADDW in the earlier P extension draft.
 ===== Operation
 
 [source,pseudocode]
@@ -2424,18 +2433,13 @@ else:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-saddu _rd_, _rs1_, _rs2_
-
-===== Description
-
-SADDU performs unsigned saturating addition of the full XLEN-wide values in
-`rs1` and `rs2`, writing the result to `rd`. The result is clamped to the range
-[0, 2^XLEN-1]. Corresponds to UKADDW in the earlier P extension draft.
 
 <<<
 ==== PSADD.DB (RV32)
+
+===== Mnemonic
+
+psadd.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -2458,6 +2462,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSADD.DB performs signed saturating addition on packed 8-bit byte elements using
+double-wide (register-pair) operands. It is equivalent to two PSADD.B
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
+specify even register numbers. Each element result is clamped to the range
+[-128, 127]. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -2494,21 +2506,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psadd.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSADD.DB performs signed saturating addition on packed 8-bit byte elements using
-double-wide (register-pair) operands. It is equivalent to two PSADD.B
-operations: one on the even registers and one on the odd registers of each pair.
-All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
-specify even register numbers. Each element result is clamped to the range
-[-128, 127]. Available only in RV32.
 
 <<<
 ==== PSADD.DH (RV32)
+
+===== Mnemonic
+
+psadd.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -2531,6 +2535,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSADD.DH performs signed saturating addition on packed 16-bit halfword elements
+using double-wide (register-pair) operands. It is equivalent to two PSADD.H
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
+specify even register numbers. Each element result is clamped to the range
+[-32768, 32767]. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -2567,21 +2579,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psadd.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSADD.DH performs signed saturating addition on packed 16-bit halfword elements
-using double-wide (register-pair) operands. It is equivalent to two PSADD.H
-operations: one on the even registers and one on the odd registers of each pair.
-All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
-specify even register numbers. Each element result is clamped to the range
-[-32768, 32767]. Available only in RV32.
 
 <<<
 ==== PSADD.DW (RV32)
+
+===== Mnemonic
+
+psadd.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -2604,6 +2608,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSADD.DW performs signed saturating 32-bit word addition on double-wide
+(register-pair) operands. It is equivalent to two SADD operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Each element result is clamped to the range [-(2^31), 2^31-1].
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -2638,21 +2650,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psadd.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSADD.DW performs signed saturating 32-bit word addition on double-wide
-(register-pair) operands. It is equivalent to two SADD operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Each element result is clamped to the range [-(2^31), 2^31-1].
-Available only in RV32.
 
 <<<
 ==== PSADDU.DB (RV32)
+
+===== Mnemonic
+
+psaddu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -2675,6 +2679,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSADDU.DB performs unsigned saturating addition on packed 8-bit byte elements
+using double-wide (register-pair) operands. It is equivalent to two PSADDU.B
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
+specify even register numbers. Each element result is clamped to the range
+[0, 255]. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -2707,21 +2719,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psaddu.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSADDU.DB performs unsigned saturating addition on packed 8-bit byte elements
-using double-wide (register-pair) operands. It is equivalent to two PSADDU.B
-operations: one on the even registers and one on the odd registers of each pair.
-All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
-specify even register numbers. Each element result is clamped to the range
-[0, 255]. Available only in RV32.
 
 <<<
 ==== PSADDU.DH (RV32)
+
+===== Mnemonic
+
+psaddu.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -2745,6 +2749,13 @@ only for RV32 and uses register pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
+===== Description
+
+PSADDU.DH (Packed Saturating Add Unsigned, Double-wide Halfword) performs
+unsigned saturating addition on corresponding packed 16-bit halfword elements
+across a register pair. This is equivalent to performing PSADDU.H on both the
+even and odd registers of the pair. Each element result is clamped to the
+range [0, 2^16-1]. Available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -2777,20 +2788,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-psaddu.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSADDU.DH (Packed Saturating Add Unsigned, Double-wide Halfword) performs
-unsigned saturating addition on corresponding packed 16-bit halfword elements
-across a register pair. This is equivalent to performing PSADDU.H on both the
-even and odd registers of the pair. Each element result is clamped to the
-range [0, 2^16-1]. Available only on RV32.
 
 <<<
 ==== PSADDU.DW (RV32)
+
+===== Mnemonic
+
+psaddu.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -2814,6 +2818,13 @@ pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
+===== Description
+
+PSADDU.DW (Packed Saturating Add Unsigned, Double-wide Word) performs unsigned
+saturating addition on corresponding 32-bit word values across a register
+pair. This is equivalent to performing SADDU on both the even and odd
+registers of the pair. Each element result is clamped to the range
+[0, 2^32-1]. Available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -2835,23 +2846,16 @@ if res_hi > 2^32 - 1:
 X[2*rd_p+1] = res_hi[31:0]
 ----
 
-===== Mnemonic
-
-psaddu.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSADDU.DW (Packed Saturating Add Unsigned, Double-wide Word) performs unsigned
-saturating addition on corresponding 32-bit word values across a register
-pair. This is equivalent to performing SADDU on both the even and odd
-registers of the pair. Each element result is clamped to the range
-[0, 2^32-1]. Available only on RV32.
 
 <<<
 === Saturating Subtract
 
 
 ==== PSSUB.B
+
+===== Mnemonic
+
+pssub.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2871,6 +2875,11 @@ PSSUB.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PSSUB.B performs signed saturating subtraction on corresponding packed 8-bit
+byte elements of `rs1` and `rs2`, writing the results to `rd`. Each element
+result is clamped to the range [-(2^7), 2^7-1].
 ===== Operation
 
 [source,pseudocode]
@@ -2891,18 +2900,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssub.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSSUB.B performs signed saturating subtraction on corresponding packed 8-bit
-byte elements of `rs1` and `rs2`, writing the results to `rd`. Each element
-result is clamped to the range [-(2^7), 2^7-1].
 
 <<<
 ==== PSSUB.H
+
+===== Mnemonic
+
+pssub.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2922,6 +2926,11 @@ PSSUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PSSUB.H performs signed saturating subtraction on corresponding packed 16-bit
+halfword elements of `rs1` and `rs2`, writing the results to `rd`. Each
+element result is clamped to the range [-(2^15), 2^15-1].
 ===== Operation
 
 [source,pseudocode]
@@ -2942,18 +2951,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssub.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSSUB.H performs signed saturating subtraction on corresponding packed 16-bit
-halfword elements of `rs1` and `rs2`, writing the results to `rd`. Each
-element result is clamped to the range [-(2^15), 2^15-1].
 
 <<<
 ==== PSSUB.W (RV64)
+
+===== Mnemonic
+
+pssub.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -2973,6 +2977,11 @@ PSSUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSSUB.W performs signed saturating subtraction on corresponding packed 32-bit
+word elements of `rs1` and `rs2`, writing the results to `rd`. Each element
+result is clamped to the range [-(2^31), 2^31-1]. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -3003,18 +3012,13 @@ d[63:32] = res_hi[31:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssub.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSSUB.W performs signed saturating subtraction on corresponding packed 32-bit
-word elements of `rs1` and `rs2`, writing the results to `rd`. Each element
-result is clamped to the range [-(2^31), 2^31-1]. Available only in RV64.
 
 <<<
 ==== PSSUBU.B
+
+===== Mnemonic
+
+pssubu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3034,6 +3038,11 @@ PSSUBU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PSSUBU.B performs unsigned saturating subtraction on corresponding packed
+8-bit byte elements of `rs1` and `rs2`, writing the results to `rd`. Each
+element result is clamped to the range [0, 2^8-1].
 ===== Operation
 
 [source,pseudocode]
@@ -3052,18 +3061,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssubu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSSUBU.B performs unsigned saturating subtraction on corresponding packed
-8-bit byte elements of `rs1` and `rs2`, writing the results to `rd`. Each
-element result is clamped to the range [0, 2^8-1].
 
 <<<
 ==== PSSUBU.H
+
+===== Mnemonic
+
+pssubu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3083,6 +3087,11 @@ PSSUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PSSUBU.H performs unsigned saturating subtraction on corresponding packed
+16-bit halfword elements of `rs1` and `rs2`, writing the results to `rd`.
+Each element result is clamped to the range [0, 2^16-1].
 ===== Operation
 
 [source,pseudocode]
@@ -3101,18 +3110,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssubu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSSUBU.H performs unsigned saturating subtraction on corresponding packed
-16-bit halfword elements of `rs1` and `rs2`, writing the results to `rd`.
-Each element result is clamped to the range [0, 2^16-1].
 
 <<<
 ==== PSSUBU.W (RV64)
+
+===== Mnemonic
+
+pssubu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3132,6 +3136,11 @@ PSSUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSSUBU.W performs unsigned saturating subtraction on corresponding packed
+32-bit word elements of `rs1` and `rs2`, writing the results to `rd`. Each
+element result is clamped to the range [0, 2^32-1]. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -3158,18 +3167,13 @@ d[63:32] = res_hi[31:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssubu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSSUBU.W performs unsigned saturating subtraction on corresponding packed
-32-bit word elements of `rs1` and `rs2`, writing the results to `rd`. Each
-element result is clamped to the range [0, 2^32-1]. Available only in RV64.
 
 <<<
 ==== SSUB (RV32)
+
+===== Mnemonic
+
+ssub _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3190,6 +3194,12 @@ XLEN-wide (32-bit) value; on RV64 it is the PSSUB.W instruction.
 ]}
 ....
 
+===== Description
+
+SSUB performs signed saturating subtraction of `rs2` from `rs1`, writing the
+result to `rd`. The result is clamped to the range [-(2^(XLEN-1)),
+2^(XLEN-1)-1]. On RV32 this is the XLEN-wide scalar form; on RV64 this
+encoding is used by PSSUB.W.
 ===== Operation
 
 [source,pseudocode]
@@ -3206,19 +3216,13 @@ else if res < -(2^(XLEN-1)):
 X[rd] = res[XLEN-1:0]
 ----
 
-===== Mnemonic
-
-ssub _rd_, _rs1_, _rs2_
-
-===== Description
-
-SSUB performs signed saturating subtraction of `rs2` from `rs1`, writing the
-result to `rd`. The result is clamped to the range [-(2^(XLEN-1)),
-2^(XLEN-1)-1]. On RV32 this is the XLEN-wide scalar form; on RV64 this
-encoding is used by PSSUB.W.
 
 <<<
 ==== SSUBU (RV32)
+
+===== Mnemonic
+
+ssubu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3238,6 +3242,11 @@ SSUBU is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
+===== Description
+
+SSUBU performs unsigned saturating subtraction of `rs2` from `rs1`, writing
+the result to `rd`. The result is clamped to the range [0, 2^XLEN-1]. This
+instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -3252,18 +3261,13 @@ if res < 0:
 X[rd] = res[XLEN-1:0]
 ----
 
-===== Mnemonic
-
-ssubu _rd_, _rs1_, _rs2_
-
-===== Description
-
-SSUBU performs unsigned saturating subtraction of `rs2` from `rs1`, writing
-the result to `rd`. The result is clamped to the range [0, 2^XLEN-1]. This
-instruction is available only on RV32.
 
 <<<
 ==== PSSUB.DB (RV32)
+
+===== Mnemonic
+
+pssub.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -3287,6 +3291,13 @@ pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
+===== Description
+
+PSSUB.DB (Packed Signed Saturating Subtract, Double-wide Byte) performs signed
+saturating subtraction on corresponding packed 8-bit byte elements across a
+register pair. This is equivalent to performing PSSUB.B on both the even and
+odd registers of the pair. Each element result is clamped to the range
+[-(2^7), 2^7-1]. Available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -3323,20 +3334,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-pssub.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSUB.DB (Packed Signed Saturating Subtract, Double-wide Byte) performs signed
-saturating subtraction on corresponding packed 8-bit byte elements across a
-register pair. This is equivalent to performing PSSUB.B on both the even and
-odd registers of the pair. Each element result is clamped to the range
-[-(2^7), 2^7-1]. Available only on RV32.
 
 <<<
 ==== PSSUB.DH (RV32)
+
+===== Mnemonic
+
+pssub.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -3360,6 +3364,13 @@ register pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
+===== Description
+
+PSSUB.DH (Packed Signed Saturating Subtract, Double-wide Halfword) performs
+signed saturating subtraction on corresponding packed 16-bit halfword elements
+across a register pair. This is equivalent to performing PSSUB.H on both the
+even and odd registers of the pair. Each element result is clamped to the
+range [-(2^15), 2^15-1]. Available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -3396,20 +3407,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-pssub.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSUB.DH (Packed Signed Saturating Subtract, Double-wide Halfword) performs
-signed saturating subtraction on corresponding packed 16-bit halfword elements
-across a register pair. This is equivalent to performing PSSUB.H on both the
-even and odd registers of the pair. Each element result is clamped to the
-range [-(2^15), 2^15-1]. Available only on RV32.
 
 <<<
 ==== PSSUB.DW (RV32)
+
+===== Mnemonic
+
+pssub.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -3433,6 +3437,13 @@ instruction exists only for RV32 and uses register pairs `rd_p`, `rs1_p`, and
 ]}
 ....
 
+===== Description
+
+PSSUB.DW (Packed Signed Saturating Subtract, Double-wide Word) performs signed
+saturating subtraction on corresponding 32-bit word values across a register
+pair. This is equivalent to performing SSUB on both the even and odd registers
+of the pair. Each element result is clamped to the range [-(2^31), 2^31-1].
+Available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -3458,20 +3469,13 @@ else if res_hi < -(2^31):
 X[2*rd_p+1] = res_hi[31:0]
 ----
 
-===== Mnemonic
-
-pssub.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSUB.DW (Packed Signed Saturating Subtract, Double-wide Word) performs signed
-saturating subtraction on corresponding 32-bit word values across a register
-pair. This is equivalent to performing SSUB on both the even and odd registers
-of the pair. Each element result is clamped to the range [-(2^31), 2^31-1].
-Available only on RV32.
 
 <<<
 ==== PSSUBU.DB (RV32)
+
+===== Mnemonic
+
+pssubu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -3495,6 +3499,13 @@ pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
+===== Description
+
+PSSUBU.DB (Packed Unsigned Saturating Subtract, Double-wide Byte) performs
+unsigned saturating subtraction on corresponding packed 8-bit byte elements
+across a register pair. This is equivalent to performing PSSUBU.B on both the
+even and odd registers of the pair. Each element result is clamped to the
+range [0, 2^8-1]. Available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -3527,20 +3538,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-pssubu.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSUBU.DB (Packed Unsigned Saturating Subtract, Double-wide Byte) performs
-unsigned saturating subtraction on corresponding packed 8-bit byte elements
-across a register pair. This is equivalent to performing PSSUBU.B on both the
-even and odd registers of the pair. Each element result is clamped to the
-range [0, 2^8-1]. Available only on RV32.
 
 <<<
 ==== PSSUBU.DH (RV32)
+
+===== Mnemonic
+
+pssubu.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -3564,6 +3568,13 @@ register pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
+===== Description
+
+PSSUBU.DH (Packed Unsigned Saturating Subtract, Double-wide Halfword) performs
+unsigned saturating subtraction on corresponding packed 16-bit halfword
+elements across a register pair. This is equivalent to performing PSSUBU.H on
+both the even and odd registers of the pair. Each element result is clamped to
+the range [0, 2^16-1]. Available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -3596,20 +3607,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-pssubu.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSUBU.DH (Packed Unsigned Saturating Subtract, Double-wide Halfword) performs
-unsigned saturating subtraction on corresponding packed 16-bit halfword
-elements across a register pair. This is equivalent to performing PSSUBU.H on
-both the even and odd registers of the pair. Each element result is clamped to
-the range [0, 2^16-1]. Available only on RV32.
 
 <<<
 ==== PSSUBU.DW (RV32)
+
+===== Mnemonic
+
+pssubu.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -3633,6 +3637,13 @@ instruction exists only for RV32 and uses register pairs `rd_p`, `rs1_p`, and
 ]}
 ....
 
+===== Description
+
+PSSUBU.DW (Packed Unsigned Saturating Subtract, Double-wide Word) performs
+unsigned saturating subtraction on corresponding 32-bit word values across a
+register pair. This is equivalent to performing SSUBU on both the even and odd
+registers of the pair. Each element result is clamped to the range
+[0, 2^32-1]. Available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -3654,23 +3665,16 @@ if res_hi < 0:
 X[2*rd_p+1] = res_hi[31:0]
 ----
 
-===== Mnemonic
-
-pssubu.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSUBU.DW (Packed Unsigned Saturating Subtract, Double-wide Word) performs
-unsigned saturating subtraction on corresponding 32-bit word values across a
-register pair. This is equivalent to performing SSUBU on both the even and odd
-registers of the pair. Each element result is clamped to the range
-[0, 2^32-1]. Available only on RV32.
 
 <<<
 === Averaging Add
 
 
 ==== PAADD.B
+
+===== Mnemonic
+
+paadd.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3690,6 +3694,12 @@ PAADD.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PAADD.B performs a signed averaging addition on packed 8-bit elements. For each
+byte lane, it adds the signed elements from `rs1` and `rs2` at full precision
+(9 bits), then shifts the result right by 1 (toward negative infinity), and
+writes the lower 8 bits to the corresponding byte of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -3706,19 +3716,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-paadd.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAADD.B performs a signed averaging addition on packed 8-bit elements. For each
-byte lane, it adds the signed elements from `rs1` and `rs2` at full precision
-(9 bits), then shifts the result right by 1 (toward negative infinity), and
-writes the lower 8 bits to the corresponding byte of `rd`.
 
 <<<
 ==== PAADD.H
+
+===== Mnemonic
+
+paadd.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3738,6 +3742,12 @@ PAADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PAADD.H performs a signed averaging addition on packed 16-bit halfword elements.
+For each halfword lane, it adds the signed elements from `rs1` and `rs2` at full
+precision (17 bits), then shifts the result right by 1 (toward negative
+infinity), and writes the lower 16 bits to the corresponding halfword of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -3754,19 +3764,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-paadd.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAADD.H performs a signed averaging addition on packed 16-bit halfword elements.
-For each halfword lane, it adds the signed elements from `rs1` and `rs2` at full
-precision (17 bits), then shifts the result right by 1 (toward negative
-infinity), and writes the lower 16 bits to the corresponding halfword of `rd`.
 
 <<<
 ==== PAADD.W (RV64)
+
+===== Mnemonic
+
+paadd.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3786,6 +3790,13 @@ PAADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PAADD.W performs a signed averaging addition on packed 32-bit word elements.
+For each word lane, it adds the signed elements from `rs1` and `rs2` at full
+precision (33 bits), then shifts the result right by 1 (toward negative
+infinity), and writes the lower 32 bits to the corresponding word of `rd`.
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -3807,20 +3818,13 @@ d[63:32] = to_bits(32, sum_hi >> 1)
 X[rd] = d
 ----
 
-===== Mnemonic
-
-paadd.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAADD.W performs a signed averaging addition on packed 32-bit word elements.
-For each word lane, it adds the signed elements from `rs1` and `rs2` at full
-precision (33 bits), then shifts the result right by 1 (toward negative
-infinity), and writes the lower 32 bits to the corresponding word of `rd`.
-Available only in RV64.
 
 <<<
 ==== PAADDU.B
+
+===== Mnemonic
+
+paaddu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3840,6 +3844,12 @@ PAADDU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PAADDU.B performs an unsigned averaging addition on packed 8-bit elements. For
+each byte lane, it adds the unsigned elements from `rs1` and `rs2` at full
+precision (9 bits), then shifts the result right by 1, and writes the lower
+8 bits to the corresponding byte of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -3856,19 +3866,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-paaddu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAADDU.B performs an unsigned averaging addition on packed 8-bit elements. For
-each byte lane, it adds the unsigned elements from `rs1` and `rs2` at full
-precision (9 bits), then shifts the result right by 1, and writes the lower
-8 bits to the corresponding byte of `rd`.
 
 <<<
 ==== PAADDU.H
+
+===== Mnemonic
+
+paaddu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3888,6 +3892,12 @@ PAADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PAADDU.H performs an unsigned averaging addition on packed 16-bit halfword
+elements. For each halfword lane, it adds the unsigned elements from `rs1` and
+`rs2` at full precision (17 bits), then shifts the result right by 1, and writes
+the lower 16 bits to the corresponding halfword of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -3904,19 +3914,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-paaddu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAADDU.H performs an unsigned averaging addition on packed 16-bit halfword
-elements. For each halfword lane, it adds the unsigned elements from `rs1` and
-`rs2` at full precision (17 bits), then shifts the result right by 1, and writes
-the lower 16 bits to the corresponding halfword of `rd`.
 
 <<<
 ==== PAADDU.W (RV64)
+
+===== Mnemonic
+
+paaddu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3936,6 +3940,12 @@ PAADDU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PAADDU.W performs an unsigned averaging addition on packed 32-bit word elements.
+For each word lane, it adds the unsigned elements from `rs1` and `rs2` at full
+precision (33 bits), then shifts the result right by 1, and writes the lower
+32 bits to the corresponding word of `rd`. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -3957,19 +3967,13 @@ d[63:32] = to_bits(32, sum_hi >> 1)
 X[rd] = d
 ----
 
-===== Mnemonic
-
-paaddu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAADDU.W performs an unsigned averaging addition on packed 32-bit word elements.
-For each word lane, it adds the unsigned elements from `rs1` and `rs2` at full
-precision (33 bits), then shifts the result right by 1, and writes the lower
-32 bits to the corresponding word of `rd`. Available only in RV64.
 
 <<<
 ==== AADD (RV32)
+
+===== Mnemonic
+
+aadd _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -3989,6 +3993,12 @@ AADD is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
+===== Description
+
+AADD performs a signed averaging addition on a single XLEN-wide value. It adds
+the signed values in `rs1` and `rs2` at full precision (33 bits), then shifts
+the result right by 1 (toward negative infinity), and writes the lower 32 bits
+to `rd`. Available only in RV32; the RV64 counterpart is PAADD.W.
 ===== Operation
 
 [source,pseudocode]
@@ -4000,19 +4010,13 @@ sum = s1 + s2
 X[rd] = to_bits(32, sum >> 1)
 ----
 
-===== Mnemonic
-
-aadd _rd_, _rs1_, _rs2_
-
-===== Description
-
-AADD performs a signed averaging addition on a single XLEN-wide value. It adds
-the signed values in `rs1` and `rs2` at full precision (33 bits), then shifts
-the result right by 1 (toward negative infinity), and writes the lower 32 bits
-to `rd`. Available only in RV32; the RV64 counterpart is PAADD.W.
 
 <<<
 ==== AADDU (RV32)
+
+===== Mnemonic
+
+aaddu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4032,6 +4036,12 @@ AADDU is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
+===== Description
+
+AADDU performs an unsigned averaging addition on a single XLEN-wide value. It
+adds the unsigned values in `rs1` and `rs2` at full precision (33 bits), then
+shifts the result right by 1, and writes the lower 32 bits to `rd`. Available
+only in RV32; the RV64 counterpart is PAADDU.W.
 ===== Operation
 
 [source,pseudocode]
@@ -4043,19 +4053,13 @@ sum = s1 + s2
 X[rd] = to_bits(32, sum >> 1)
 ----
 
-===== Mnemonic
-
-aaddu _rd_, _rs1_, _rs2_
-
-===== Description
-
-AADDU performs an unsigned averaging addition on a single XLEN-wide value. It
-adds the unsigned values in `rs1` and `rs2` at full precision (33 bits), then
-shifts the result right by 1, and writes the lower 32 bits to `rd`. Available
-only in RV32; the RV64 counterpart is PAADDU.W.
 
 <<<
 ==== PAADD.DB (RV32)
+
+===== Mnemonic
+
+paadd.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4079,6 +4083,12 @@ register-pair format with register-pair operands.
 ]}
 ....
 
+===== Description
+
+PAADD.DB (Packed Averaging Add, Double-wide Byte) performs a signed averaging
+addition on packed 8-bit elements across register pairs. It is equivalent to
+performing PAADD.B independently on both the even and odd registers of the
+source and destination pairs. This instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4105,19 +4115,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-paadd.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PAADD.DB (Packed Averaging Add, Double-wide Byte) performs a signed averaging
-addition on packed 8-bit elements across register pairs. It is equivalent to
-performing PAADD.B independently on both the even and odd registers of the
-source and destination pairs. This instruction is available only on RV32.
 
 <<<
 ==== PAADD.DH (RV32)
+
+===== Mnemonic
+
+paadd.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4141,6 +4145,13 @@ register-pair format with register-pair operands.
 ]}
 ....
 
+===== Description
+
+PAADD.DH (Packed Averaging Add, Double-wide Halfword) performs a signed
+averaging addition on packed 16-bit halfword elements across register pairs. It
+is equivalent to performing PAADD.H independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4167,20 +4178,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-paadd.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PAADD.DH (Packed Averaging Add, Double-wide Halfword) performs a signed
-averaging addition on packed 16-bit halfword elements across register pairs. It
-is equivalent to performing PAADD.H independently on both the even and odd
-registers of the source and destination pairs. This instruction is available
-only on RV32.
 
 <<<
 ==== PAADD.DW (RV32)
+
+===== Mnemonic
+
+paadd.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4204,6 +4208,12 @@ register-pair format with register-pair operands.
 ]}
 ....
 
+===== Description
+
+PAADD.DW (Packed Averaging Add, Double-wide Word) performs a signed averaging
+addition on packed 32-bit word elements across register pairs. It is equivalent
+to performing AADD independently on both the even and odd registers of the
+source and destination pairs. This instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4224,19 +4234,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-paadd.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PAADD.DW (Packed Averaging Add, Double-wide Word) performs a signed averaging
-addition on packed 32-bit word elements across register pairs. It is equivalent
-to performing AADD independently on both the even and odd registers of the
-source and destination pairs. This instruction is available only on RV32.
 
 <<<
 ==== PAADDU.DB (RV32)
+
+===== Mnemonic
+
+paaddu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4260,6 +4264,13 @@ register-pair operands.
 ]}
 ....
 
+===== Description
+
+PAADDU.DB (Packed Averaging Add Unsigned, Double-wide Byte) performs an unsigned
+averaging addition on packed 8-bit elements across register pairs. It is
+equivalent to performing PAADDU.B independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4286,20 +4297,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-paaddu.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PAADDU.DB (Packed Averaging Add Unsigned, Double-wide Byte) performs an unsigned
-averaging addition on packed 8-bit elements across register pairs. It is
-equivalent to performing PAADDU.B independently on both the even and odd
-registers of the source and destination pairs. This instruction is available
-only on RV32.
 
 <<<
 ==== PAADDU.DH (RV32)
+
+===== Mnemonic
+
+paaddu.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4323,6 +4327,13 @@ double-wide register-pair format with register-pair operands.
 ]}
 ....
 
+===== Description
+
+PAADDU.DH (Packed Averaging Add Unsigned, Double-wide Halfword) performs an
+unsigned averaging addition on packed 16-bit halfword elements across register
+pairs. It is equivalent to performing PAADDU.H independently on both the even
+and odd registers of the source and destination pairs. This instruction is
+available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4349,20 +4360,13 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-paaddu.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PAADDU.DH (Packed Averaging Add Unsigned, Double-wide Halfword) performs an
-unsigned averaging addition on packed 16-bit halfword elements across register
-pairs. It is equivalent to performing PAADDU.H independently on both the even
-and odd registers of the source and destination pairs. This instruction is
-available only on RV32.
 
 <<<
 ==== PAADDU.DW (RV32)
+
+===== Mnemonic
+
+paaddu.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4386,6 +4390,12 @@ double-wide register-pair format with register-pair operands.
 ]}
 ....
 
+===== Description
+
+PAADDU.DW (Packed Averaging Add Unsigned, Double-wide Word) performs an unsigned
+averaging addition on packed 32-bit word elements across register pairs. It is
+equivalent to performing AADDU independently on both the even and odd registers
+of the source and destination pairs. This instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4406,22 +4416,16 @@ X[2*rd_p] = d_lo
 X[2*rd_p+1] = d_hi
 ----
 
-===== Mnemonic
-
-paaddu.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PAADDU.DW (Packed Averaging Add Unsigned, Double-wide Word) performs an unsigned
-averaging addition on packed 32-bit word elements across register pairs. It is
-equivalent to performing AADDU independently on both the even and odd registers
-of the source and destination pairs. This instruction is available only on RV32.
 
 <<<
 === Averaging Subtract
 
 
 ==== PASUB.B
+
+===== Mnemonic
+
+pasub.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4441,6 +4445,13 @@ PASUB.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PASUB.B performs a signed averaging subtraction on packed 8-bit elements. For
+each byte lane, it subtracts the signed element in `rs2` from the signed element
+in `rs1` at full precision (9 bits), then shifts the result right by 1 (toward
+negative infinity), and writes the lower 8 bits to the corresponding byte of
+`rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -4457,20 +4468,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pasub.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PASUB.B performs a signed averaging subtraction on packed 8-bit elements. For
-each byte lane, it subtracts the signed element in `rs2` from the signed element
-in `rs1` at full precision (9 bits), then shifts the result right by 1 (toward
-negative infinity), and writes the lower 8 bits to the corresponding byte of
-`rd`.
 
 <<<
 ==== PASUB.H
+
+===== Mnemonic
+
+pasub.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4490,6 +4494,13 @@ PASUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PASUB.H performs a signed averaging subtraction on packed 16-bit halfword
+elements. For each halfword lane, it subtracts the signed element in `rs2` from
+the signed element in `rs1` at full precision (17 bits), then shifts the result
+right by 1 (toward negative infinity), and writes the lower 16 bits to the
+corresponding halfword of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -4506,20 +4517,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pasub.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PASUB.H performs a signed averaging subtraction on packed 16-bit halfword
-elements. For each halfword lane, it subtracts the signed element in `rs2` from
-the signed element in `rs1` at full precision (17 bits), then shifts the result
-right by 1 (toward negative infinity), and writes the lower 16 bits to the
-corresponding halfword of `rd`.
 
 <<<
 ==== PASUB.W (RV64)
+
+===== Mnemonic
+
+pasub.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4539,6 +4543,13 @@ PASUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PASUB.W performs a signed averaging subtraction on packed 32-bit word elements.
+For each word lane, it subtracts the signed element in `rs2` from the signed
+element in `rs1` at full precision (33 bits), then shifts the result right by 1
+(toward negative infinity), and writes the lower 32 bits to the corresponding
+word of `rd`. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -4560,20 +4571,13 @@ d[63:32] = to_bits(32, diff_hi >> 1)
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pasub.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PASUB.W performs a signed averaging subtraction on packed 32-bit word elements.
-For each word lane, it subtracts the signed element in `rs2` from the signed
-element in `rs1` at full precision (33 bits), then shifts the result right by 1
-(toward negative infinity), and writes the lower 32 bits to the corresponding
-word of `rd`. Available only in RV64.
 
 <<<
 ==== PASUBU.B
+
+===== Mnemonic
+
+pasubu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4593,6 +4597,12 @@ PASUBU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PASUBU.B performs an unsigned averaging subtraction on packed 8-bit elements.
+For each byte lane, it subtracts the unsigned element in `rs2` from the unsigned
+element in `rs1` at full precision (9 bits), then shifts the result right by 1,
+and writes the lower 8 bits to the corresponding byte of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -4609,19 +4619,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pasubu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PASUBU.B performs an unsigned averaging subtraction on packed 8-bit elements.
-For each byte lane, it subtracts the unsigned element in `rs2` from the unsigned
-element in `rs1` at full precision (9 bits), then shifts the result right by 1,
-and writes the lower 8 bits to the corresponding byte of `rd`.
 
 <<<
 ==== PASUBU.H
+
+===== Mnemonic
+
+pasubu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4641,6 +4645,13 @@ PASUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PASUBU.H performs an unsigned averaging subtraction on packed 16-bit halfword
+elements. For each halfword lane, it subtracts the unsigned element in `rs2`
+from the unsigned element in `rs1` at full precision (17 bits), then shifts the
+result right by 1, and writes the lower 16 bits to the corresponding halfword
+of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -4657,20 +4668,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pasubu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PASUBU.H performs an unsigned averaging subtraction on packed 16-bit halfword
-elements. For each halfword lane, it subtracts the unsigned element in `rs2`
-from the unsigned element in `rs1` at full precision (17 bits), then shifts the
-result right by 1, and writes the lower 16 bits to the corresponding halfword
-of `rd`.
 
 <<<
 ==== PASUBU.W (RV64)
+
+===== Mnemonic
+
+pasubu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4690,6 +4694,13 @@ PASUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PASUBU.W performs an unsigned averaging subtraction on packed 32-bit word
+elements. For each word lane, it subtracts the unsigned element in `rs2` from
+the unsigned element in `rs1` at full precision (33 bits), then shifts the
+result right by 1, and writes the lower 32 bits to the corresponding word of
+`rd`. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -4711,20 +4722,13 @@ d[63:32] = to_bits(32, diff_hi >> 1)
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pasubu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PASUBU.W performs an unsigned averaging subtraction on packed 32-bit word
-elements. For each word lane, it subtracts the unsigned element in `rs2` from
-the unsigned element in `rs1` at full precision (33 bits), then shifts the
-result right by 1, and writes the lower 32 bits to the corresponding word of
-`rd`. Available only in RV64.
 
 <<<
 ==== ASUB (RV32)
+
+===== Mnemonic
+
+asub _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4744,6 +4748,12 @@ ASUB is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
+===== Description
+
+ASUB performs a signed averaging subtraction on a single XLEN-wide value. It
+subtracts the signed value in `rs2` from `rs1` at full precision (33 bits), then
+shifts the result right by 1 (toward negative infinity), and writes the lower
+32 bits to `rd`. Available only in RV32; the RV64 counterpart is PASUB.W.
 ===== Operation
 
 [source,pseudocode]
@@ -4755,19 +4765,13 @@ diff = s1 - s2
 X[rd] = to_bits(32, diff >> 1)
 ----
 
-===== Mnemonic
-
-asub _rd_, _rs1_, _rs2_
-
-===== Description
-
-ASUB performs a signed averaging subtraction on a single XLEN-wide value. It
-subtracts the signed value in `rs2` from `rs1` at full precision (33 bits), then
-shifts the result right by 1 (toward negative infinity), and writes the lower
-32 bits to `rd`. Available only in RV32; the RV64 counterpart is PASUB.W.
 
 <<<
 ==== ASUBU (RV32)
+
+===== Mnemonic
+
+asubu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -4787,6 +4791,12 @@ ASUBU is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
+===== Description
+
+ASUBU performs an unsigned averaging subtraction on a single XLEN-wide value. It
+subtracts the unsigned value in `rs2` from `rs1` at full precision (33 bits),
+then shifts the result right by 1, and writes the lower 32 bits to `rd`.
+Available only in RV32; the RV64 counterpart is PASUBU.W.
 ===== Operation
 
 [source,pseudocode]
@@ -4798,19 +4808,13 @@ diff = s1 - s2
 X[rd] = to_bits(32, diff >> 1)
 ----
 
-===== Mnemonic
-
-asubu _rd_, _rs1_, _rs2_
-
-===== Description
-
-ASUBU performs an unsigned averaging subtraction on a single XLEN-wide value. It
-subtracts the unsigned value in `rs2` from `rs1` at full precision (33 bits),
-then shifts the result right by 1, and writes the lower 32 bits to `rd`.
-Available only in RV32; the RV64 counterpart is PASUBU.W.
 
 <<<
 ==== PASUB.DB (RV32)
+
+===== Mnemonic
+
+pasub.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4833,6 +4837,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PASUB.DB (Packed Averaging Subtract, Double-wide Byte) performs a signed
+averaging subtraction on packed 8-bit elements across register pairs. It is
+equivalent to performing PASUB.B independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4859,20 +4870,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pasub.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PASUB.DB (Packed Averaging Subtract, Double-wide Byte) performs a signed
-averaging subtraction on packed 8-bit elements across register pairs. It is
-equivalent to performing PASUB.B independently on both the even and odd
-registers of the source and destination pairs. This instruction is available
-only on RV32.
 
 <<<
 ==== PASUB.DH (RV32)
+
+===== Mnemonic
+
+pasub.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4895,6 +4899,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PASUB.DH (Packed Averaging Subtract, Double-wide Halfword) performs a signed
+averaging subtraction on packed 16-bit halfword elements across register pairs.
+It is equivalent to performing PASUB.H independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4921,20 +4932,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pasub.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PASUB.DH (Packed Averaging Subtract, Double-wide Halfword) performs a signed
-averaging subtraction on packed 16-bit halfword elements across register pairs.
-It is equivalent to performing PASUB.H independently on both the even and odd
-registers of the source and destination pairs. This instruction is available
-only on RV32.
 
 <<<
 ==== PASUB.DW (RV32)
+
+===== Mnemonic
+
+pasub.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -4957,6 +4961,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PASUB.DW (Packed Averaging Subtract, Double-wide Word) performs a signed
+averaging subtraction on packed 32-bit word elements across register pairs. It
+is equivalent to performing ASUB independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -4977,20 +4988,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pasub.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PASUB.DW (Packed Averaging Subtract, Double-wide Word) performs a signed
-averaging subtraction on packed 32-bit word elements across register pairs. It
-is equivalent to performing ASUB independently on both the even and odd
-registers of the source and destination pairs. This instruction is available
-only on RV32.
 
 <<<
 ==== PASUBU.DB (RV32)
+
+===== Mnemonic
+
+pasubu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -5013,6 +5017,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PASUBU.DB (Packed Averaging Subtract Unsigned, Double-wide Byte) performs an
+unsigned averaging subtraction on packed 8-bit elements across register pairs.
+It is equivalent to performing PASUBU.B independently on both the even and odd
+registers of the source and destination pairs. This instruction is available
+only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -5039,20 +5050,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pasubu.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PASUBU.DB (Packed Averaging Subtract Unsigned, Double-wide Byte) performs an
-unsigned averaging subtraction on packed 8-bit elements across register pairs.
-It is equivalent to performing PASUBU.B independently on both the even and odd
-registers of the source and destination pairs. This instruction is available
-only on RV32.
 
 <<<
 ==== PASUBU.DH (RV32)
+
+===== Mnemonic
+
+pasubu.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -5075,6 +5079,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PASUBU.DH (Packed Averaging Subtract Unsigned, Double-wide Halfword) performs
+an unsigned averaging subtraction on packed 16-bit halfword elements across
+register pairs. It is equivalent to performing PASUBU.H independently on both
+the even and odd registers of the source and destination pairs. This instruction
+is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -5101,20 +5112,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pasubu.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PASUBU.DH (Packed Averaging Subtract Unsigned, Double-wide Halfword) performs
-an unsigned averaging subtraction on packed 16-bit halfword elements across
-register pairs. It is equivalent to performing PASUBU.H independently on both
-the even and odd registers of the source and destination pairs. This instruction
-is available only on RV32.
 
 <<<
 ==== PASUBU.DW (RV32)
+
+===== Mnemonic
+
+pasubu.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -5137,6 +5141,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PASUBU.DW (Packed Averaging Subtract Unsigned, Double-wide Word) performs an
+unsigned averaging subtraction on packed 32-bit word elements across register
+pairs. It is equivalent to performing ASUBU independently on both the even and
+odd registers of the source and destination pairs. This instruction is available
+only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -5157,22 +5168,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pasubu.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PASUBU.DW (Packed Averaging Subtract Unsigned, Double-wide Word) performs an
-unsigned averaging subtraction on packed 32-bit word elements across register
-pairs. It is equivalent to performing ASUBU independently on both the even and
-odd registers of the source and destination pairs. This instruction is available
-only on RV32.
 
 <<<
 === Shift-Add
 
 ==== PSH1ADD.H
+
+===== Mnemonic
+
+psh1add.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5193,6 +5197,10 @@ PSH1ADD.H is encoded in the OP-32 major opcode. It uses packed halfword elements
 ]}
 ....
 
+===== Description
+
+The PSH1ADD.H instruction computes, for each packed 16-bit element,
+`(rs1_h << 1) + rs2_h`, and writes the packed halfword result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -5208,17 +5216,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psh1add.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSH1ADD.H instruction computes, for each packed 16-bit element,
-`(rs1_h << 1) + rs2_h`, and writes the packed halfword result to `rd`.
 
 <<<
 ==== PSH1ADD.W (RV64)
+
+===== Mnemonic
+
+psh1add.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5239,6 +5243,10 @@ PSH1ADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The PSH1ADD.W instruction computes, for each packed 32-bit element,
+`(rs1_w << 1) + rs2_w`.
 ===== Operation
 
 [source,pseudocode]
@@ -5252,17 +5260,13 @@ d[63:32] = (s1[63:32] << 1) + s2[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psh1add.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSH1ADD.W instruction computes, for each packed 32-bit element,
-`(rs1_w << 1) + rs2_w`.
 
 <<<
 ==== PSSH1SADD.H
+
+===== Mnemonic
+
+pssh1sadd.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5283,6 +5287,13 @@ elements and performs signed saturating arithmetic.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The PSSH1SADD.H instruction performs a signed saturating left shift by 1 on each
+packed 16-bit element of `rs1`, then performs a signed saturating add with the
+corresponding packed 16-bit element of `rs2`. The packed halfword result is
+written to `rd`.
 
 ===== Operation
 
@@ -5317,17 +5328,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssh1sadd.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSSH1SADD.H instruction performs a signed saturating left shift by 1 on each
-packed 16-bit element of `rs1`, then performs a signed saturating add with the
-corresponding packed 16-bit element of `rs2`. The packed halfword result is
-written to `rd`.
-
 ===== Notes
 
 * `vxsat` is set to 1 if saturation occurs in any element, either during the
@@ -5335,6 +5335,10 @@ written to `rd`.
 
 <<<
 ==== PSSH1SADD.W (RV64)
+
+===== Mnemonic
+
+pssh1sadd.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5355,6 +5359,11 @@ PSSH1SADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The PSSH1SADD.W instruction performs a signed saturating left shift by 1 on each
+packed 32-bit element of `rs1`, followed by a signed saturating add with the
+corresponding element of `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -5388,18 +5397,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssh1sadd.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSSH1SADD.W instruction performs a signed saturating left shift by 1 on each
-packed 32-bit element of `rs1`, followed by a signed saturating add with the
-corresponding element of `rs2`.
 
 <<<
 ==== SSH1SADD (RV32)
+
+===== Mnemonic
+
+ssh1sadd _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5420,6 +5424,10 @@ SSH1SADD is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
+===== Description
+
+The SSH1SADD instruction performs a signed saturating left shift by 1 on `rs1`,
+followed by a signed saturating add with `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -5445,18 +5453,14 @@ else
     X[rd] = to_bits(32, s)
 ----
 
-===== Mnemonic
-
-ssh1sadd _rd_, _rs1_, _rs2_
-
-===== Description
-
-The SSH1SADD instruction performs a signed saturating left shift by 1 on `rs1`,
-followed by a signed saturating add with `rs2`.
 
 
 <<<
 ==== PSH1ADD.DH (RV32)
+
+===== Mnemonic
+
+psh1add.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -5480,6 +5484,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSH1ADD.DH (Packed Shift-left-by-1 and Add, Double-wide Halfword) performs a
+packed halfword shift-left-by-1-and-add across register pairs. For each 16-bit
+element, it shifts the element from `rs1` left by 1 and adds the corresponding
+element from `rs2`, wrapping modulo 2^16. It is equivalent to performing
+PSH1ADD.H independently on both the even and odd registers of the source and
+destination pairs. This instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -5504,21 +5516,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psh1add.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSH1ADD.DH (Packed Shift-left-by-1 and Add, Double-wide Halfword) performs a
-packed halfword shift-left-by-1-and-add across register pairs. For each 16-bit
-element, it shifts the element from `rs1` left by 1 and adds the corresponding
-element from `rs2`, wrapping modulo 2^16. It is equivalent to performing
-PSH1ADD.H independently on both the even and odd registers of the source and
-destination pairs. This instruction is available only on RV32.
 
 <<<
 ==== PSH1ADD.DW (RV32)
+
+===== Mnemonic
+
+psh1add.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -5542,6 +5546,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSH1ADD.DW (Packed Shift-left-by-1 and Add, Double-wide Word) performs a 32-bit
+word shift-left-by-1-and-add across register pairs. For each 32-bit element, it
+shifts the element from `rs1` left by 1 and adds the corresponding element from
+`rs2`, wrapping modulo 2^32. It is equivalent to performing SH1ADD independently
+on both the even and odd registers of the source and destination pairs. This
+instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -5559,21 +5571,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psh1add.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSH1ADD.DW (Packed Shift-left-by-1 and Add, Double-wide Word) performs a 32-bit
-word shift-left-by-1-and-add across register pairs. For each 32-bit element, it
-shifts the element from `rs1` left by 1 and adds the corresponding element from
-`rs2`, wrapping modulo 2^32. It is equivalent to performing SH1ADD independently
-on both the even and odd registers of the source and destination pairs. This
-instruction is available only on RV32.
 
 <<<
 ==== PSSH1SADD.DH (RV32)
+
+===== Mnemonic
+
+pssh1sadd.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -5597,6 +5601,16 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSSH1SADD.DH (Packed Saturating Shift-left-by-1 Saturating Add, Double-wide
+Halfword) performs a packed halfword saturating shift-left-by-1 followed by a
+saturating add across register pairs. For each 16-bit element, the value from
+`rs1` is saturating-shifted left by 1 (clamped to [-2^15, 2^15-1]), then the
+corresponding element from `rs2` is added with signed saturation. It is
+equivalent to performing PSSH1SADD.H independently on both the even and odd
+registers of the source and destination pairs. Sets `vxsat` on saturation. This
+instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -5639,23 +5653,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pssh1sadd.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSH1SADD.DH (Packed Saturating Shift-left-by-1 Saturating Add, Double-wide
-Halfword) performs a packed halfword saturating shift-left-by-1 followed by a
-saturating add across register pairs. For each 16-bit element, the value from
-`rs1` is saturating-shifted left by 1 (clamped to [-2^15, 2^15-1]), then the
-corresponding element from `rs2` is added with signed saturation. It is
-equivalent to performing PSSH1SADD.H independently on both the even and odd
-registers of the source and destination pairs. Sets `vxsat` on saturation. This
-instruction is available only on RV32.
 
 <<<
 ==== PSSH1SADD.DW (RV32)
+
+===== Mnemonic
+
+pssh1sadd.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -5679,6 +5683,16 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSSH1SADD.DW (Packed Saturating Shift-left-by-1 Saturating Add, Double-wide
+Word) performs a 32-bit word saturating shift-left-by-1 followed by a saturating
+add across register pairs. For each 32-bit element, the value from `rs1` is
+saturating-shifted left by 1 (clamped to [-2^31, 2^31-1]), then the
+corresponding element from `rs2` is added with signed saturation. It is
+equivalent to performing SSH1SADD independently on both the even and odd
+registers of the source and destination pairs. Sets `vxsat` on saturation. This
+instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -5715,26 +5729,16 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pssh1sadd.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSH1SADD.DW (Packed Saturating Shift-left-by-1 Saturating Add, Double-wide
-Word) performs a 32-bit word saturating shift-left-by-1 followed by a saturating
-add across register pairs. For each 32-bit element, the value from `rs1` is
-saturating-shifted left by 1 (clamped to [-2^31, 2^31-1]), then the
-corresponding element from `rs2` is added with signed saturation. It is
-equivalent to performing SSH1SADD independently on both the even and odd
-registers of the source and destination pairs. Sets `vxsat` on saturation. This
-instruction is available only on RV32.
 
 <<<
 === Add-Subtract Cross
 
 
 ==== PAS.HX
+
+===== Mnemonic
+
+pas.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5755,6 +5759,13 @@ elements.
 ]}
 ....
 
+===== Description
+
+PAS.HX (Packed Add-Subtract Cross, Halfword) performs a cross add-subtract on
+packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
+halfword of `rs1` is added to the even halfword of `rs2`, while the odd (upper)
+halfword of `rs1` has the odd halfword of `rs2` subtracted from it. Results
+wrap modulo 2^16. This instruction is useful for complex number arithmetic.
 ===== Operation
 
 [source,pseudocode]
@@ -5776,20 +5787,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pas.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAS.HX (Packed Add-Subtract Cross, Halfword) performs a cross add-subtract on
-packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
-halfword of `rs1` is added to the even halfword of `rs2`, while the odd (upper)
-halfword of `rs1` has the odd halfword of `rs2` subtracted from it. Results
-wrap modulo 2^16. This instruction is useful for complex number arithmetic.
 
 <<<
 ==== PAS.WX (RV64)
+
+===== Mnemonic
+
+pas.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5809,6 +5813,13 @@ PAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PAS.WX (Packed Add-Subtract Cross, Word) performs a cross add-subtract on
+packed 32-bit word pairs. The even (lower) word of `rs1` is added to the even
+word of `rs2`, while the odd (upper) word of `rs1` has the odd word of `rs2`
+subtracted from it. Results wrap modulo 2^32. This instruction is useful for
+complex number arithmetic. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -5829,20 +5840,13 @@ d[63:32] = a_odd - b_odd
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pas.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAS.WX (Packed Add-Subtract Cross, Word) performs a cross add-subtract on
-packed 32-bit word pairs. The even (lower) word of `rs1` is added to the even
-word of `rs2`, while the odd (upper) word of `rs1` has the odd word of `rs2`
-subtracted from it. Results wrap modulo 2^32. This instruction is useful for
-complex number arithmetic. Available only in RV64.
 
 <<<
 ==== PSA.HX
+
+===== Mnemonic
+
+psa.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5863,6 +5867,13 @@ elements.
 ]}
 ....
 
+===== Description
+
+PSA.HX (Packed Subtract-Add Cross, Halfword) performs a cross subtract-add on
+packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
+halfword of `rs1` has the even halfword of `rs2` subtracted from it, while the
+odd (upper) halfword of `rs1` is added to the odd halfword of `rs2`. Results
+wrap modulo 2^16. This instruction is useful for complex number arithmetic.
 ===== Operation
 
 [source,pseudocode]
@@ -5884,20 +5895,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psa.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSA.HX (Packed Subtract-Add Cross, Halfword) performs a cross subtract-add on
-packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
-halfword of `rs1` has the even halfword of `rs2` subtracted from it, while the
-odd (upper) halfword of `rs1` is added to the odd halfword of `rs2`. Results
-wrap modulo 2^16. This instruction is useful for complex number arithmetic.
 
 <<<
 ==== PSA.WX (RV64)
+
+===== Mnemonic
+
+psa.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5917,6 +5921,13 @@ PSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSA.WX (Packed Subtract-Add Cross, Word) performs a cross subtract-add on
+packed 32-bit word pairs. The even (lower) word of `rs1` has the even word of
+`rs2` subtracted from it, while the odd (upper) word of `rs1` is added to the
+odd word of `rs2`. Results wrap modulo 2^32. This instruction is useful for
+complex number arithmetic. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -5937,20 +5948,13 @@ d[63:32] = a_odd + b_odd
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psa.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSA.WX (Packed Subtract-Add Cross, Word) performs a cross subtract-add on
-packed 32-bit word pairs. The even (lower) word of `rs1` has the even word of
-`rs2` subtracted from it, while the odd (upper) word of `rs1` is added to the
-odd word of `rs2`. Results wrap modulo 2^32. This instruction is useful for
-complex number arithmetic. Available only in RV64.
 
 <<<
 ==== PSAS.HX
+
+===== Mnemonic
+
+psas.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -5971,6 +5975,14 @@ elements.
 ]}
 ....
 
+===== Description
+
+PSAS.HX (Packed Saturating Add-Subtract Cross, Halfword) performs a cross
+saturating add-subtract on packed 16-bit halfword pairs. Within each 32-bit
+word, the even (lower) halfword is computed as a signed saturating addition,
+while the odd (upper) halfword is computed as a signed saturating subtraction.
+Results are clamped to the range [-2^15, 2^15-1]. Sets `vxsat` on saturation.
+This instruction is useful for complex number arithmetic.
 ===== Operation
 
 [source,pseudocode]
@@ -6002,21 +6014,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psas.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSAS.HX (Packed Saturating Add-Subtract Cross, Halfword) performs a cross
-saturating add-subtract on packed 16-bit halfword pairs. Within each 32-bit
-word, the even (lower) halfword is computed as a signed saturating addition,
-while the odd (upper) halfword is computed as a signed saturating subtraction.
-Results are clamped to the range [-2^15, 2^15-1]. Sets `vxsat` on saturation.
-This instruction is useful for complex number arithmetic.
 
 <<<
 ==== PSAS.WX (RV64)
+
+===== Mnemonic
+
+psas.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6036,6 +6040,14 @@ PSAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSAS.WX (Packed Saturating Add-Subtract Cross, Word) performs a cross saturating
+add-subtract on packed 32-bit word pairs. The even (lower) word is computed as a
+signed saturating addition, while the odd (upper) word is computed as a signed
+saturating subtraction. Results are clamped to the range [-2^31, 2^31-1]. Sets
+`vxsat` on saturation. This instruction is useful for complex number arithmetic.
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -6066,21 +6078,13 @@ d[63:32] = res_odd[31:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psas.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSAS.WX (Packed Saturating Add-Subtract Cross, Word) performs a cross saturating
-add-subtract on packed 32-bit word pairs. The even (lower) word is computed as a
-signed saturating addition, while the odd (upper) word is computed as a signed
-saturating subtraction. Results are clamped to the range [-2^31, 2^31-1]. Sets
-`vxsat` on saturation. This instruction is useful for complex number arithmetic.
-Available only in RV64.
 
 <<<
 ==== PSSA.HX
+
+===== Mnemonic
+
+pssa.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6101,6 +6105,14 @@ elements.
 ]}
 ....
 
+===== Description
+
+PSSA.HX (Packed Saturating Subtract-Add Cross, Halfword) performs a cross
+saturating subtract-add on packed 16-bit halfword pairs. Within each 32-bit
+word, the even (lower) halfword is computed as a signed saturating subtraction,
+while the odd (upper) halfword is computed as a signed saturating addition.
+Results are clamped to the range [-2^15, 2^15-1]. Sets `vxsat` on saturation.
+This instruction is useful for complex number arithmetic.
 ===== Operation
 
 [source,pseudocode]
@@ -6132,21 +6144,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssa.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSSA.HX (Packed Saturating Subtract-Add Cross, Halfword) performs a cross
-saturating subtract-add on packed 16-bit halfword pairs. Within each 32-bit
-word, the even (lower) halfword is computed as a signed saturating subtraction,
-while the odd (upper) halfword is computed as a signed saturating addition.
-Results are clamped to the range [-2^15, 2^15-1]. Sets `vxsat` on saturation.
-This instruction is useful for complex number arithmetic.
 
 <<<
 ==== PSSA.WX (RV64)
+
+===== Mnemonic
+
+pssa.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6166,6 +6170,14 @@ PSSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSSA.WX (Packed Saturating Subtract-Add Cross, Word) performs a cross saturating
+subtract-add on packed 32-bit word pairs. The even (lower) word is computed as a
+signed saturating subtraction, while the odd (upper) word is computed as a
+signed saturating addition. Results are clamped to the range [-2^31, 2^31-1].
+Sets `vxsat` on saturation. This instruction is useful for complex number
+arithmetic. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -6196,21 +6208,13 @@ d[63:32] = res_odd[31:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssa.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSSA.WX (Packed Saturating Subtract-Add Cross, Word) performs a cross saturating
-subtract-add on packed 32-bit word pairs. The even (lower) word is computed as a
-signed saturating subtraction, while the odd (upper) word is computed as a
-signed saturating addition. Results are clamped to the range [-2^31, 2^31-1].
-Sets `vxsat` on saturation. This instruction is useful for complex number
-arithmetic. Available only in RV64.
 
 <<<
 ==== PAAS.HX
+
+===== Mnemonic
+
+paas.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6231,6 +6235,15 @@ operations.
 ]}
 ....
 
+===== Description
+
+PAAS.HX (Packed Averaging Add-Subtract, Cross Halfword) performs a signed
+averaging cross add-subtract on packed 16-bit halfword elements. For each pair
+of halfwords, the odd (upper) halfword of `rs1` is added to the even (lower)
+halfword of `rs2` at full precision and the result is shifted right by 1, while
+the even (lower) halfword of `rs1` has the odd (upper) halfword of `rs2`
+subtracted at full precision and the result is shifted right by 1. The truncated
+results are written to the corresponding halfwords of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -6253,22 +6266,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-paas.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAAS.HX (Packed Averaging Add-Subtract, Cross Halfword) performs a signed
-averaging cross add-subtract on packed 16-bit halfword elements. For each pair
-of halfwords, the odd (upper) halfword of `rs1` is added to the even (lower)
-halfword of `rs2` at full precision and the result is shifted right by 1, while
-the even (lower) halfword of `rs1` has the odd (upper) halfword of `rs2`
-subtracted at full precision and the result is shifted right by 1. The truncated
-results are written to the corresponding halfwords of `rd`.
 
 <<<
 ==== PAAS.WX (RV64)
+
+===== Mnemonic
+
+paas.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6289,6 +6293,15 @@ Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PAAS.WX (Packed Averaging Add-Subtract, Cross Word) performs a signed averaging
+cross add-subtract on packed 32-bit word elements within a 64-bit register. The
+upper word of `rs1` is added to the lower word of `rs2` at full precision and
+the result is shifted right by 1, while the lower word of `rs1` has the upper
+word of `rs2` subtracted at full precision and the result is shifted right by 1.
+The truncated results are written to the corresponding words of `rd`. Available
+only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -6312,22 +6325,13 @@ d[31:0] = to_bits(32, diff >> 1)
 X[rd] = d
 ----
 
-===== Mnemonic
-
-paas.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PAAS.WX (Packed Averaging Add-Subtract, Cross Word) performs a signed averaging
-cross add-subtract on packed 32-bit word elements within a 64-bit register. The
-upper word of `rs1` is added to the lower word of `rs2` at full precision and
-the result is shifted right by 1, while the lower word of `rs1` has the upper
-word of `rs2` subtracted at full precision and the result is shifted right by 1.
-The truncated results are written to the corresponding words of `rd`. Available
-only in RV64.
 
 <<<
 ==== PASA.HX
+
+===== Mnemonic
+
+pasa.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6348,6 +6352,15 @@ operations.
 ]}
 ....
 
+===== Description
+
+PASA.HX (Packed Averaging Subtract-Add, Cross Halfword) performs a signed
+averaging cross subtract-add on packed 16-bit halfword elements. For each pair
+of halfwords, the odd (upper) halfword of `rs1` has the even (lower) halfword of
+`rs2` subtracted at full precision and the result is shifted right by 1, while
+the even (lower) halfword of `rs1` is added to the odd (upper) halfword of
+`rs2` at full precision and the result is shifted right by 1. The truncated
+results are written to the corresponding halfwords of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -6370,22 +6383,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pasa.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PASA.HX (Packed Averaging Subtract-Add, Cross Halfword) performs a signed
-averaging cross subtract-add on packed 16-bit halfword elements. For each pair
-of halfwords, the odd (upper) halfword of `rs1` has the even (lower) halfword of
-`rs2` subtracted at full precision and the result is shifted right by 1, while
-the even (lower) halfword of `rs1` is added to the odd (upper) halfword of
-`rs2` at full precision and the result is shifted right by 1. The truncated
-results are written to the corresponding halfwords of `rd`.
 
 <<<
 ==== PASA.WX (RV64)
+
+===== Mnemonic
+
+pasa.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6406,6 +6410,15 @@ Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PASA.WX (Packed Averaging Subtract-Add, Cross Word) performs a signed averaging
+cross subtract-add on packed 32-bit word elements within a 64-bit register. The
+upper word of `rs1` has the lower word of `rs2` subtracted at full precision and
+the result is shifted right by 1, while the lower word of `rs1` is added to the
+upper word of `rs2` at full precision and the result is shifted right by 1. The
+truncated results are written to the corresponding words of `rd`. Available only
+in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -6429,22 +6442,13 @@ d[31:0] = to_bits(32, sum >> 1)
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pasa.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PASA.WX (Packed Averaging Subtract-Add, Cross Word) performs a signed averaging
-cross subtract-add on packed 32-bit word elements within a 64-bit register. The
-upper word of `rs1` has the lower word of `rs2` subtracted at full precision and
-the result is shifted right by 1, while the lower word of `rs1` is added to the
-upper word of `rs2` at full precision and the result is shifted right by 1. The
-truncated results are written to the corresponding words of `rd`. Available only
-in RV64.
 
 <<<
 ==== PAS.DHX (RV32)
+
+===== Mnemonic
+
+pas.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -6467,6 +6471,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PAS.DHX (Packed Add-Subtract, Double-wide Cross Halfword) performs packed
+16-bit cross add-subtract on double-wide (register-pair) operands. It is
+equivalent to two PAS.HX operations: one on the even registers and one on the
+odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`) are
+register pairs and must specify even register numbers. For each pair of
+halfwords, the upper halfword is added cross with the lower halfword of the
+other operand, and vice versa with subtraction. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -6489,22 +6502,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pas.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PAS.DHX (Packed Add-Subtract, Double-wide Cross Halfword) performs packed
-16-bit cross add-subtract on double-wide (register-pair) operands. It is
-equivalent to two PAS.HX operations: one on the even registers and one on the
-odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`) are
-register pairs and must specify even register numbers. For each pair of
-halfwords, the upper halfword is added cross with the lower halfword of the
-other operand, and vice versa with subtraction. Available only in RV32.
 
 <<<
 ==== PSA.DHX (RV32)
+
+===== Mnemonic
+
+psa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -6527,6 +6531,16 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSA.DHX (Packed Subtract-Add, Double-wide Cross Halfword) performs packed
+16-bit cross subtract-add on double-wide (register-pair) operands. It is
+equivalent to two PSA.HX operations: one on the even registers and one on the
+odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`) are
+register pairs and must specify even register numbers. For each pair of
+halfwords, the upper halfword of `rs1` has the lower halfword of `rs2`
+subtracted, and the lower halfword of `rs1` is added with the upper halfword
+of `rs2`. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -6549,23 +6563,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psa.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSA.DHX (Packed Subtract-Add, Double-wide Cross Halfword) performs packed
-16-bit cross subtract-add on double-wide (register-pair) operands. It is
-equivalent to two PSA.HX operations: one on the even registers and one on the
-odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`) are
-register pairs and must specify even register numbers. For each pair of
-halfwords, the upper halfword of `rs1` has the lower halfword of `rs2`
-subtracted, and the lower halfword of `rs1` is added with the upper halfword
-of `rs2`. Available only in RV32.
 
 <<<
 ==== PSAS.DHX (RV32)
+
+===== Mnemonic
+
+psas.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -6588,6 +6592,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSAS.DHX (Packed Saturating Add-Subtract, Double-wide Cross Halfword) performs
+signed saturating cross add-subtract on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PSAS.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Results are saturated to the signed 16-bit range [-2^15, 2^15-1]. If saturation
+occurs, the overflow flag `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -6622,22 +6635,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psas.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSAS.DHX (Packed Saturating Add-Subtract, Double-wide Cross Halfword) performs
-signed saturating cross add-subtract on packed 16-bit halfword elements across
-register pairs. It is equivalent to two PSAS.HX operations: one on the even
-registers and one on the odd registers of each pair. All three operands (`rd_p`,
-`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
-Results are saturated to the signed 16-bit range [-2^15, 2^15-1]. If saturation
-occurs, the overflow flag `vxsat` is set. Available only in RV32.
 
 <<<
 ==== PSSA.DHX (RV32)
+
+===== Mnemonic
+
+pssa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -6660,6 +6664,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSSA.DHX (Packed Saturating Subtract-Add, Double-wide Cross Halfword) performs
+signed saturating cross subtract-add on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PSSA.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Results are saturated to the signed 16-bit range [-2^15, 2^15-1]. If saturation
+occurs, the overflow flag `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -6694,22 +6707,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pssa.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PSSA.DHX (Packed Saturating Subtract-Add, Double-wide Cross Halfword) performs
-signed saturating cross subtract-add on packed 16-bit halfword elements across
-register pairs. It is equivalent to two PSSA.HX operations: one on the even
-registers and one on the odd registers of each pair. All three operands (`rd_p`,
-`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
-Results are saturated to the signed 16-bit range [-2^15, 2^15-1]. If saturation
-occurs, the overflow flag `vxsat` is set. Available only in RV32.
 
 <<<
 ==== PAAS.DHX (RV32)
+
+===== Mnemonic
+
+paas.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -6732,6 +6736,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PAAS.DHX (Packed Averaging Add-Subtract, Double-wide Cross Halfword) performs
+signed averaging cross add-subtract on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PAAS.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Each result is computed at full precision and then shifted right by 1 (toward
+negative infinity). Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -6766,22 +6779,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-paas.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PAAS.DHX (Packed Averaging Add-Subtract, Double-wide Cross Halfword) performs
-signed averaging cross add-subtract on packed 16-bit halfword elements across
-register pairs. It is equivalent to two PAAS.HX operations: one on the even
-registers and one on the odd registers of each pair. All three operands (`rd_p`,
-`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
-Each result is computed at full precision and then shifted right by 1 (toward
-negative infinity). Available only in RV32.
 
 <<<
 ==== PASA.DHX (RV32)
+
+===== Mnemonic
+
+pasa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -6804,6 +6808,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PASA.DHX (Packed Averaging Subtract-Add, Double-wide Cross Halfword) performs
+signed averaging cross subtract-add on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PASA.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Each result is computed at full precision and then shifted right by 1 (toward
+negative infinity). Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -6838,24 +6851,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pasa.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PASA.DHX (Packed Averaging Subtract-Add, Double-wide Cross Halfword) performs
-signed averaging cross subtract-add on packed 16-bit halfword elements across
-register pairs. It is equivalent to two PASA.HX operations: one on the even
-registers and one on the odd registers of each pair. All three operands (`rd_p`,
-`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
-Each result is computed at full precision and then shifted right by 1 (toward
-negative infinity). Available only in RV32.
 
 <<<
 === Absolute Difference
 
 ==== PABD.B
+
+===== Mnemonic
+
+pabd.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6875,6 +6879,12 @@ PABD.B is encoded in the OP-32 major opcode. It uses packed byte elements.
 ]}
 ....
 
+===== Description
+
+The PABD.B instruction computes the absolute difference of corresponding packed
+8-bit elements of `rs1` and `rs2`, using signed comparison, and writes the result
+to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -6890,22 +6900,16 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pabd.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PABD.B instruction computes the absolute difference of corresponding packed
-8-bit elements of `rs1` and `rs2`, using signed comparison, and writes the result
-to `rd`.
-
 ===== Notes
 
 * Signed ordering is used to determine the magnitude of each element difference.
 
 <<<
 ==== PABD.H
+
+===== Mnemonic
+
+pabd.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6925,6 +6929,11 @@ PABD.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
 ]}
 ....
 
+===== Description
+
+The PABD.H instruction computes the absolute difference of corresponding packed
+16-bit elements of `rs1` and `rs2`, using signed comparison, and writes the
+result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -6940,18 +6949,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pabd.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PABD.H instruction computes the absolute difference of corresponding packed
-16-bit elements of `rs1` and `rs2`, using signed comparison, and writes the
-result to `rd`.
 
 <<<
 ==== PABDU.B
+
+===== Mnemonic
+
+pabdu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -6971,6 +6975,12 @@ PABDU.B is encoded in the OP-32 major opcode. It uses packed byte elements.
 ]}
 ....
 
+===== Description
+
+The PABDU.B instruction computes the absolute difference of corresponding packed
+8-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
+result to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -6986,22 +6996,16 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pabdu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PABDU.B instruction computes the absolute difference of corresponding packed
-8-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
-result to `rd`.
-
 ===== Notes
 
 * Unsigned ordering is used to determine the magnitude of each element difference.
 
 <<<
 ==== PABDU.H
+
+===== Mnemonic
+
+pabdu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7021,6 +7025,11 @@ PABDU.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
 ]}
 ....
 
+===== Description
+
+The PABDU.H instruction computes the absolute difference of corresponding packed
+16-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
+result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -7036,19 +7045,14 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pabdu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PABDU.H instruction computes the absolute difference of corresponding packed
-16-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
-result to `rd`.
 
 
 <<<
 ==== PABDSUMU.B
+
+===== Mnemonic
+
+pabdsumu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7068,6 +7072,14 @@ PABDSUMU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PABDSUMU.B (Packed Absolute Difference Sum, Unsigned Byte) computes the sum of
+absolute differences of packed unsigned 8-bit byte elements from `rs1` and
+`rs2`. For each byte lane, the unsigned absolute difference is computed, and all
+differences are summed into a single scalar result written to `rd`. This
+instruction is commonly used in motion estimation and image processing
+algorithms.
 ===== Operation
 
 [source,pseudocode]
@@ -7085,21 +7097,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = to_bits(XLEN, sum)
 ----
 
-===== Mnemonic
-
-pabdsumu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PABDSUMU.B (Packed Absolute Difference Sum, Unsigned Byte) computes the sum of
-absolute differences of packed unsigned 8-bit byte elements from `rs1` and
-`rs2`. For each byte lane, the unsigned absolute difference is computed, and all
-differences are summed into a single scalar result written to `rd`. This
-instruction is commonly used in motion estimation and image processing
-algorithms.
 
 <<<
 ==== PABDSUMAU.B
+
+===== Mnemonic
+
+pabdsumau.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7119,6 +7123,15 @@ PABDSUMAU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PABDSUMAU.B (Packed Absolute Difference Sum Accumulate, Unsigned Byte) computes
+the sum of absolute differences of packed unsigned 8-bit byte elements from
+`rs1` and `rs2`, and accumulates the result into `rd`. For each byte lane, the
+unsigned absolute difference is computed. All differences are summed and added to
+the current value of `rd`. This accumulating form is useful for iteratively
+computing the sum of absolute differences across multiple register-widths of
+data, as commonly needed in motion estimation and image processing algorithms.
 ===== Operation
 
 [source,pseudocode]
@@ -7136,22 +7149,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = to_bits(XLEN, sum)
 ----
 
-===== Mnemonic
-
-pabdsumau.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PABDSUMAU.B (Packed Absolute Difference Sum Accumulate, Unsigned Byte) computes
-the sum of absolute differences of packed unsigned 8-bit byte elements from
-`rs1` and `rs2`, and accumulates the result into `rd`. For each byte lane, the
-unsigned absolute difference is computed. All differences are summed and added to
-the current value of `rd`. This accumulating form is useful for iteratively
-computing the sum of absolute differences across multiple register-widths of
-data, as commonly needed in motion estimation and image processing algorithms.
 
 <<<
 ==== PABD.DB (RV32)
+
+===== Mnemonic
+
+pabd.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -7175,6 +7179,14 @@ operands.
 ]}
 ....
 
+===== Description
+
+PABD.DB (Packed Absolute Difference, Double-wide Byte) computes the signed
+absolute difference of packed 8-bit elements across register pairs. It is
+equivalent to performing PABD.B independently on both the even and odd registers
+of the source and destination pairs. For each byte lane, the signed absolute
+difference |rs1[i] - rs2[i]| is computed. This instruction is available only
+on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -7199,21 +7211,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pabd.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PABD.DB (Packed Absolute Difference, Double-wide Byte) computes the signed
-absolute difference of packed 8-bit elements across register pairs. It is
-equivalent to performing PABD.B independently on both the even and odd registers
-of the source and destination pairs. For each byte lane, the signed absolute
-difference |rs1[i] - rs2[i]| is computed. This instruction is available only
-on RV32.
 
 <<<
 ==== PABD.DH (RV32)
+
+===== Mnemonic
+
+pabd.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -7237,6 +7241,14 @@ operands.
 ]}
 ....
 
+===== Description
+
+PABD.DH (Packed Absolute Difference, Double-wide Halfword) computes the signed
+absolute difference of packed 16-bit halfword elements across register pairs. It
+is equivalent to performing PABD.H independently on both the even and odd
+registers of the source and destination pairs. For each halfword lane, the
+signed absolute difference |rs1[i] - rs2[i]| is computed. This instruction is
+available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -7261,21 +7273,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pabd.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PABD.DH (Packed Absolute Difference, Double-wide Halfword) computes the signed
-absolute difference of packed 16-bit halfword elements across register pairs. It
-is equivalent to performing PABD.H independently on both the even and odd
-registers of the source and destination pairs. For each halfword lane, the
-signed absolute difference |rs1[i] - rs2[i]| is computed. This instruction is
-available only on RV32.
 
 <<<
 ==== PABDU.DB (RV32)
+
+===== Mnemonic
+
+pabdu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -7299,6 +7303,14 @@ operands.
 ]}
 ....
 
+===== Description
+
+PABDU.DB (Packed Absolute Difference Unsigned, Double-wide Byte) computes the
+unsigned absolute difference of packed 8-bit elements across register pairs. It
+is equivalent to performing PABDU.B independently on both the even and odd
+registers of the source and destination pairs. For each byte lane, the unsigned
+absolute difference |rs1[i] - rs2[i]| is computed. This instruction is
+available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -7323,21 +7335,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pabdu.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PABDU.DB (Packed Absolute Difference Unsigned, Double-wide Byte) computes the
-unsigned absolute difference of packed 8-bit elements across register pairs. It
-is equivalent to performing PABDU.B independently on both the even and odd
-registers of the source and destination pairs. For each byte lane, the unsigned
-absolute difference |rs1[i] - rs2[i]| is computed. This instruction is
-available only on RV32.
 
 <<<
 ==== PABDU.DH (RV32)
+
+===== Mnemonic
+
+pabdu.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -7361,6 +7365,14 @@ operands.
 ]}
 ....
 
+===== Description
+
+PABDU.DH (Packed Absolute Difference Unsigned, Double-wide Halfword) computes
+the unsigned absolute difference of packed 16-bit halfword elements across
+register pairs. It is equivalent to performing PABDU.H independently on both the
+even and odd registers of the source and destination pairs. For each halfword
+lane, the unsigned absolute difference |rs1[i] - rs2[i]| is computed. This
+instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -7385,24 +7397,16 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pabdu.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PABDU.DH (Packed Absolute Difference Unsigned, Double-wide Halfword) computes
-the unsigned absolute difference of packed 16-bit halfword elements across
-register pairs. It is equivalent to performing PABDU.H independently on both the
-even and odd registers of the source and destination pairs. For each halfword
-lane, the unsigned absolute difference |rs1[i] - rs2[i]| is computed. This
-instruction is available only on RV32.
 
 <<<
 === Saturating Absolute
 
 
 ==== PSABS.B
+
+===== Mnemonic
+
+psabs.b _rd_, _rs1_
 
 ===== Encoding
 
@@ -7422,6 +7426,13 @@ packed byte elements.
 ]}
 ....
 
+===== Description
+
+PSABS.B (Packed Saturating Absolute Value, Byte) computes the saturating
+absolute value of each packed signed 8-bit byte element in `rs1` and writes the
+results to `rd`. If an element is -128 (the most negative value), the result
+saturates to 127 and the overflow flag `vxsat` is set. For all other values,
+the result is the standard absolute value.
 ===== Operation
 
 [source,pseudocode]
@@ -7441,20 +7452,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psabs.b _rd_, _rs1_
-
-===== Description
-
-PSABS.B (Packed Saturating Absolute Value, Byte) computes the saturating
-absolute value of each packed signed 8-bit byte element in `rs1` and writes the
-results to `rd`. If an element is -128 (the most negative value), the result
-saturates to 127 and the overflow flag `vxsat` is set. For all other values,
-the result is the standard absolute value.
 
 <<<
 ==== PSABS.H
+
+===== Mnemonic
+
+psabs.h _rd_, _rs1_
 
 ===== Encoding
 
@@ -7474,6 +7478,13 @@ packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PSABS.H (Packed Saturating Absolute Value, Halfword) computes the saturating
+absolute value of each packed signed 16-bit halfword element in `rs1` and writes
+the results to `rd`. If an element is -32768 (the most negative value), the
+result saturates to 32767 and the overflow flag `vxsat` is set. For all other
+values, the result is the standard absolute value.
 ===== Operation
 
 [source,pseudocode]
@@ -7493,20 +7504,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psabs.h _rd_, _rs1_
-
-===== Description
-
-PSABS.H (Packed Saturating Absolute Value, Halfword) computes the saturating
-absolute value of each packed signed 16-bit halfword element in `rs1` and writes
-the results to `rd`. If an element is -32768 (the most negative value), the
-result saturates to 32767 and the overflow flag `vxsat` is set. For all other
-values, the result is the standard absolute value.
 
 <<<
 ==== PSABS.DB (RV32)
+
+===== Mnemonic
+
+psabs.db _rd_p_, _rs1_p_
 
 ===== Encoding
 
@@ -7528,6 +7532,14 @@ opcode using the double-wide register-pair format.
 ]}
 ....
 
+===== Description
+
+PSABS.DB (Packed Saturating Absolute Value, Double-wide Byte) computes the
+saturating absolute value of packed signed 8-bit byte elements across register
+pairs. It is equivalent to performing PSABS.B independently on both the even and
+odd registers of the source and destination pairs. If an element is -128 (the
+most negative value), the result saturates to 127 and the overflow flag `vxsat`
+is set. This instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -7560,21 +7572,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psabs.db _rd_p_, _rs1_p_
-
-===== Description
-
-PSABS.DB (Packed Saturating Absolute Value, Double-wide Byte) computes the
-saturating absolute value of packed signed 8-bit byte elements across register
-pairs. It is equivalent to performing PSABS.B independently on both the even and
-odd registers of the source and destination pairs. If an element is -128 (the
-most negative value), the result saturates to 127 and the overflow flag `vxsat`
-is set. This instruction is available only on RV32.
 
 <<<
 ==== PSABS.DH (RV32)
+
+===== Mnemonic
+
+psabs.dh _rd_p_, _rs1_p_
 
 ===== Encoding
 
@@ -7596,6 +7600,14 @@ opcode using the double-wide register-pair format.
 ]}
 ....
 
+===== Description
+
+PSABS.DH (Packed Saturating Absolute Value, Double-wide Halfword) computes the
+saturating absolute value of packed signed 16-bit halfword elements across
+register pairs. It is equivalent to performing PSABS.H independently on both the
+even and odd registers of the source and destination pairs. If an element is
+-32768 (the most negative value), the result saturates to 32767 and the overflow
+flag `vxsat` is set. This instruction is available only on RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -7628,23 +7640,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psabs.dh _rd_p_, _rs1_p_
-
-===== Description
-
-PSABS.DH (Packed Saturating Absolute Value, Double-wide Halfword) computes the
-saturating absolute value of packed signed 16-bit halfword elements across
-register pairs. It is equivalent to performing PSABS.H independently on both the
-even and odd registers of the source and destination pairs. If an element is
--32768 (the most negative value), the result saturates to 32767 and the overflow
-flag `vxsat` is set. This instruction is available only on RV32.
 
 <<<
 === Reduction Sum
 
 ==== PREDSUM.BS
+
+===== Mnemonic
+
+predsum.bs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7666,6 +7670,11 @@ operation using packed byte elements.
 ]}
 ....
 
+===== Description
+
+The PREDSUM.BS instruction computes a signed reduction sum of packed 8-bit
+elements in `rs1`. Each element is sign-extended to XLEN and accumulated into
+the initial value in `rs2`. The final sum is written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -7680,18 +7689,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = sum
 ----
 
-===== Mnemonic
-
-predsum.bs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PREDSUM.BS instruction computes a signed reduction sum of packed 8-bit
-elements in `rs1`. Each element is sign-extended to XLEN and accumulated into
-the initial value in `rs2`. The final sum is written to `rd`.
 
 <<<
 ==== PREDSUM.HS
+
+===== Mnemonic
+
+predsum.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7712,6 +7716,10 @@ PREDSUM.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
+===== Description
+
+The PREDSUM.HS instruction computes a signed reduction sum of packed 16-bit
+elements in `rs1`, accumulating into the initial value in `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -7726,17 +7734,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = sum
 ----
 
-===== Mnemonic
-
-predsum.hs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PREDSUM.HS instruction computes a signed reduction sum of packed 16-bit
-elements in `rs1`, accumulating into the initial value in `rs2`.
 
 <<<
 ==== PREDSUM.WS (RV64)
+
+===== Mnemonic
+
+predsum.ws _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7757,6 +7761,10 @@ PREDSUM.WS is encoded in the OP-IMM-32 major opcode and is available only in RV6
 ]}
 ....
 
+===== Description
+
+The PREDSUM.WS instruction computes a signed reduction sum of the two packed
+32-bit elements in `rs1`, accumulating into `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -7767,17 +7775,13 @@ X[rd] = X[rs2]
         + sign_extend(64, s1[63:32])
 ----
 
-===== Mnemonic
-
-predsum.ws _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PREDSUM.WS instruction computes a signed reduction sum of the two packed
-32-bit elements in `rs1`, accumulating into `rs2`.
 
 <<<
 ==== PREDSUMU.BS
+
+===== Mnemonic
+
+predsumu.bs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7799,6 +7803,11 @@ operation using packed byte elements.
 ]}
 ....
 
+===== Description
+
+The PREDSUMU.BS instruction computes an unsigned reduction sum of packed 8-bit
+elements in `rs1`. Each element is zero-extended to XLEN and accumulated into
+the initial value in `rs2`. The final sum is written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -7813,18 +7822,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = sum
 ----
 
-===== Mnemonic
-
-predsumu.bs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PREDSUMU.BS instruction computes an unsigned reduction sum of packed 8-bit
-elements in `rs1`. Each element is zero-extended to XLEN and accumulated into
-the initial value in `rs2`. The final sum is written to `rd`.
 
 <<<
 ==== PREDSUMU.HS
+
+===== Mnemonic
+
+predsumu.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7845,6 +7849,10 @@ PREDSUMU.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
+===== Description
+
+The PREDSUMU.HS instruction computes an unsigned reduction sum of packed 16-bit
+elements in `rs1`, accumulating into the initial value in `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -7859,17 +7867,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = sum
 ----
 
-===== Mnemonic
-
-predsumu.hs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PREDSUMU.HS instruction computes an unsigned reduction sum of packed 16-bit
-elements in `rs1`, accumulating into the initial value in `rs2`.
 
 <<<
 ==== PREDSUMU.WS (RV64)
+
+===== Mnemonic
+
+predsumu.ws _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7890,6 +7894,10 @@ PREDSUMU.WS is encoded in the OP-IMM-32 major opcode and is available only in RV
 ]}
 ....
 
+===== Description
+
+The PREDSUMU.WS instruction computes an unsigned reduction sum of the two packed
+32-bit elements in `rs1`, accumulating into `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -7900,14 +7908,6 @@ X[rd] = X[rs2]
         + zero_extend(64, s1[63:32])
 ----
 
-===== Mnemonic
-
-predsumu.ws _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PREDSUMU.WS instruction computes an unsigned reduction sum of the two packed
-32-bit elements in `rs1`, accumulating into `rs2`.
 
 
 <<<
@@ -7915,6 +7915,10 @@ The PREDSUMU.WS instruction computes an unsigned reduction sum of the two packed
 
 
 ==== PMIN.B
+
+===== Mnemonic
+
+pmin.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7934,6 +7938,10 @@ PMIN.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PMIN.B computes the signed minimum of corresponding packed 8-bit byte elements
+of `rs1` and `rs2` and writes the packed byte results to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -7949,17 +7957,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmin.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMIN.B computes the signed minimum of corresponding packed 8-bit byte elements
-of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
 <<<
 ==== PMIN.H
+
+===== Mnemonic
+
+pmin.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -7979,6 +7983,10 @@ PMIN.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMIN.H computes the signed minimum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -7994,17 +8002,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmin.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMIN.H computes the signed minimum of corresponding packed 16-bit halfword
-elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
 <<<
 ==== PMIN.W (RV64)
+
+===== Mnemonic
+
+pmin.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8024,6 +8028,11 @@ PMIN.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PMIN.W computes the signed minimum of corresponding packed 32-bit word elements
+of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
+in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -8037,18 +8046,13 @@ d[63:32] = (signed(s1[63:32]) < signed(s2[63:32])) ? s1[63:32] : s2[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmin.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMIN.W computes the signed minimum of corresponding packed 32-bit word elements
-of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
-in RV64.
 
 <<<
 ==== PMINU.B
+
+===== Mnemonic
+
+pminu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8068,6 +8072,10 @@ PMINU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PMINU.B computes the unsigned minimum of corresponding packed 8-bit byte
+elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -8083,17 +8091,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pminu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMINU.B computes the unsigned minimum of corresponding packed 8-bit byte
-elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
 <<<
 ==== PMINU.H
+
+===== Mnemonic
+
+pminu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8113,6 +8117,10 @@ PMINU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMINU.H computes the unsigned minimum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -8128,17 +8136,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pminu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMINU.H computes the unsigned minimum of corresponding packed 16-bit halfword
-elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
 <<<
 ==== PMINU.W (RV64)
+
+===== Mnemonic
+
+pminu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8158,6 +8162,11 @@ PMINU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PMINU.W computes the unsigned minimum of corresponding packed 32-bit word
+elements of `rs1` and `rs2` and writes the packed word results to `rd`.
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -8171,18 +8180,13 @@ d[63:32] = (unsigned(s1[63:32]) < unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pminu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMINU.W computes the unsigned minimum of corresponding packed 32-bit word
-elements of `rs1` and `rs2` and writes the packed word results to `rd`.
-Available only in RV64.
 
 <<<
 ==== PMAX.B
+
+===== Mnemonic
+
+pmax.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8202,6 +8206,10 @@ PMAX.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PMAX.B computes the signed maximum of corresponding packed 8-bit byte elements
+of `rs1` and `rs2` and writes the packed byte results to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -8217,17 +8225,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmax.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMAX.B computes the signed maximum of corresponding packed 8-bit byte elements
-of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
 <<<
 ==== PMAX.H
+
+===== Mnemonic
+
+pmax.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8247,6 +8251,10 @@ PMAX.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMAX.H computes the signed maximum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -8262,17 +8270,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmax.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMAX.H computes the signed maximum of corresponding packed 16-bit halfword
-elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
 <<<
 ==== PMAX.W (RV64)
+
+===== Mnemonic
+
+pmax.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8292,6 +8296,11 @@ PMAX.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PMAX.W computes the signed maximum of corresponding packed 32-bit word elements
+of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
+in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -8305,18 +8314,13 @@ d[63:32] = (signed(s1[63:32]) > signed(s2[63:32])) ? s1[63:32] : s2[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmax.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMAX.W computes the signed maximum of corresponding packed 32-bit word elements
-of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
-in RV64.
 
 <<<
 ==== PMAXU.B
+
+===== Mnemonic
+
+pmaxu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8336,6 +8340,10 @@ PMAXU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PMAXU.B computes the unsigned maximum of corresponding packed 8-bit byte
+elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -8351,17 +8359,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmaxu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMAXU.B computes the unsigned maximum of corresponding packed 8-bit byte
-elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
 <<<
 ==== PMAXU.H
+
+===== Mnemonic
+
+pmaxu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8381,6 +8385,10 @@ PMAXU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMAXU.H computes the unsigned maximum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -8396,17 +8404,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmaxu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMAXU.H computes the unsigned maximum of corresponding packed 16-bit halfword
-elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
 <<<
 ==== PMAXU.W (RV64)
+
+===== Mnemonic
+
+pmaxu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -8426,6 +8430,11 @@ PMAXU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+PMAXU.W computes the unsigned maximum of corresponding packed 32-bit word
+elements of `rs1` and `rs2` and writes the packed word results to `rd`.
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -8439,18 +8448,13 @@ d[63:32] = (unsigned(s1[63:32]) > unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmaxu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMAXU.W computes the unsigned maximum of corresponding packed 32-bit word
-elements of `rs1` and `rs2` and writes the packed word results to `rd`.
-Available only in RV64.
 
 <<<
 ==== PMIN.DB (RV32)
+
+===== Mnemonic
+
+pmin.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8473,6 +8477,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMIN.DB performs packed signed 8-bit byte minimum on double-wide (register-pair)
+operands. It is equivalent to two PMIN.B operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8497,20 +8508,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmin.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMIN.DB performs packed signed 8-bit byte minimum on double-wide (register-pair)
-operands. It is equivalent to two PMIN.B operations: one on the even registers
-and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
-`rs2_p`) are register pairs and must specify even register numbers. Available
-only in RV32.
 
 <<<
 ==== PMIN.DH (RV32)
+
+===== Mnemonic
+
+pmin.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8533,6 +8537,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMIN.DH performs packed signed 16-bit halfword minimum on double-wide
+(register-pair) operands. It is equivalent to two PMIN.H operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8557,20 +8568,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmin.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMIN.DH performs packed signed 16-bit halfword minimum on double-wide
-(register-pair) operands. It is equivalent to two PMIN.H operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMIN.DW (RV32)
+
+===== Mnemonic
+
+pmin.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8593,6 +8597,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMIN.DW performs signed 32-bit word minimum on double-wide (register-pair)
+operands. It is equivalent to two signed MIN operations: one on the even
+registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8610,20 +8621,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmin.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMIN.DW performs signed 32-bit word minimum on double-wide (register-pair)
-operands. It is equivalent to two signed MIN operations: one on the even
-registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMINU.DB (RV32)
+
+===== Mnemonic
+
+pminu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8646,6 +8650,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMINU.DB performs packed unsigned 8-bit byte minimum on double-wide
+(register-pair) operands. It is equivalent to two PMINU.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8670,20 +8681,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pminu.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMINU.DB performs packed unsigned 8-bit byte minimum on double-wide
-(register-pair) operands. It is equivalent to two PMINU.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMINU.DH (RV32)
+
+===== Mnemonic
+
+pminu.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8706,6 +8710,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMINU.DH performs packed unsigned 16-bit halfword minimum on double-wide
+(register-pair) operands. It is equivalent to two PMINU.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8730,20 +8741,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pminu.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMINU.DH performs packed unsigned 16-bit halfword minimum on double-wide
-(register-pair) operands. It is equivalent to two PMINU.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMINU.DW (RV32)
+
+===== Mnemonic
+
+pminu.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8766,6 +8770,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMINU.DW performs unsigned 32-bit word minimum on double-wide (register-pair)
+operands. It is equivalent to two unsigned MIN operations: one on the even
+registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8783,20 +8794,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pminu.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMINU.DW performs unsigned 32-bit word minimum on double-wide (register-pair)
-operands. It is equivalent to two unsigned MIN operations: one on the even
-registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMAX.DB (RV32)
+
+===== Mnemonic
+
+pmax.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8819,6 +8823,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMAX.DB performs packed signed 8-bit byte maximum on double-wide (register-pair)
+operands. It is equivalent to two PMAX.B operations: one on the even registers
+and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
+`rs2_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8843,20 +8854,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmax.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMAX.DB performs packed signed 8-bit byte maximum on double-wide (register-pair)
-operands. It is equivalent to two PMAX.B operations: one on the even registers
-and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
-`rs2_p`) are register pairs and must specify even register numbers. Available
-only in RV32.
 
 <<<
 ==== PMAX.DH (RV32)
+
+===== Mnemonic
+
+pmax.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8879,6 +8883,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMAX.DH performs packed signed 16-bit halfword maximum on double-wide
+(register-pair) operands. It is equivalent to two PMAX.H operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8903,20 +8914,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmax.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMAX.DH performs packed signed 16-bit halfword maximum on double-wide
-(register-pair) operands. It is equivalent to two PMAX.H operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMAX.DW (RV32)
+
+===== Mnemonic
+
+pmax.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8939,6 +8943,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMAX.DW performs signed 32-bit word maximum on double-wide (register-pair)
+operands. It is equivalent to two signed MAX operations: one on the even
+registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -8956,20 +8967,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmax.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMAX.DW performs signed 32-bit word maximum on double-wide (register-pair)
-operands. It is equivalent to two signed MAX operations: one on the even
-registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMAXU.DB (RV32)
+
+===== Mnemonic
+
+pmaxu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -8992,6 +8996,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMAXU.DB performs packed unsigned 8-bit byte maximum on double-wide
+(register-pair) operands. It is equivalent to two PMAXU.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -9016,20 +9027,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmaxu.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMAXU.DB performs packed unsigned 8-bit byte maximum on double-wide
-(register-pair) operands. It is equivalent to two PMAXU.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMAXU.DH (RV32)
+
+===== Mnemonic
+
+pmaxu.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -9052,6 +9056,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMAXU.DH performs packed unsigned 16-bit halfword maximum on double-wide
+(register-pair) operands. It is equivalent to two PMAXU.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -9076,20 +9087,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmaxu.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMAXU.DH performs packed unsigned 16-bit halfword maximum on double-wide
-(register-pair) operands. It is equivalent to two PMAXU.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PMAXU.DW (RV32)
+
+===== Mnemonic
+
+pmaxu.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -9112,6 +9116,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMAXU.DW performs unsigned 32-bit word maximum on double-wide (register-pair)
+operands. It is equivalent to two unsigned MAX operations: one on the even
+registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -9129,22 +9140,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmaxu.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMAXU.DW performs unsigned 32-bit word maximum on double-wide (register-pair)
-operands. It is equivalent to two unsigned MAX operations: one on the even
-registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 === Comparison
 
 ==== PMSEQ.B
+
+===== Mnemonic
+
+pmseq.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9164,6 +9168,12 @@ PMSEQ.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PMSEQ.B (Packed Mask Set-if-Equal, Byte) compares corresponding packed 8-bit
+byte elements of `rs1` and `rs2`. For each element position, if the elements
+are equal the result byte is set to all ones (0xFF); otherwise it is set to
+all zeros (0x00). The packed results are written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -9179,19 +9189,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmseq.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMSEQ.B (Packed Mask Set-if-Equal, Byte) compares corresponding packed 8-bit
-byte elements of `rs1` and `rs2`. For each element position, if the elements
-are equal the result byte is set to all ones (0xFF); otherwise it is set to
-all zeros (0x00). The packed results are written to `rd`.
 
 <<<
 ==== PMSEQ.H
+
+===== Mnemonic
+
+pmseq.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9211,6 +9215,12 @@ PMSEQ.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMSEQ.H (Packed Mask Set-if-Equal, Halfword) compares corresponding packed
+16-bit halfword elements of `rs1` and `rs2`. For each element position, if the
+elements are equal the result halfword is set to all ones (0xFFFF); otherwise
+it is set to all zeros (0x0000). The packed results are written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -9226,19 +9236,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmseq.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMSEQ.H (Packed Mask Set-if-Equal, Halfword) compares corresponding packed
-16-bit halfword elements of `rs1` and `rs2`. For each element position, if the
-elements are equal the result halfword is set to all ones (0xFFFF); otherwise
-it is set to all zeros (0x0000). The packed results are written to `rd`.
 
 <<<
 ==== PMSEQ.W (RV64)
+
+===== Mnemonic
+
+pmseq.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9258,6 +9262,10 @@ PMSEQ.W is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The PMSEQ.W instruction compares corresponding packed 32-bit elements for
+equality and produces a packed word mask in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -9269,17 +9277,13 @@ d1 = (s1[63:32] == s2[63:32]) ? 0xFFFFFFFF : 0x00000000
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmseq.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMSEQ.W instruction compares corresponding packed 32-bit elements for
-equality and produces a packed word mask in `rd`.
 
 <<<
 ==== PMSLT.B
+
+===== Mnemonic
+
+pmslt.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9299,6 +9303,12 @@ PMSLT.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PMSLT.B performs a signed less-than comparison on corresponding packed 8-bit byte
+elements of `rs1` and `rs2`. For each element, if the signed value of `rs1` is
+less than the signed value of `rs2`, the corresponding byte in `rd` is set to
+all-ones (0xFF); otherwise it is set to all-zeros (0x00).
 ===== Operation
 
 [source,pseudocode]
@@ -9314,19 +9324,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmslt.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMSLT.B performs a signed less-than comparison on corresponding packed 8-bit byte
-elements of `rs1` and `rs2`. For each element, if the signed value of `rs1` is
-less than the signed value of `rs2`, the corresponding byte in `rd` is set to
-all-ones (0xFF); otherwise it is set to all-zeros (0x00).
 
 <<<
 ==== PMSLT.H
+
+===== Mnemonic
+
+pmslt.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9346,6 +9350,12 @@ PMSLT.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMSLT.H performs a signed less-than comparison on corresponding packed 16-bit
+halfword elements of `rs1` and `rs2`. For each element, if the signed value of
+`rs1` is less than the signed value of `rs2`, the corresponding halfword in `rd`
+is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
 ===== Operation
 
 [source,pseudocode]
@@ -9361,19 +9371,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmslt.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMSLT.H performs a signed less-than comparison on corresponding packed 16-bit
-halfword elements of `rs1` and `rs2`. For each element, if the signed value of
-`rs1` is less than the signed value of `rs2`, the corresponding halfword in `rd`
-is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
 
 <<<
 ==== PMSLT.W (RV64)
+
+===== Mnemonic
+
+pmslt.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9393,6 +9397,10 @@ PMSLT.W is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The PMSLT.W instruction performs signed less-than comparisons on corresponding
+packed 32-bit elements and produces a packed word mask in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -9404,17 +9412,13 @@ d1 = (s1[63:32] <_s s2[63:32]) ? 0xFFFFFFFF : 0x00000000
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmslt.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMSLT.W instruction performs signed less-than comparisons on corresponding
-packed 32-bit elements and produces a packed word mask in `rd`.
 
 <<<
 ==== PMSLTU.B
+
+===== Mnemonic
+
+pmsltu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9434,6 +9438,12 @@ PMSLTU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PMSLTU.B performs an unsigned less-than comparison on corresponding packed 8-bit
+byte elements of `rs1` and `rs2`. For each element, if the unsigned value of
+`rs1` is less than the unsigned value of `rs2`, the corresponding byte in `rd` is
+set to all-ones (0xFF); otherwise it is set to all-zeros (0x00).
 ===== Operation
 
 [source,pseudocode]
@@ -9449,19 +9459,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmsltu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMSLTU.B performs an unsigned less-than comparison on corresponding packed 8-bit
-byte elements of `rs1` and `rs2`. For each element, if the unsigned value of
-`rs1` is less than the unsigned value of `rs2`, the corresponding byte in `rd` is
-set to all-ones (0xFF); otherwise it is set to all-zeros (0x00).
 
 <<<
 ==== PMSLTU.H
+
+===== Mnemonic
+
+pmsltu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9481,6 +9485,12 @@ PMSLTU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMSLTU.H performs an unsigned less-than comparison on corresponding packed 16-bit
+halfword elements of `rs1` and `rs2`. For each element, if the unsigned value of
+`rs1` is less than the unsigned value of `rs2`, the corresponding halfword in
+`rd` is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
 ===== Operation
 
 [source,pseudocode]
@@ -9496,19 +9506,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmsltu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMSLTU.H performs an unsigned less-than comparison on corresponding packed 16-bit
-halfword elements of `rs1` and `rs2`. For each element, if the unsigned value of
-`rs1` is less than the unsigned value of `rs2`, the corresponding halfword in
-`rd` is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
 
 <<<
 ==== PMSLTU.W (RV64)
+
+===== Mnemonic
+
+pmsltu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9528,6 +9532,10 @@ PMSLTU.W is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The PMSLTU.W instruction performs unsigned less-than comparisons on corresponding
+packed 32-bit elements and produces a packed word mask in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -9539,17 +9547,13 @@ d1 = (s1[63:32] <_u s2[63:32]) ? 0xFFFFFFFF : 0x00000000
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmsltu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMSLTU.W instruction performs unsigned less-than comparisons on corresponding
-packed 32-bit elements and produces a packed word mask in `rd`.
 
 <<<
 ==== MSEQ (RV32)
+
+===== Mnemonic
+
+mseq _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9569,6 +9573,10 @@ MSEQ is available only in RV32.
 ]}
 ....
 
+===== Description
+
+The MSEQ instruction sets `rd` to all ones if `rs1` equals `rs2`; otherwise it
+sets `rd` to zero.
 ===== Operation
 
 [source,pseudocode]
@@ -9576,17 +9584,13 @@ MSEQ is available only in RV32.
 X[rd] = (X[rs1] == X[rs2]) ? 0xFFFFFFFF : 0x00000000
 ----
 
-===== Mnemonic
-
-mseq _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MSEQ instruction sets `rd` to all ones if `rs1` equals `rs2`; otherwise it
-sets `rd` to zero.
 
 <<<
 ==== MSLT (RV32)
+
+===== Mnemonic
+
+mslt _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9606,6 +9610,10 @@ MSLT is available only in RV32.
 ]}
 ....
 
+===== Description
+
+The MSLT instruction sets `rd` to all ones if `rs1` is less than `rs2` using
+signed comparison; otherwise it sets `rd` to zero.
 ===== Operation
 
 [source,pseudocode]
@@ -9613,17 +9621,13 @@ MSLT is available only in RV32.
 X[rd] = (X[rs1] <_s X[rs2]) ? 0xFFFFFFFF : 0x00000000
 ----
 
-===== Mnemonic
-
-mslt _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MSLT instruction sets `rd` to all ones if `rs1` is less than `rs2` using
-signed comparison; otherwise it sets `rd` to zero.
 
 <<<
 ==== MSLTU (RV32)
+
+===== Mnemonic
+
+msltu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -9643,6 +9647,10 @@ MSLTU is available only in RV32.
 ]}
 ....
 
+===== Description
+
+The MSLTU instruction sets `rd` to all ones if `rs1` is less than `rs2` using
+unsigned comparison; otherwise it sets `rd` to zero.
 ===== Operation
 
 [source,pseudocode]
@@ -9650,18 +9658,14 @@ MSLTU is available only in RV32.
 X[rd] = (X[rs1] <_u X[rs2]) ? 0xFFFFFFFF : 0x00000000
 ----
 
-===== Mnemonic
-
-msltu _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MSLTU instruction sets `rd` to all ones if `rs1` is less than `rs2` using
-unsigned comparison; otherwise it sets `rd` to zero.
 
 
 <<<
 ==== PMSEQ.DB (RV32)
+
+===== Mnemonic
+
+pmseq.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -9684,6 +9688,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSEQ.DB performs packed 8-bit byte mask-equality comparison on double-wide
+(register-pair) operands. It is equivalent to two PMSEQ.B operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFF) if the elements are
+equal, or all-zeros (0x00) otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -9708,21 +9720,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmseq.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSEQ.DB performs packed 8-bit byte mask-equality comparison on double-wide
-(register-pair) operands. It is equivalent to two PMSEQ.B operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. For each element, the result is all-ones (0xFF) if the elements are
-equal, or all-zeros (0x00) otherwise. Available only in RV32.
 
 <<<
 ==== PMSEQ.DH (RV32)
+
+===== Mnemonic
+
+pmseq.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -9745,6 +9749,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSEQ.DH performs packed 16-bit halfword mask-equality comparison on double-wide
+(register-pair) operands. It is equivalent to two PMSEQ.H operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFFFF) if the elements are
+equal, or all-zeros (0x0000) otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -9769,21 +9781,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmseq.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSEQ.DH performs packed 16-bit halfword mask-equality comparison on double-wide
-(register-pair) operands. It is equivalent to two PMSEQ.H operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. For each element, the result is all-ones (0xFFFF) if the elements are
-equal, or all-zeros (0x0000) otherwise. Available only in RV32.
 
 <<<
 ==== PMSEQ.DW (RV32)
+
+===== Mnemonic
+
+pmseq.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -9806,6 +9810,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSEQ.DW performs 32-bit word mask-equality comparison on double-wide
+(register-pair) operands. It is equivalent to two MSEQ operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFFFFFFFF) if the elements
+are equal, or all-zeros (0x00000000) otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -9823,21 +9835,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmseq.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSEQ.DW performs 32-bit word mask-equality comparison on double-wide
-(register-pair) operands. It is equivalent to two MSEQ operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. For each element, the result is all-ones (0xFFFFFFFF) if the elements
-are equal, or all-zeros (0x00000000) otherwise. Available only in RV32.
 
 <<<
 ==== PMSLT.DB (RV32)
+
+===== Mnemonic
+
+pmslt.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -9860,6 +9864,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSLT.DB performs packed 8-bit byte signed less-than mask comparison on
+double-wide (register-pair) operands. It is equivalent to two PMSLT.B operations:
+one on the even registers and one on the odd registers of each pair. All three
+operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even
+register numbers. For each element, the result is all-ones (0xFF) if the signed
+`rs1` element is less than the signed `rs2` element, or all-zeros (0x00)
+otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -9884,22 +9897,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmslt.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSLT.DB performs packed 8-bit byte signed less-than mask comparison on
-double-wide (register-pair) operands. It is equivalent to two PMSLT.B operations:
-one on the even registers and one on the odd registers of each pair. All three
-operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even
-register numbers. For each element, the result is all-ones (0xFF) if the signed
-`rs1` element is less than the signed `rs2` element, or all-zeros (0x00)
-otherwise. Available only in RV32.
 
 <<<
 ==== PMSLT.DH (RV32)
+
+===== Mnemonic
+
+pmslt.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -9922,6 +9926,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSLT.DH performs packed 16-bit halfword signed less-than mask comparison on
+double-wide (register-pair) operands. It is equivalent to two PMSLT.H operations:
+one on the even registers and one on the odd registers of each pair. All three
+operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even
+register numbers. For each element, the result is all-ones (0xFFFF) if the signed
+`rs1` element is less than the signed `rs2` element, or all-zeros (0x0000)
+otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -9946,22 +9959,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmslt.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSLT.DH performs packed 16-bit halfword signed less-than mask comparison on
-double-wide (register-pair) operands. It is equivalent to two PMSLT.H operations:
-one on the even registers and one on the odd registers of each pair. All three
-operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even
-register numbers. For each element, the result is all-ones (0xFFFF) if the signed
-`rs1` element is less than the signed `rs2` element, or all-zeros (0x0000)
-otherwise. Available only in RV32.
 
 <<<
 ==== PMSLT.DW (RV32)
+
+===== Mnemonic
+
+pmslt.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -9984,6 +9988,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSLT.DW performs 32-bit word signed less-than mask comparison on double-wide
+(register-pair) operands. It is equivalent to two MSLT operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFFFFFFFF) if the signed
+`rs1` element is less than the signed `rs2` element, or all-zeros (0x00000000)
+otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -10001,22 +10014,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmslt.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSLT.DW performs 32-bit word signed less-than mask comparison on double-wide
-(register-pair) operands. It is equivalent to two MSLT operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. For each element, the result is all-ones (0xFFFFFFFF) if the signed
-`rs1` element is less than the signed `rs2` element, or all-zeros (0x00000000)
-otherwise. Available only in RV32.
 
 <<<
 ==== PMSLTU.DB (RV32)
+
+===== Mnemonic
+
+pmsltu.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -10039,6 +10043,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSLTU.DB performs packed 8-bit byte unsigned less-than mask comparison on
+double-wide (register-pair) operands. It is equivalent to two PMSLTU.B
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify
+even register numbers. For each element, the result is all-ones (0xFF) if the
+unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
+(0x00) otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -10063,22 +10076,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmsltu.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSLTU.DB performs packed 8-bit byte unsigned less-than mask comparison on
-double-wide (register-pair) operands. It is equivalent to two PMSLTU.B
-operations: one on the even registers and one on the odd registers of each pair.
-All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify
-even register numbers. For each element, the result is all-ones (0xFF) if the
-unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
-(0x00) otherwise. Available only in RV32.
 
 <<<
 ==== PMSLTU.DH (RV32)
+
+===== Mnemonic
+
+pmsltu.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -10101,6 +10105,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSLTU.DH performs packed 16-bit halfword unsigned less-than mask comparison on
+double-wide (register-pair) operands. It is equivalent to two PMSLTU.H
+operations: one on the even registers and one on the odd registers of each pair.
+All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify
+even register numbers. For each element, the result is all-ones (0xFFFF) if the
+unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
+(0x0000) otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -10125,22 +10138,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmsltu.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSLTU.DH performs packed 16-bit halfword unsigned less-than mask comparison on
-double-wide (register-pair) operands. It is equivalent to two PMSLTU.H
-operations: one on the even registers and one on the odd registers of each pair.
-All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify
-even register numbers. For each element, the result is all-ones (0xFFFF) if the
-unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
-(0x0000) otherwise. Available only in RV32.
 
 <<<
 ==== PMSLTU.DW (RV32)
+
+===== Mnemonic
+
+pmsltu.dw _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -10163,6 +10167,15 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PMSLTU.DW performs 32-bit word unsigned less-than mask comparison on double-wide
+(register-pair) operands. It is equivalent to two MSLTU operations: one on the
+even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. For each element, the result is all-ones (0xFFFFFFFF) if the unsigned
+`rs1` element is less than the unsigned `rs2` element, or all-zeros (0x00000000)
+otherwise. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -10180,24 +10193,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pmsltu.dw _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PMSLTU.DW performs 32-bit word unsigned less-than mask comparison on double-wide
-(register-pair) operands. It is equivalent to two MSLTU operations: one on the
-even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. For each element, the result is all-ones (0xFFFFFFFF) if the unsigned
-`rs1` element is less than the unsigned `rs2` element, or all-zeros (0x00000000)
-otherwise. Available only in RV32.
 
 <<<
 === Sign Extension
 
 ==== PSEXT.H.B
+
+===== Mnemonic
+
+psext.h.b _rd_, _rs1_
 
 ===== Encoding
 
@@ -10217,6 +10221,12 @@ PSEXT.H.B is encoded in the OP-IMM-32 major opcode as a unary instruction.
 ]}
 ....
 
+===== Description
+
+PSEXT.H.B sign-extends packed 8-bit byte elements from the lower byte of each
+16-bit halfword position in `rs1` into full 16-bit halfword results in `rd`. The
+upper byte of each halfword input is ignored; only the lower byte is
+sign-extended.
 ===== Operation
 
 [source,pseudocode]
@@ -10231,19 +10241,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psext.h.b _rd_, _rs1_
-
-===== Description
-
-PSEXT.H.B sign-extends packed 8-bit byte elements from the lower byte of each
-16-bit halfword position in `rs1` into full 16-bit halfword results in `rd`. The
-upper byte of each halfword input is ignored; only the lower byte is
-sign-extended.
 
 <<<
 ==== PSEXT.W.B (RV64)
+
+===== Mnemonic
+
+psext.w.b _rd_, _rs1_
 
 ===== Encoding
 
@@ -10262,6 +10266,10 @@ PSEXT.W.B is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The PSEXT.W.B instruction extracts byte elements from `rs1`, sign-extends them
+to 32-bit values, and packs them into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -10270,17 +10278,13 @@ s1 = X[rs1]
 X[rd] = sign_extend(32, s1[39:32]) @ sign_extend(32, s1[7:0])
 ----
 
-===== Mnemonic
-
-psext.w.b _rd_, _rs1_
-
-===== Description
-
-The PSEXT.W.B instruction extracts byte elements from `rs1`, sign-extends them
-to 32-bit values, and packs them into `rd`.
 
 <<<
 ==== PSEXT.W.H (RV64)
+
+===== Mnemonic
+
+psext.w.h _rd_, _rs1_
 
 ===== Encoding
 
@@ -10299,6 +10303,10 @@ PSEXT.W.H is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The PSEXT.W.H instruction extracts halfword elements from `rs1`, sign-extends
+them to 32-bit values, and packs them into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -10307,18 +10315,14 @@ s1 = X[rs1]
 X[rd] = sign_extend(32, s1[47:32]) @ sign_extend(32, s1[15:0])
 ----
 
-===== Mnemonic
-
-psext.w.h _rd_, _rs1_
-
-===== Description
-
-The PSEXT.W.H instruction extracts halfword elements from `rs1`, sign-extends
-them to 32-bit values, and packs them into `rd`.
 
 
 <<<
 ==== PSEXT.DH.B (RV32)
+
+===== Mnemonic
+
+psext.dh.b _rd_p_, _rs1_p_
 
 ===== Encoding
 
@@ -10340,6 +10344,13 @@ register-pair unary format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSEXT.DH.B performs packed sign-extension of bytes to halfwords on double-wide
+(register-pair) operands. It is equivalent to two PSEXT.H.B operations: one on
+the even registers and one on the odd registers of each pair. Both operands
+(`rd_p`, `rs1_p`) are register pairs and must specify even register numbers.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -10360,20 +10371,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psext.dh.b _rd_p_, _rs1_p_
-
-===== Description
-
-PSEXT.DH.B performs packed sign-extension of bytes to halfwords on double-wide
-(register-pair) operands. It is equivalent to two PSEXT.H.B operations: one on
-the even registers and one on the odd registers of each pair. Both operands
-(`rd_p`, `rs1_p`) are register pairs and must specify even register numbers.
-Available only in RV32.
 
 <<<
 ==== PSEXT.DW.B (RV32)
+
+===== Mnemonic
+
+psext.dw.b _rd_p_, _rs1_p_
 
 ===== Encoding
 
@@ -10395,6 +10399,13 @@ register-pair unary format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSEXT.DW.B performs sign-extension of bytes to words on double-wide
+(register-pair) operands. It is equivalent to two SEXT.B operations: one on the
+even registers and one on the odd registers of each pair. Both operands (`rd_p`,
+`rs1_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -10410,20 +10421,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psext.dw.b _rd_p_, _rs1_p_
-
-===== Description
-
-PSEXT.DW.B performs sign-extension of bytes to words on double-wide
-(register-pair) operands. It is equivalent to two SEXT.B operations: one on the
-even registers and one on the odd registers of each pair. Both operands (`rd_p`,
-`rs1_p`) are register pairs and must specify even register numbers. Available
-only in RV32.
 
 <<<
 ==== PSEXT.DW.H (RV32)
+
+===== Mnemonic
+
+psext.dw.h _rd_p_, _rs1_p_
 
 ===== Encoding
 
@@ -10445,6 +10449,13 @@ register-pair unary format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSEXT.DW.H performs sign-extension of halfwords to words on double-wide
+(register-pair) operands. It is equivalent to two SEXT.H operations: one on the
+even registers and one on the odd registers of each pair. Both operands (`rd_p`,
+`rs1_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -10460,22 +10471,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psext.dw.h _rd_p_, _rs1_p_
-
-===== Description
-
-PSEXT.DW.H performs sign-extension of halfwords to words on double-wide
-(register-pair) operands. It is equivalent to two SEXT.H operations: one on the
-even registers and one on the odd registers of each pair. Both operands (`rd_p`,
-`rs1_p`) are register pairs and must specify even register numbers. Available
-only in RV32.
 
 <<<
 === Saturation/Clipping
 
 ==== PSATI.H
+
+===== Mnemonic
+
+psati.h _rd_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -10497,6 +10501,13 @@ packed halfword elements with a 4-bit unsigned immediate.
 ]}
 ....
 
+===== Description
+
+PSATI.H saturates each packed 16-bit halfword element of `rs1` to the signed
+range [-(2^n), 2^n - 1], where n is specified by the 4-bit unsigned immediate.
+If an element exceeds the range, the result is clamped to the nearest bound and
+the `vxsat` overflow flag is set. Elements already within range are passed
+through unchanged.
 ===== Operation
 
 [source,pseudocode]
@@ -10520,20 +10531,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psati.h _rd_, _rs1_, _uimm4_
-
-===== Description
-
-PSATI.H saturates each packed 16-bit halfword element of `rs1` to the signed
-range [-(2^n), 2^n - 1], where n is specified by the 4-bit unsigned immediate.
-If an element exceeds the range, the result is clamped to the nearest bound and
-the `vxsat` overflow flag is set. Elements already within range are passed
-through unchanged.
 
 <<<
 ==== PSATI.W (RV64)
+
+===== Mnemonic
+
+psati.w _rd_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -10555,6 +10559,13 @@ packed word elements with a 5-bit unsigned immediate. Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSATI.W saturates each packed 32-bit word element of `rs1` to the signed range
+[-(2^n), 2^n - 1], where n is specified by the 5-bit unsigned immediate. If an
+element exceeds the range, the result is clamped to the nearest bound and the
+`vxsat` overflow flag is set. Elements already within range are passed through
+unchanged. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -10578,20 +10589,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psati.w _rd_, _rs1_, _uimm5_
-
-===== Description
-
-PSATI.W saturates each packed 32-bit word element of `rs1` to the signed range
-[-(2^n), 2^n - 1], where n is specified by the 5-bit unsigned immediate. If an
-element exceeds the range, the result is clamped to the nearest bound and the
-`vxsat` overflow flag is set. Elements already within range are passed through
-unchanged. Available only in RV64.
 
 <<<
 ==== PUSATI.H
+
+===== Mnemonic
+
+pusati.h _rd_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -10613,6 +10617,13 @@ packed halfword elements with a 4-bit unsigned immediate.
 ]}
 ....
 
+===== Description
+
+PUSATI.H performs unsigned saturation on each packed 16-bit halfword element of
+`rs1` to the range [0, 2^n - 1], where n is specified by the 4-bit unsigned
+immediate. Negative values are clamped to zero and values exceeding the maximum
+are clamped to 2^n - 1. When clamping occurs, the `vxsat` overflow flag is set.
+Elements already within range are passed through unchanged.
 ===== Operation
 
 [source,pseudocode]
@@ -10635,20 +10646,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pusati.h _rd_, _rs1_, _uimm4_
-
-===== Description
-
-PUSATI.H performs unsigned saturation on each packed 16-bit halfword element of
-`rs1` to the range [0, 2^n - 1], where n is specified by the 4-bit unsigned
-immediate. Negative values are clamped to zero and values exceeding the maximum
-are clamped to 2^n - 1. When clamping occurs, the `vxsat` overflow flag is set.
-Elements already within range are passed through unchanged.
 
 <<<
 ==== PUSATI.W (RV64)
+
+===== Mnemonic
+
+pusati.w _rd_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -10670,6 +10674,13 @@ packed word elements with a 5-bit unsigned immediate. Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PUSATI.W performs unsigned saturation on each packed 32-bit word element of `rs1`
+to the range [0, 2^n - 1], where n is specified by the 5-bit unsigned immediate.
+Negative values are clamped to zero and values exceeding the maximum are clamped
+to 2^n - 1. When clamping occurs, the `vxsat` overflow flag is set. Elements
+already within range are passed through unchanged. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -10692,20 +10703,14 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pusati.w _rd_, _rs1_, _uimm5_
-
-===== Description
-
-PUSATI.W performs unsigned saturation on each packed 32-bit word element of `rs1`
-to the range [0, 2^n - 1], where n is specified by the 5-bit unsigned immediate.
-Negative values are clamped to zero and values exceeding the maximum are clamped
-to 2^n - 1. When clamping occurs, the `vxsat` overflow flag is set. Elements
-already within range are passed through unchanged. Available only in RV64.
 
 <<<
 ==== SATI
+
+===== Mnemonic
+
+sati _rd_, _rs1_, _uimm5_ (RV32) +
+sati _rd_, _rs1_, _uimm6_ (RV64)
 
 ===== Encoding
 
@@ -10744,6 +10749,11 @@ RV64:
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The SATI instruction saturates `rs1` to a signed range determined by the
+immediate `uimm5` or `uimm6` and writes the result to `rd`.
 
 ===== Operation
 
@@ -10787,22 +10797,17 @@ else:
     X[rd] = s1
 ----
 
-===== Mnemonic
-
-sati _rd_, _rs1_, _uimm5_ (RV32) +
-sati _rd_, _rs1_, _uimm6_ (RV64)
-
-===== Description
-
-The SATI instruction saturates `rs1` to a signed range determined by the
-immediate `uimm5` or `uimm6` and writes the result to `rd`.
-
 ===== Notes
 
 * `vxsat` is set to 1 if saturation occurs.
 
 <<<
 ==== USATI
+
+===== Mnemonic
+
+usati _rd_, _rs1_, _uimm5_ (RV32) +
+usati _rd_, _rs1_, _uimm6_ (RV64)
 
 ===== Encoding
 
@@ -10841,6 +10846,11 @@ RV64:
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The USATI instruction saturates `rs1` to the unsigned range [0, maxval]
+determined by the immediate `uimm5` or `uimm6` and writes the result to `rd`.
 
 ===== Operation
 
@@ -10882,16 +10892,6 @@ else:
     X[rd] = s1
 ----
 
-===== Mnemonic
-
-usati _rd_, _rs1_, _uimm5_ (RV32) +
-usati _rd_, _rs1_, _uimm6_ (RV64)
-
-===== Description
-
-The USATI instruction saturates `rs1` to the unsigned range [0, maxval]
-determined by the immediate `uimm5` or `uimm6` and writes the result to `rd`.
-
 ===== Notes
 
 * `vxsat` is set to 1 if saturation occurs.
@@ -10899,6 +10899,10 @@ determined by the immediate `uimm5` or `uimm6` and writes the result to `rd`.
 
 <<<
 ==== PSATI.DH (RV32)
+
+===== Mnemonic
+
+psati.dh _rd_p_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -10920,6 +10924,15 @@ register-pair w-uimm format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSATI.DH performs packed 16-bit halfword signed saturation on double-wide
+(register-pair) operands. It is equivalent to two PSATI.H operations: one on the
+even registers and one on the odd registers of each pair. Both operands (`rd_p`,
+`rs1_p`) are register pairs and must specify even register numbers. Each halfword
+element is saturated to the signed range [-(2^n), 2^n - 1], where n is specified
+by the 4-bit unsigned immediate. When clamping occurs, the `vxsat` overflow flag
+is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -10957,22 +10970,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psati.dh _rd_p_, _rs1_p_, _uimm4_
-
-===== Description
-
-PSATI.DH performs packed 16-bit halfword signed saturation on double-wide
-(register-pair) operands. It is equivalent to two PSATI.H operations: one on the
-even registers and one on the odd registers of each pair. Both operands (`rd_p`,
-`rs1_p`) are register pairs and must specify even register numbers. Each halfword
-element is saturated to the signed range [-(2^n), 2^n - 1], where n is specified
-by the 4-bit unsigned immediate. When clamping occurs, the `vxsat` overflow flag
-is set. Available only in RV32.
 
 <<<
 ==== PSATI.DW (RV32)
+
+===== Mnemonic
+
+psati.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -10995,6 +10999,15 @@ immediate format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSATI.DW performs signed saturation on each 32-bit element across a double-wide
+(register-pair) source. It is equivalent to two SATI operations: one on the even
+registers and one on the odd registers of each pair. Each element is clamped to
+the range [-2^n, 2^n - 1] where `n` is encoded in the `uimm5` field. If
+saturation occurs, `vxsat` is set. The destination (`rd_p`) and source
+(`rs1_p`) are register pairs and must specify even register numbers. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -11025,22 +11038,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psati.dw _rd_p_, _rs1_p_, _uimm5_
-
-===== Description
-
-PSATI.DW performs signed saturation on each 32-bit element across a double-wide
-(register-pair) source. It is equivalent to two SATI operations: one on the even
-registers and one on the odd registers of each pair. Each element is clamped to
-the range [-2^n, 2^n - 1] where `n` is encoded in the `uimm5` field. If
-saturation occurs, `vxsat` is set. The destination (`rd_p`) and source
-(`rs1_p`) are register pairs and must specify even register numbers. Available
-only in RV32.
 
 <<<
 ==== PUSATI.DH (RV32)
+
+===== Mnemonic
+
+pusati.dh _rd_p_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -11063,6 +11067,15 @@ immediate format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PUSATI.DH performs unsigned saturation on each packed 16-bit element across a
+double-wide (register-pair) source. It is equivalent to two PUSATI.H operations:
+one on the even registers and one on the odd registers of each pair. Each
+element is clamped to the range [0, 2^n - 1] where `n` is encoded in the
+`uimm4` field. If saturation occurs, `vxsat` is set. The destination (`rd_p`)
+and source (`rs1_p`) are register pairs and must specify even register numbers.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -11096,22 +11109,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pusati.dh _rd_p_, _rs1_p_, _uimm4_
-
-===== Description
-
-PUSATI.DH performs unsigned saturation on each packed 16-bit element across a
-double-wide (register-pair) source. It is equivalent to two PUSATI.H operations:
-one on the even registers and one on the odd registers of each pair. Each
-element is clamped to the range [0, 2^n - 1] where `n` is encoded in the
-`uimm4` field. If saturation occurs, `vxsat` is set. The destination (`rd_p`)
-and source (`rs1_p`) are register pairs and must specify even register numbers.
-Available only in RV32.
 
 <<<
 ==== PUSATI.DW (RV32)
+
+===== Mnemonic
+
+pusati.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -11134,6 +11138,15 @@ immediate format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PUSATI.DW performs unsigned saturation on each 32-bit element across a
+double-wide (register-pair) source. It is equivalent to two USATI operations:
+one on the even registers and one on the odd registers of each pair. Each
+element is clamped to the range [0, 2^n - 1] where `n` is encoded in the
+`uimm5` field. If saturation occurs, `vxsat` is set. The destination (`rd_p`)
+and source (`rs1_p`) are register pairs and must specify even register numbers.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -11163,24 +11176,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pusati.dw _rd_p_, _rs1_p_, _uimm5_
-
-===== Description
-
-PUSATI.DW performs unsigned saturation on each 32-bit element across a
-double-wide (register-pair) source. It is equivalent to two USATI operations:
-one on the even registers and one on the odd registers of each pair. Each
-element is clamped to the range [0, 2^n - 1] where `n` is encoded in the
-`uimm5` field. If saturation occurs, `vxsat` is set. The destination (`rd_p`)
-and source (`rs1_p`) are register pairs and must specify even register numbers.
-Available only in RV32.
 
 <<<
 === Shift Operations
 
 ==== PSLL.BS
+
+===== Mnemonic
+
+psll.bs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11201,6 +11205,10 @@ PSLL.BS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
+===== Description
+
+The PSLL.BS instruction shifts each packed 8-bit element of `rs1` left by the
+shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -11213,17 +11221,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psll.bs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSLL.BS instruction shifts each packed 8-bit element of `rs1` left by the
-shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 
 <<<
 ==== PSLL.HS
+
+===== Mnemonic
+
+psll.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11244,6 +11248,10 @@ PSLL.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
+===== Description
+
+The PSLL.HS instruction shifts each packed 16-bit element of `rs1` left by the
+shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -11256,17 +11264,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psll.hs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSLL.HS instruction shifts each packed 16-bit element of `rs1` left by the
-shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 
 <<<
 ==== PSLL.WS (RV64)
+
+===== Mnemonic
+
+psll.ws _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11288,6 +11292,12 @@ and word elements. Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSLL.WS shifts each packed 32-bit element of `rs1` left by the scalar shift
+amount in `rs2[4:0]` and writes the packed word result to `rd`. Bits shifted
+out are discarded and vacated bit positions are filled with zeros. Available
+only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -11300,19 +11310,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psll.ws _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSLL.WS shifts each packed 32-bit element of `rs1` left by the scalar shift
-amount in `rs2[4:0]` and writes the packed word result to `rd`. Bits shifted
-out are discarded and vacated bit positions are filled with zeros. Available
-only in RV64.
 
 <<<
 ==== PSRL.BS
+
+===== Mnemonic
+
+psrl.bs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11333,6 +11337,10 @@ PSRL.BS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
+===== Description
+
+The PSRL.BS instruction logically shifts each packed 8-bit element of `rs1`
+right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -11345,17 +11353,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrl.bs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSRL.BS instruction logically shifts each packed 8-bit element of `rs1`
-right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 
 <<<
 ==== PSRL.HS
+
+===== Mnemonic
+
+psrl.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11376,6 +11380,10 @@ PSRL.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
+===== Description
+
+The PSRL.HS instruction logically shifts each packed 16-bit element of `rs1`
+right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -11388,17 +11396,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrl.hs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSRL.HS instruction logically shifts each packed 16-bit element of `rs1`
-right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 
 <<<
 ==== PSRL.WS (RV64)
+
+===== Mnemonic
+
+psrl.ws _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11420,6 +11424,12 @@ and word elements. Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSRL.WS logically shifts each packed 32-bit element of `rs1` right by the
+scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -11432,19 +11442,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrl.ws _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSRL.WS logically shifts each packed 32-bit element of `rs1` right by the
-scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
-Bits shifted out are discarded and vacated bit positions are filled with zeros.
-Available only in RV64.
 
 <<<
 ==== PSRA.BS
+
+===== Mnemonic
+
+psra.bs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11465,6 +11469,10 @@ PSRA.BS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
+===== Description
+
+The PSRA.BS instruction arithmetically shifts each packed 8-bit element of `rs1`
+right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -11477,17 +11485,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psra.bs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSRA.BS instruction arithmetically shifts each packed 8-bit element of `rs1`
-right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 
 <<<
 ==== PSRA.HS
+
+===== Mnemonic
+
+psra.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11508,6 +11512,10 @@ PSRA.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
+===== Description
+
+The PSRA.HS instruction arithmetically shifts each packed 16-bit element of `rs1`
+right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -11520,18 +11528,14 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psra.hs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSRA.HS instruction arithmetically shifts each packed 16-bit element of `rs1`
-right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 
 
 <<<
 ==== PSRA.WS (RV64)
+
+===== Mnemonic
+
+psra.ws _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -11553,6 +11557,12 @@ and word elements. Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PSRA.WS arithmetically shifts each packed 32-bit element of `rs1` right by the
+scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with copies
+of the sign bit. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -11565,19 +11575,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psra.ws _rd_, _rs1_, _rs2_
-
-===== Description
-
-PSRA.WS arithmetically shifts each packed 32-bit element of `rs1` right by the
-scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
-Bits shifted out are discarded and vacated bit positions are filled with copies
-of the sign bit. Available only in RV64.
 
 <<<
 ==== PSLLI.B
+
+===== Mnemonic
+
+pslli.b _rd_, _rs1_, _uimm3_
 
 ===== Encoding
 
@@ -11601,6 +11605,11 @@ and an immediate shift amount.
 
 The `uimm3` field encodes the 3-bit shift amount for byte elements.
 
+===== Description
+
+PSLLI.B shifts each packed 8-bit element of `rs1` left by the immediate shift
+amount encoded in `uimm3` and writes the packed byte result to `rd`. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
 ===== Operation
 
 [source,pseudocode]
@@ -11613,18 +11622,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pslli.b _rd_, _rs1_, _uimm3_
-
-===== Description
-
-PSLLI.B shifts each packed 8-bit element of `rs1` left by the immediate shift
-amount encoded in `uimm3` and writes the packed byte result to `rd`. Bits
-shifted out are discarded and vacated bit positions are filled with zeros.
 
 <<<
 ==== PSLLI.H
+
+===== Mnemonic
+
+pslli.h _rd_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -11648,6 +11652,11 @@ and an immediate shift amount.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
+===== Description
+
+PSLLI.H shifts each packed 16-bit element of `rs1` left by the immediate shift
+amount encoded in `uimm4` and writes the packed halfword result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with zeros.
 ===== Operation
 
 [source,pseudocode]
@@ -11660,18 +11669,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pslli.h _rd_, _rs1_, _uimm4_
-
-===== Description
-
-PSLLI.H shifts each packed 16-bit element of `rs1` left by the immediate shift
-amount encoded in `uimm4` and writes the packed halfword result to `rd`.
-Bits shifted out are discarded and vacated bit positions are filled with zeros.
 
 <<<
 ==== PSLLI.W (RV64)
+
+===== Mnemonic
+
+pslli.w _rd_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -11695,6 +11699,12 @@ and an immediate shift amount. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
+===== Description
+
+PSLLI.W shifts each packed 32-bit element of `rs1` left by the immediate shift
+amount encoded in `uimm5` and writes the packed word result to `rd`. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -11707,19 +11717,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pslli.w _rd_, _rs1_, _uimm5_
-
-===== Description
-
-PSLLI.W shifts each packed 32-bit element of `rs1` left by the immediate shift
-amount encoded in `uimm5` and writes the packed word result to `rd`. Bits
-shifted out are discarded and vacated bit positions are filled with zeros.
-Available only in RV64.
 
 <<<
 ==== PSRLI.B
+
+===== Mnemonic
+
+psrli.b _rd_, _rs1_, _uimm3_
 
 ===== Encoding
 
@@ -11743,6 +11747,12 @@ and an immediate shift amount.
 
 The `uimm3` field encodes the 3-bit shift amount for byte elements.
 
+===== Description
+
+PSRLI.B logically shifts each packed 8-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm3` and writes the packed byte result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with zeros.
 ===== Operation
 
 [source,pseudocode]
@@ -11755,19 +11765,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrli.b _rd_, _rs1_, _uimm3_
-
-===== Description
-
-PSRLI.B logically shifts each packed 8-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm3` and writes the packed byte result
-to `rd`. Bits shifted out are discarded and vacated bit positions are filled
-with zeros.
 
 <<<
 ==== PSRLI.H
+
+===== Mnemonic
+
+psrli.h _rd_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -11791,6 +11795,12 @@ and an immediate shift amount.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
+===== Description
+
+PSRLI.H logically shifts each packed 16-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm4` and writes the packed halfword
+result to `rd`. Bits shifted out are discarded and vacated bit positions are
+filled with zeros.
 ===== Operation
 
 [source,pseudocode]
@@ -11803,19 +11813,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrli.h _rd_, _rs1_, _uimm4_
-
-===== Description
-
-PSRLI.H logically shifts each packed 16-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm4` and writes the packed halfword
-result to `rd`. Bits shifted out are discarded and vacated bit positions are
-filled with zeros.
 
 <<<
 ==== PSRLI.W (RV64)
+
+===== Mnemonic
+
+psrli.w _rd_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -11839,6 +11843,12 @@ and an immediate shift amount. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
+===== Description
+
+PSRLI.W logically shifts each packed 32-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm5` and writes the packed word result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with zeros. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -11851,19 +11861,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrli.w _rd_, _rs1_, _uimm5_
-
-===== Description
-
-PSRLI.W logically shifts each packed 32-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm5` and writes the packed word result
-to `rd`. Bits shifted out are discarded and vacated bit positions are filled
-with zeros. Available only in RV64.
 
 <<<
 ==== PSRAI.B
+
+===== Mnemonic
+
+psrai.b _rd_, _rs1_, _uimm3_
 
 ===== Encoding
 
@@ -11887,6 +11891,12 @@ and an immediate shift amount.
 
 The `uimm3` field encodes the 3-bit shift amount for byte elements.
 
+===== Description
+
+PSRAI.B arithmetically shifts each packed 8-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm3` and writes the packed byte result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with copies of the sign bit.
 ===== Operation
 
 [source,pseudocode]
@@ -11899,19 +11909,13 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrai.b _rd_, _rs1_, _uimm3_
-
-===== Description
-
-PSRAI.B arithmetically shifts each packed 8-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm3` and writes the packed byte result
-to `rd`. Bits shifted out are discarded and vacated bit positions are filled
-with copies of the sign bit.
 
 <<<
 ==== PSRAI.H
+
+===== Mnemonic
+
+psrai.h _rd_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -11935,6 +11939,12 @@ and an immediate shift amount.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
+===== Description
+
+PSRAI.H arithmetically shifts each packed 16-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm4` and writes the packed halfword
+result to `rd`. Bits shifted out are discarded and vacated bit positions are
+filled with copies of the sign bit.
 ===== Operation
 
 [source,pseudocode]
@@ -11947,19 +11957,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrai.h _rd_, _rs1_, _uimm4_
-
-===== Description
-
-PSRAI.H arithmetically shifts each packed 16-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm4` and writes the packed halfword
-result to `rd`. Bits shifted out are discarded and vacated bit positions are
-filled with copies of the sign bit.
 
 <<<
 ==== PSRAI.W (RV64)
+
+===== Mnemonic
+
+psrai.w _rd_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -11983,6 +11987,12 @@ and an immediate shift amount. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
+===== Description
+
+PSRAI.W arithmetically shifts each packed 32-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm5` and writes the packed word result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with copies of the sign bit. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -11995,19 +12005,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrai.w _rd_, _rs1_, _uimm5_
-
-===== Description
-
-PSRAI.W arithmetically shifts each packed 32-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm5` and writes the packed word result
-to `rd`. Bits shifted out are discarded and vacated bit positions are filled
-with copies of the sign bit. Available only in RV64.
 
 <<<
 ==== PSRARI.H
+
+===== Mnemonic
+
+psrari.h _rd_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -12031,6 +12035,12 @@ and an immediate shift amount.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
+===== Description
+
+PSRARI.H arithmetically shifts each packed 16-bit element of `rs1` right by
+the immediate shift amount encoded in `uimm4` with rounding and writes the
+packed halfword result to `rd`. A rounding bit is added before the shift so that
+the result is rounded to the nearest integer (round-to-nearest, ties round up).
 ===== Operation
 
 [source,pseudocode]
@@ -12045,19 +12055,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrari.h _rd_, _rs1_, _uimm4_
-
-===== Description
-
-PSRARI.H arithmetically shifts each packed 16-bit element of `rs1` right by
-the immediate shift amount encoded in `uimm4` with rounding and writes the
-packed halfword result to `rd`. A rounding bit is added before the shift so that
-the result is rounded to the nearest integer (round-to-nearest, ties round up).
 
 <<<
 ==== PSRARI.W (RV64)
+
+===== Mnemonic
+
+psrari.w _rd_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -12081,6 +12085,13 @@ and an immediate shift amount. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
+===== Description
+
+PSRARI.W arithmetically shifts each packed 32-bit element of `rs1` right by
+the immediate shift amount encoded in `uimm5` with rounding and writes the
+packed word result to `rd`. A rounding bit is added before the shift so that the
+result is rounded to the nearest integer (round-to-nearest, ties round up).
+Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -12095,20 +12106,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psrari.w _rd_, _rs1_, _uimm5_
-
-===== Description
-
-PSRARI.W arithmetically shifts each packed 32-bit element of `rs1` right by
-the immediate shift amount encoded in `uimm5` with rounding and writes the
-packed word result to `rd`. A rounding bit is added before the shift so that the
-result is rounded to the nearest integer (round-to-nearest, ties round up).
-Available only in RV64.
 
 <<<
 ==== PSLL.DBS (RV32)
+
+===== Mnemonic
+
+psll.dbs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12131,6 +12135,15 @@ scalar format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSLL.DBS shifts each packed 8-bit element left by the scalar shift amount in
+`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
+PSLL.BS operations: one on the even registers and one on the odd registers of
+each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12152,22 +12165,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psll.dbs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSLL.DBS shifts each packed 8-bit element left by the scalar shift amount in
-`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
-PSLL.BS operations: one on the even registers and one on the odd registers of
-each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
-pairs and must specify even register numbers; `rs2` is a single register. Bits
-shifted out are discarded and vacated bit positions are filled with zeros.
-Available only in RV32.
 
 <<<
 ==== PSLL.DHS (RV32)
+
+===== Mnemonic
+
+psll.dhs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12190,6 +12194,15 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSLL.DHS shifts each packed 16-bit element left by the scalar shift amount in
+`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
+PSLL.HS operations: one on the even registers and one on the odd registers of
+each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12211,22 +12224,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psll.dhs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSLL.DHS shifts each packed 16-bit element left by the scalar shift amount in
-`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
-PSLL.HS operations: one on the even registers and one on the odd registers of
-each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
-pairs and must specify even register numbers; `rs2` is a single register. Bits
-shifted out are discarded and vacated bit positions are filled with zeros.
-Available only in RV32.
 
 <<<
 ==== PSLL.DWS (RV32)
+
+===== Mnemonic
+
+psll.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12249,6 +12253,15 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSLL.DWS shifts each 32-bit element left by the scalar shift amount in
+`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
+SLL operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs and
+must specify even register numbers; `rs2` is a single register. Bits shifted out
+are discarded and vacated bit positions are filled with zeros. Available only in
+RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12265,22 +12278,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psll.dws _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSLL.DWS shifts each 32-bit element left by the scalar shift amount in
-`rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
-SLL operations: one on the even registers and one on the odd registers of each
-pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs and
-must specify even register numbers; `rs2` is a single register. Bits shifted out
-are discarded and vacated bit positions are filled with zeros. Available only in
-RV32.
 
 <<<
 ==== PSRL.DBS (RV32)
+
+===== Mnemonic
+
+psrl.dbs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12303,6 +12307,15 @@ scalar format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRL.DBS logically shifts each packed 8-bit element right by the scalar shift
+amount in `rs2[4:0]` across a double-wide (register-pair) source. It is
+equivalent to two PSRL.BS operations: one on the even registers and one on the
+odd registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
+are register pairs and must specify even register numbers; `rs2` is a single
+register. Bits shifted out are discarded and vacated bit positions are filled
+with zeros. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12324,22 +12337,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrl.dbs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSRL.DBS logically shifts each packed 8-bit element right by the scalar shift
-amount in `rs2[4:0]` across a double-wide (register-pair) source. It is
-equivalent to two PSRL.BS operations: one on the even registers and one on the
-odd registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
-are register pairs and must specify even register numbers; `rs2` is a single
-register. Bits shifted out are discarded and vacated bit positions are filled
-with zeros. Available only in RV32.
 
 <<<
 ==== PSRL.DHS (RV32)
+
+===== Mnemonic
+
+psrl.dhs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12362,6 +12366,15 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRL.DHS logically shifts each packed 16-bit element right by the scalar shift
+amount in `rs2[4:0]` across a double-wide (register-pair) source. It is
+equivalent to two PSRL.HS operations: one on the even registers and one on the
+odd registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
+are register pairs and must specify even register numbers; `rs2` is a single
+register. Bits shifted out are discarded and vacated bit positions are filled
+with zeros. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12383,22 +12396,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrl.dhs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSRL.DHS logically shifts each packed 16-bit element right by the scalar shift
-amount in `rs2[4:0]` across a double-wide (register-pair) source. It is
-equivalent to two PSRL.HS operations: one on the even registers and one on the
-odd registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
-are register pairs and must specify even register numbers; `rs2` is a single
-register. Bits shifted out are discarded and vacated bit positions are filled
-with zeros. Available only in RV32.
 
 <<<
 ==== PSRL.DWS (RV32)
+
+===== Mnemonic
+
+psrl.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12421,6 +12425,15 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRL.DWS (Packed Shift Right Logical, Double-wide Word, Scalar) performs
+logical right shift on each 32-bit word element across a double-wide
+(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
+to two SRL operations: one on the even registers and one on the odd registers
+of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12437,22 +12450,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrl.dws _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSRL.DWS (Packed Shift Right Logical, Double-wide Word, Scalar) performs
-logical right shift on each 32-bit word element across a double-wide
-(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
-to two SRL operations: one on the even registers and one on the odd registers
-of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
-pairs and must specify even register numbers; `rs2` is a single register.
-Available only in RV32.
 
 <<<
 ==== PSRA.DBS (RV32)
+
+===== Mnemonic
+
+psra.dbs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12475,6 +12479,16 @@ scalar format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRA.DBS (Packed Shift Right Arithmetic, Double-wide Byte, Scalar) performs
+arithmetic right shift on each packed 8-bit element across a double-wide
+(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
+to two PSRA.BS operations: one on the even registers and one on the odd
+registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
+are register pairs and must specify even register numbers; `rs2` is a single
+register. Each element is sign-extended before shifting. Available only in
+RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12496,23 +12510,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psra.dbs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSRA.DBS (Packed Shift Right Arithmetic, Double-wide Byte, Scalar) performs
-arithmetic right shift on each packed 8-bit element across a double-wide
-(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
-to two PSRA.BS operations: one on the even registers and one on the odd
-registers of each pair. The destination (`rd_p`) and first source (`rs1_p`)
-are register pairs and must specify even register numbers; `rs2` is a single
-register. Each element is sign-extended before shifting. Available only in
-RV32.
 
 <<<
 ==== PSRA.DHS (RV32)
+
+===== Mnemonic
+
+psra.dhs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12535,6 +12539,16 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRA.DHS (Packed Shift Right Arithmetic, Double-wide Halfword, Scalar)
+performs arithmetic right shift on each packed 16-bit element across a
+double-wide (register-pair) source by a scalar shift amount from `rs2`. It is
+equivalent to two PSRA.HS operations: one on the even registers and one on
+the odd registers of each pair. The destination (`rd_p`) and first source
+(`rs1_p`) are register pairs and must specify even register numbers; `rs2` is
+a single register. Each element is sign-extended before shifting. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12556,23 +12570,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psra.dhs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSRA.DHS (Packed Shift Right Arithmetic, Double-wide Halfword, Scalar)
-performs arithmetic right shift on each packed 16-bit element across a
-double-wide (register-pair) source by a scalar shift amount from `rs2`. It is
-equivalent to two PSRA.HS operations: one on the even registers and one on
-the odd registers of each pair. The destination (`rd_p`) and first source
-(`rs1_p`) are register pairs and must specify even register numbers; `rs2` is
-a single register. Each element is sign-extended before shifting. Available
-only in RV32.
 
 <<<
 ==== PSRA.DWS (RV32)
+
+===== Mnemonic
+
+psra.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -12595,6 +12599,15 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRA.DWS (Packed Shift Right Arithmetic, Double-wide Word, Scalar) performs
+arithmetic right shift on each 32-bit word element across a double-wide
+(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
+to two SRA operations: one on the even registers and one on the odd registers
+of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register.
+Each element is sign-extended before shifting. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12611,22 +12624,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psra.dws _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSRA.DWS (Packed Shift Right Arithmetic, Double-wide Word, Scalar) performs
-arithmetic right shift on each 32-bit word element across a double-wide
-(register-pair) source by a scalar shift amount from `rs2`. It is equivalent
-to two SRA operations: one on the even registers and one on the odd registers
-of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
-pairs and must specify even register numbers; `rs2` is a single register.
-Each element is sign-extended before shifting. Available only in RV32.
 
 <<<
 ==== PSLLI.DB (RV32)
+
+===== Mnemonic
+
+pslli.db _rd_p_, _rs1_p_, _uimm3_
 
 ===== Encoding
 
@@ -12649,6 +12653,14 @@ w-uimm format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSLLI.DB (Packed Shift Left Logical Immediate, Double-wide Byte) shifts each
+packed 8-bit element left by a 3-bit unsigned immediate across a double-wide
+(register-pair) source. It is equivalent to two PSLLI.B operations: one on
+the even registers and one on the odd registers of each pair. The destination
+(`rd_p`) and source (`rs1_p`) are register pairs and must specify even register
+numbers. Vacated bits are filled with zeros. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12670,21 +12682,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pslli.db _rd_p_, _rs1_p_, _uimm3_
-
-===== Description
-
-PSLLI.DB (Packed Shift Left Logical Immediate, Double-wide Byte) shifts each
-packed 8-bit element left by a 3-bit unsigned immediate across a double-wide
-(register-pair) source. It is equivalent to two PSLLI.B operations: one on
-the even registers and one on the odd registers of each pair. The destination
-(`rd_p`) and source (`rs1_p`) are register pairs and must specify even register
-numbers. Vacated bits are filled with zeros. Available only in RV32.
 
 <<<
 ==== PSLLI.DH (RV32)
+
+===== Mnemonic
+
+pslli.dh _rd_p_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -12707,6 +12711,15 @@ w-uimm format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSLLI.DH (Packed Shift Left Logical Immediate, Double-wide Halfword) shifts
+each packed 16-bit element left by a 4-bit unsigned immediate across a
+double-wide (register-pair) source. It is equivalent to two PSLLI.H
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
+must specify even register numbers. Vacated bits are filled with zeros.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12728,22 +12741,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pslli.dh _rd_p_, _rs1_p_, _uimm4_
-
-===== Description
-
-PSLLI.DH (Packed Shift Left Logical Immediate, Double-wide Halfword) shifts
-each packed 16-bit element left by a 4-bit unsigned immediate across a
-double-wide (register-pair) source. It is equivalent to two PSLLI.H
-operations: one on the even registers and one on the odd registers of each
-pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
-must specify even register numbers. Vacated bits are filled with zeros.
-Available only in RV32.
 
 <<<
 ==== PSLLI.DW (RV32)
+
+===== Mnemonic
+
+pslli.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -12766,6 +12770,14 @@ w-uimm format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSLLI.DW (Packed Shift Left Logical Immediate, Double-wide Word) shifts each
+32-bit word element left by a 5-bit unsigned immediate across a double-wide
+(register-pair) source. It is equivalent to two SLLI operations: one on the
+even registers and one on the odd registers of each pair. The destination
+(`rd_p`) and source (`rs1_p`) are register pairs and must specify even register
+numbers. Vacated bits are filled with zeros. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12782,21 +12794,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pslli.dw _rd_p_, _rs1_p_, _uimm5_
-
-===== Description
-
-PSLLI.DW (Packed Shift Left Logical Immediate, Double-wide Word) shifts each
-32-bit word element left by a 5-bit unsigned immediate across a double-wide
-(register-pair) source. It is equivalent to two SLLI operations: one on the
-even registers and one on the odd registers of each pair. The destination
-(`rd_p`) and source (`rs1_p`) are register pairs and must specify even register
-numbers. Vacated bits are filled with zeros. Available only in RV32.
 
 <<<
 ==== PSRLI.DB (RV32)
+
+===== Mnemonic
+
+psrli.db _rd_p_, _rs1_p_, _uimm3_
 
 ===== Encoding
 
@@ -12819,6 +12823,15 @@ w-uimm format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRLI.DB (Packed Shift Right Logical Immediate, Double-wide Byte) shifts each
+packed 8-bit element right logically by a 3-bit unsigned immediate across a
+double-wide (register-pair) source. It is equivalent to two PSRLI.B
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
+must specify even register numbers. Vacated bits are filled with zeros.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12840,22 +12853,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrli.db _rd_p_, _rs1_p_, _uimm3_
-
-===== Description
-
-PSRLI.DB (Packed Shift Right Logical Immediate, Double-wide Byte) shifts each
-packed 8-bit element right logically by a 3-bit unsigned immediate across a
-double-wide (register-pair) source. It is equivalent to two PSRLI.B
-operations: one on the even registers and one on the odd registers of each
-pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
-must specify even register numbers. Vacated bits are filled with zeros.
-Available only in RV32.
 
 <<<
 ==== PSRLI.DH (RV32)
+
+===== Mnemonic
+
+psrli.dh _rd_p_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -12878,6 +12882,15 @@ w-uimm format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRLI.DH (Packed Shift Right Logical Immediate, Double-wide Halfword) shifts
+each packed 16-bit element right logically by a 4-bit unsigned immediate
+across a double-wide (register-pair) source. It is equivalent to two PSRLI.H
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
+must specify even register numbers. Vacated bits are filled with zeros.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12899,22 +12912,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrli.dh _rd_p_, _rs1_p_, _uimm4_
-
-===== Description
-
-PSRLI.DH (Packed Shift Right Logical Immediate, Double-wide Halfword) shifts
-each packed 16-bit element right logically by a 4-bit unsigned immediate
-across a double-wide (register-pair) source. It is equivalent to two PSRLI.H
-operations: one on the even registers and one on the odd registers of each
-pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
-must specify even register numbers. Vacated bits are filled with zeros.
-Available only in RV32.
 
 <<<
 ==== PSRLI.DW (RV32)
+
+===== Mnemonic
+
+psrli.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -12937,6 +12941,15 @@ w-uimm format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRLI.DW (Packed Shift Right Logical Immediate, Double-wide Word) shifts each
+32-bit word element right logically by a 5-bit unsigned immediate across a
+double-wide (register-pair) source. It is equivalent to two SRLI operations:
+one on the even registers and one on the odd registers of each pair. The
+destination (`rd_p`) and source (`rs1_p`) are register pairs and must specify
+even register numbers. Vacated bits are filled with zeros. Available only in
+RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -12953,22 +12966,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrli.dw _rd_p_, _rs1_p_, _uimm5_
-
-===== Description
-
-PSRLI.DW (Packed Shift Right Logical Immediate, Double-wide Word) shifts each
-32-bit word element right logically by a 5-bit unsigned immediate across a
-double-wide (register-pair) source. It is equivalent to two SRLI operations:
-one on the even registers and one on the odd registers of each pair. The
-destination (`rd_p`) and source (`rs1_p`) are register pairs and must specify
-even register numbers. Vacated bits are filled with zeros. Available only in
-RV32.
 
 <<<
 ==== PSRAI.DB (RV32)
+
+===== Mnemonic
+
+psrai.db _rd_p_, _rs1_p_, _uimm3_
 
 ===== Encoding
 
@@ -12991,6 +12995,15 @@ w-uimm format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRAI.DB (Packed Shift Right Arithmetic Immediate, Double-wide Byte) performs
+arithmetic right shift on each packed 8-bit element by a 3-bit unsigned
+immediate across a double-wide (register-pair) source. It is equivalent to
+two PSRAI.B operations: one on the even registers and one on the odd registers
+of each pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs
+and must specify even register numbers. Each element is sign-extended before
+shifting. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -13012,22 +13025,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrai.db _rd_p_, _rs1_p_, _uimm3_
-
-===== Description
-
-PSRAI.DB (Packed Shift Right Arithmetic Immediate, Double-wide Byte) performs
-arithmetic right shift on each packed 8-bit element by a 3-bit unsigned
-immediate across a double-wide (register-pair) source. It is equivalent to
-two PSRAI.B operations: one on the even registers and one on the odd registers
-of each pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs
-and must specify even register numbers. Each element is sign-extended before
-shifting. Available only in RV32.
 
 <<<
 ==== PSRAI.DH (RV32)
+
+===== Mnemonic
+
+psrai.dh _rd_p_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -13050,6 +13054,15 @@ w-uimm format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRAI.DH (Packed Shift Right Arithmetic Immediate, Double-wide Halfword)
+performs arithmetic right shift on each packed 16-bit element by a 4-bit
+unsigned immediate across a double-wide (register-pair) source. It is
+equivalent to two PSRAI.H operations: one on the even registers and one on
+the odd registers of each pair. The destination (`rd_p`) and source (`rs1_p`)
+are register pairs and must specify even register numbers. Each element is
+sign-extended before shifting. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -13071,22 +13084,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrai.dh _rd_p_, _rs1_p_, _uimm4_
-
-===== Description
-
-PSRAI.DH (Packed Shift Right Arithmetic Immediate, Double-wide Halfword)
-performs arithmetic right shift on each packed 16-bit element by a 4-bit
-unsigned immediate across a double-wide (register-pair) source. It is
-equivalent to two PSRAI.H operations: one on the even registers and one on
-the odd registers of each pair. The destination (`rd_p`) and source (`rs1_p`)
-are register pairs and must specify even register numbers. Each element is
-sign-extended before shifting. Available only in RV32.
 
 <<<
 ==== PSRAI.DW (RV32)
+
+===== Mnemonic
+
+psrai.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -13109,6 +13113,15 @@ w-uimm format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRAI.DW (Packed Shift Right Arithmetic Immediate, Double-wide Word) performs
+arithmetic right shift on each 32-bit word element by a 5-bit unsigned
+immediate across a double-wide (register-pair) source. It is equivalent to
+two SRAI operations: one on the even registers and one on the odd registers of
+each pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs
+and must specify even register numbers. Each element is sign-extended before
+shifting. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -13125,22 +13138,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrai.dw _rd_p_, _rs1_p_, _uimm5_
-
-===== Description
-
-PSRAI.DW (Packed Shift Right Arithmetic Immediate, Double-wide Word) performs
-arithmetic right shift on each 32-bit word element by a 5-bit unsigned
-immediate across a double-wide (register-pair) source. It is equivalent to
-two SRAI operations: one on the even registers and one on the odd registers of
-each pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs
-and must specify even register numbers. Each element is sign-extended before
-shifting. Available only in RV32.
 
 <<<
 ==== PSRARI.DH (RV32)
+
+===== Mnemonic
+
+psrari.dh _rd_p_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -13163,6 +13167,16 @@ w-uimm format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSRARI.DH (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
+Halfword) performs arithmetic right shift with rounding on each packed 16-bit
+element by a 4-bit unsigned immediate across a double-wide (register-pair)
+source. It is equivalent to two PSRARI.H operations: one on the even
+registers and one on the odd registers of each pair. The destination (`rd_p`)
+and source (`rs1_p`) are register pairs and must specify even register numbers.
+The shifted-out bit immediately below the least-significant result bit is
+added for rounding. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -13192,23 +13206,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrari.dh _rd_p_, _rs1_p_, _uimm4_
-
-===== Description
-
-PSRARI.DH (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
-Halfword) performs arithmetic right shift with rounding on each packed 16-bit
-element by a 4-bit unsigned immediate across a double-wide (register-pair)
-source. It is equivalent to two PSRARI.H operations: one on the even
-registers and one on the odd registers of each pair. The destination (`rd_p`)
-and source (`rs1_p`) are register pairs and must specify even register numbers.
-The shifted-out bit immediately below the least-significant result bit is
-added for rounding. Available only in RV32.
 
 <<<
 ==== PSRARI.DW (RV32)
+
+===== Mnemonic
+
+psrari.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -13233,6 +13237,16 @@ w-uimm format with word elements. Available only in RV32.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
+===== Description
+
+PSRARI.DW (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
+Word) performs arithmetic right shift with rounding on each 32-bit word
+element by a 5-bit unsigned immediate across a double-wide (register-pair)
+source. It is equivalent to two SRARI operations: one on the even registers
+and one on the odd registers of each pair. The destination (`rd_p`) and source
+(`rs1_p`) are register pairs and must specify even register numbers. The
+shifted-out bit immediately below the least-significant result bit is added
+for rounding. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -13255,25 +13269,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psrari.dw _rd_p_, _rs1_p_, _uimm5_
-
-===== Description
-
-PSRARI.DW (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
-Word) performs arithmetic right shift with rounding on each 32-bit word
-element by a 5-bit unsigned immediate across a double-wide (register-pair)
-source. It is equivalent to two SRARI operations: one on the even registers
-and one on the odd registers of each pair. The destination (`rd_p`) and source
-(`rs1_p`) are register pairs and must specify even register numbers. The
-shifted-out bit immediately below the least-significant result bit is added
-for rounding. Available only in RV32.
 
 <<<
 === Saturating/Rounding Shift
 
 ==== PSSHA.HS
+
+===== Mnemonic
+
+pssha.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -13293,6 +13297,12 @@ PSSHA.HS is encoded in the OP-IMM-32 major opcode.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The PSSHA.HS instruction performs a signed variable shift on each packed 16-bit
+element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts saturate
+to the signed 16-bit range.
 
 ===== Operation
 
@@ -13333,22 +13343,16 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pssha.hs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSSHA.HS instruction performs a signed variable shift on each packed 16-bit
-element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts saturate
-to the signed 16-bit range.
-
 ===== Notes
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHA.WS (RV64)
+
+===== Mnemonic
+
+pssha.ws _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -13369,21 +13373,21 @@ PSSHA.WS is available only in RV64.
 ]}
 ....
 
-===== Operation
-// (use your Sail-derived pseudocode as previously, unchanged)
-
-===== Mnemonic
-
-pssha.ws _rd_, _rs1_, _rs2_
-
 ===== Description
 
 The PSSHA.WS instruction performs a signed variable shift on each packed 32-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts
 saturate to the signed 32-bit range.
+===== Operation
+// (use your Sail-derived pseudocode as previously, unchanged)
+
 
 <<<
 ==== PSSHAR.HS
+
+===== Mnemonic
+
+psshar.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -13403,6 +13407,12 @@ PSSHAR.HS is encoded in the OP-IMM-32 major opcode.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The PSSHAR.HS instruction performs a signed variable shift on each packed 16-bit
+element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
+rounded, and left shifts saturate to the signed 16-bit range.
 
 ===== Operation
 
@@ -13440,22 +13450,16 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psshar.hs _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PSSHAR.HS instruction performs a signed variable shift on each packed 16-bit
-element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
-rounded, and left shifts saturate to the signed 16-bit range.
-
 ===== Notes
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHAR.WS (RV64)
+
+===== Mnemonic
+
+psshar.ws _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -13476,21 +13480,21 @@ PSSHAR.WS is available only in RV64.
 ]}
 ....
 
-===== Operation
-// (use your Sail-derived pseudocode as previously, unchanged)
-
-===== Mnemonic
-
-psshar.ws _rd_, _rs1_, _rs2_
-
 ===== Description
 
 The PSSHAR.WS instruction performs a signed variable shift on each packed 32-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
 rounded, and left shifts saturate to the signed 32-bit range.
+===== Operation
+// (use your Sail-derived pseudocode as previously, unchanged)
+
 
 <<<
 ==== PSSLAI.H
+
+===== Mnemonic
+
+psslai.h _rd_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -13514,6 +13518,13 @@ and packed halfword elements.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
+===== Description
+
+PSSLAI.H (Packed Saturating Shift Left Arithmetic Immediate, Halfword) shifts
+each packed signed 16-bit element of `rs1` left by a 4-bit unsigned immediate.
+If the shifted result overflows the signed 16-bit range [-2^15, 2^15-1], the
+result is saturated to the nearest boundary and the `vxsat` flag is set. The
+packed halfword results are written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -13534,20 +13545,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psslai.h _rd_, _rs1_, _uimm4_
-
-===== Description
-
-PSSLAI.H (Packed Saturating Shift Left Arithmetic Immediate, Halfword) shifts
-each packed signed 16-bit element of `rs1` left by a 4-bit unsigned immediate.
-If the shifted result overflows the signed 16-bit range [-2^15, 2^15-1], the
-result is saturated to the nearest boundary and the `vxsat` flag is set. The
-packed halfword results are written to `rd`.
 
 <<<
 ==== PSSLAI.W (RV64)
+
+===== Mnemonic
+
+psslai.w _rd_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -13571,6 +13575,13 @@ and word elements. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
+===== Description
+
+PSSLAI.W (Packed Saturating Shift Left Arithmetic Immediate, Word) shifts each
+packed signed 32-bit element of `rs1` left by a 5-bit unsigned immediate. If
+the shifted result overflows the signed 32-bit range [-2^31, 2^31-1], the
+result is saturated to the nearest boundary and the `vxsat` flag is set. The
+packed word results are written to `rd`. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -13591,20 +13602,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-psslai.w _rd_, _rs1_, _uimm5_
-
-===== Description
-
-PSSLAI.W (Packed Saturating Shift Left Arithmetic Immediate, Word) shifts each
-packed signed 32-bit element of `rs1` left by a 5-bit unsigned immediate. If
-the shifted result overflows the signed 32-bit range [-2^31, 2^31-1], the
-result is saturated to the nearest boundary and the `vxsat` flag is set. The
-packed word results are written to `rd`. Available only in RV64.
 
 <<<
 ==== SSHA (RV32)
+
+===== Mnemonic
+
+ssha _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -13625,6 +13629,10 @@ SSHA is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 ]}
 ....
 
+===== Description
+
+The SSHA instruction performs a signed variable shift of `rs1` using the signed
+shift amount in `rs2[7:0]`. Left shifts saturate to the signed 32-bit range.
 ===== Operation
 
 [source,pseudocode]
@@ -13653,17 +13661,13 @@ else:
         X[rd] = shx[31:0]
 ----
 
-===== Mnemonic
-
-ssha _rd_, _rs1_, _rs2_
-
-===== Description
-
-The SSHA instruction performs a signed variable shift of `rs1` using the signed
-shift amount in `rs2[7:0]`. Left shifts saturate to the signed 32-bit range.
 
 <<<
 ==== SSHAR (RV32)
+
+===== Mnemonic
+
+sshar _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -13683,6 +13687,12 @@ SSHAR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The SSHAR instruction performs a signed variable shift of `rs1` using the signed
+shift amount in `rs2[7:0]`. Right shifts are rounded, and left shifts saturate
+to the signed 32-bit range.
 
 ===== Operation
 
@@ -13713,22 +13723,16 @@ else:
         X[rd] = shx[31:0]
 ----
 
-===== Mnemonic
-
-sshar _rd_, _rs1_, _rs2_
-
-===== Description
-
-The SSHAR instruction performs a signed variable shift of `rs1` using the signed
-shift amount in `rs2[7:0]`. Right shifts are rounded, and left shifts saturate
-to the signed 32-bit range.
-
 ===== Notes
 
 * `vxsat` is set to 1 if saturation occurs.
 
 <<<
 ==== SSLAI (RV32)
+
+===== Mnemonic
+
+sslai _rd_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -13752,6 +13756,12 @@ a scalar XLEN-wide saturating shift left arithmetic immediate.
 
 The `uimm5` field encodes the 5-bit shift amount.
 
+===== Description
+
+SSLAI shifts the signed XLEN-wide value in `rs1` left by the immediate
+shift amount and writes the result to `rd` with signed saturation. If the
+shifted result overflows the signed XLEN-wide range, the result is clamped
+to the nearest boundary and the `vxsat` overflow flag is set.
 ===== Operation
 
 [source,pseudocode]
@@ -13771,19 +13781,14 @@ else:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-sslai _rd_, _rs1_, _uimm5_
-
-===== Description
-
-SSLAI shifts the signed XLEN-wide value in `rs1` left by the immediate
-shift amount and writes the result to `rd` with signed saturation. If the
-shifted result overflows the signed XLEN-wide range, the result is clamped
-to the nearest boundary and the `vxsat` overflow flag is set.
 
 <<<
 ==== SRARI
+
+===== Mnemonic
+
+srari _rd_, _rs1_, _uimm5_ (RV32) +
+srari _rd_, _rs1_, _uimm6_ (RV64)
 
 ===== Encoding
 
@@ -13828,6 +13833,13 @@ RV64:
 
 The `uimm6` field encodes the 6-bit shift amount for RV64.
 
+===== Description
+
+SRARI arithmetically shifts the XLEN-wide value in `rs1` right by the
+immediate shift amount with rounding and writes the result to `rd`. A
+rounding bit is added before the final shift so that the result is rounded
+to the nearest integer (round-to-nearest, ties round up). When the shift
+amount is zero the source value is written unchanged.
 ===== Operation
 
 [source,pseudocode]
@@ -13845,21 +13857,13 @@ else:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-srari _rd_, _rs1_, _uimm5_ (RV32) +
-srari _rd_, _rs1_, _uimm6_ (RV64)
-
-===== Description
-
-SRARI arithmetically shifts the XLEN-wide value in `rs1` right by the
-immediate shift amount with rounding and writes the result to `rd`. A
-rounding bit is added before the final shift so that the result is rounded
-to the nearest integer (round-to-nearest, ties round up). When the shift
-amount is zero the source value is written unchanged.
 
 <<<
 ==== SHA (RV64)
+
+===== Mnemonic
+
+sha _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -13880,6 +13884,11 @@ SHA is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The SHA instruction performs a signed variable shift of `rs1` using the signed
+shift amount in `rs2[7:0]`. Negative shift amounts shift right; non-negative
+shift amounts shift left.
 ===== Operation
 
 [source,pseudocode]
@@ -13901,18 +13910,13 @@ else:
         X[rd] = s1 << shamt[5:0]
 ----
 
-===== Mnemonic
-
-sha _rd_, _rs1_, _rs2_
-
-===== Description
-
-The SHA instruction performs a signed variable shift of `rs1` using the signed
-shift amount in `rs2[7:0]`. Negative shift amounts shift right; non-negative
-shift amounts shift left.
 
 <<<
 ==== SHAR (RV64)
+
+===== Mnemonic
+
+shar _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -13933,6 +13937,10 @@ SHAR is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The SHAR instruction matches SHA for non-negative shift amounts. For negative
+shift amounts it performs a rounding right shift as specified in the Sail code.
 ===== Operation
 
 [source,pseudocode]
@@ -13955,18 +13963,14 @@ else:
         X[rd] = s1 << shamt[5:0]
 ----
 
-===== Mnemonic
-
-shar _rd_, _rs1_, _rs2_
-
-===== Description
-
-The SHAR instruction matches SHA for non-negative shift amounts. For negative
-shift amounts it performs a rounding right shift as specified in the Sail code.
 
 
 <<<
 ==== PSSHA.DHS (RV32)
+
+===== Mnemonic
+
+pssha.dhs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -13989,6 +13993,18 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSSHA.DHS (Packed Saturating Shift Halfword Arithmetic, Double-wide, Scalar)
+performs a signed shift on each packed 16-bit element across a double-wide
+(register-pair) source using a scalar shift amount from `rs2`. When the shift
+amount is positive, elements are shifted left with signed saturation to the
+range [-2^15, 2^15-1]; on saturation the `vxsat` flag is set. When negative,
+elements are arithmetically shifted right. It is equivalent to two PSSHA.HS
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
+and must specify even register numbers; `rs2` is a single register. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -14031,25 +14047,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pssha.dhs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSSHA.DHS (Packed Saturating Shift Halfword Arithmetic, Double-wide, Scalar)
-performs a signed shift on each packed 16-bit element across a double-wide
-(register-pair) source using a scalar shift amount from `rs2`. When the shift
-amount is positive, elements are shifted left with signed saturation to the
-range [-2^15, 2^15-1]; on saturation the `vxsat` flag is set. When negative,
-elements are arithmetically shifted right. It is equivalent to two PSSHA.HS
-operations: one on the even registers and one on the odd registers of each
-pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
-and must specify even register numbers; `rs2` is a single register. Available
-only in RV32.
 
 <<<
 ==== PSSHA.DWS (RV32)
+
+===== Mnemonic
+
+pssha.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -14072,6 +14076,18 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSSHA.DWS (Packed Saturating Shift Word Arithmetic, Double-wide, Scalar)
+performs a signed shift on each 32-bit word element across a double-wide
+(register-pair) source using a scalar shift amount from `rs2`. When the shift
+amount is positive, elements are shifted left with signed saturation to the
+range [-2^31, 2^31-1]; on saturation the `vxsat` flag is set. When negative,
+elements are arithmetically shifted right. It is equivalent to two SSHA
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
+and must specify even register numbers; `rs2` is a single register. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -14108,25 +14124,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-pssha.dws _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSSHA.DWS (Packed Saturating Shift Word Arithmetic, Double-wide, Scalar)
-performs a signed shift on each 32-bit word element across a double-wide
-(register-pair) source using a scalar shift amount from `rs2`. When the shift
-amount is positive, elements are shifted left with signed saturation to the
-range [-2^31, 2^31-1]; on saturation the `vxsat` flag is set. When negative,
-elements are arithmetically shifted right. It is equivalent to two SSHA
-operations: one on the even registers and one on the odd registers of each
-pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
-and must specify even register numbers; `rs2` is a single register. Available
-only in RV32.
 
 <<<
 ==== PSSHAR.DHS (RV32)
+
+===== Mnemonic
+
+psshar.dhs _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -14149,6 +14153,19 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSSHAR.DHS (Packed Saturating Shift Halfword Arithmetic Rounding, Double-wide,
+Scalar) performs a signed shift on each packed 16-bit element across a
+double-wide (register-pair) source using a scalar shift amount from `rs2`.
+When the shift amount is positive, elements are shifted left with signed
+saturation to the range [-2^15, 2^15-1]; on saturation the `vxsat` flag is
+set. When negative, elements are arithmetically shifted right with rounding
+(the shifted-out bit below the LSB is added). It is equivalent to two
+PSSHAR.HS operations: one on the even registers and one on the odd registers
+of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
+pairs and must specify even register numbers; `rs2` is a single register.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -14195,26 +14212,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psshar.dhs _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSSHAR.DHS (Packed Saturating Shift Halfword Arithmetic Rounding, Double-wide,
-Scalar) performs a signed shift on each packed 16-bit element across a
-double-wide (register-pair) source using a scalar shift amount from `rs2`.
-When the shift amount is positive, elements are shifted left with signed
-saturation to the range [-2^15, 2^15-1]; on saturation the `vxsat` flag is
-set. When negative, elements are arithmetically shifted right with rounding
-(the shifted-out bit below the LSB is added). It is equivalent to two
-PSSHAR.HS operations: one on the even registers and one on the odd registers
-of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
-pairs and must specify even register numbers; `rs2` is a single register.
-Available only in RV32.
 
 <<<
 ==== PSSHAR.DWS (RV32)
+
+===== Mnemonic
+
+psshar.dws _rd_p_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -14237,6 +14241,19 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PSSHAR.DWS (Packed Saturating Shift Word Arithmetic Rounding, Double-wide,
+Scalar) performs a signed shift on each 32-bit word element across a
+double-wide (register-pair) source using a scalar shift amount from `rs2`.
+When the shift amount is positive, elements are shifted left with signed
+saturation to the range [-2^31, 2^31-1]; on saturation the `vxsat` flag is
+set. When negative, elements are arithmetically shifted right with rounding
+(the shifted-out bit below the LSB is added). It is equivalent to two SSHAR
+operations: one on the even registers and one on the odd registers of each
+pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
+and must specify even register numbers; `rs2` is a single register. Available
+only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -14278,26 +14295,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psshar.dws _rd_p_, _rs1_p_, _rs2_
-
-===== Description
-
-PSSHAR.DWS (Packed Saturating Shift Word Arithmetic Rounding, Double-wide,
-Scalar) performs a signed shift on each 32-bit word element across a
-double-wide (register-pair) source using a scalar shift amount from `rs2`.
-When the shift amount is positive, elements are shifted left with signed
-saturation to the range [-2^31, 2^31-1]; on saturation the `vxsat` flag is
-set. When negative, elements are arithmetically shifted right with rounding
-(the shifted-out bit below the LSB is added). It is equivalent to two SSHAR
-operations: one on the even registers and one on the odd registers of each
-pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
-and must specify even register numbers; `rs2` is a single register. Available
-only in RV32.
 
 <<<
 ==== PSSLAI.DH (RV32)
+
+===== Mnemonic
+
+psslai.dh _rd_p_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -14322,6 +14326,14 @@ immediate format with packed halfword elements. Available only in RV32.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
+===== Description
+
+PSSLAI.DH performs packed 16-bit saturating shift-left arithmetic by an immediate
+on double-wide (register-pair) operands. It is equivalent to two PSSLAI.H
+operations: one on the even registers and one on the odd registers of each pair.
+Both operands (`rd_p`, `rs1_p`) are register pairs and must specify even register
+numbers. If any result overflows the signed 16-bit range, it is saturated and the
+`vxsat` flag is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -14355,21 +14367,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psslai.dh _rd_p_, _rs1_p_, _uimm4_
-
-===== Description
-
-PSSLAI.DH performs packed 16-bit saturating shift-left arithmetic by an immediate
-on double-wide (register-pair) operands. It is equivalent to two PSSLAI.H
-operations: one on the even registers and one on the odd registers of each pair.
-Both operands (`rd_p`, `rs1_p`) are register pairs and must specify even register
-numbers. If any result overflows the signed 16-bit range, it is saturated and the
-`vxsat` flag is set. Available only in RV32.
 
 <<<
 ==== PSSLAI.DW (RV32)
+
+===== Mnemonic
+
+psslai.dw _rd_p_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -14394,6 +14398,14 @@ immediate format with word elements. Available only in RV32.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
+===== Description
+
+PSSLAI.DW performs XLEN-wide saturating shift-left arithmetic by an immediate
+on double-wide (register-pair) operands. It is equivalent to two SSLAI
+operations: one on the even registers and one on the odd registers of each pair.
+Both operands (`rd_p`, `rs1_p`) are register pairs and must specify even register
+numbers. If any result overflows the signed 32-bit range, it is saturated and the
+`vxsat` flag is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -14425,23 +14437,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-psslai.dw _rd_p_, _rs1_p_, _uimm5_
-
-===== Description
-
-PSSLAI.DW performs XLEN-wide saturating shift-left arithmetic by an immediate
-on double-wide (register-pair) operands. It is equivalent to two SSLAI
-operations: one on the even registers and one on the odd registers of each pair.
-Both operands (`rd_p`, `rs1_p`) are register pairs and must specify even register
-numbers. If any result overflows the signed 32-bit range, it is saturated and the
-`vxsat` flag is set. Available only in RV32.
 
 <<<
 === Pair Operations
 
 ==== PPAIRE.B
+
+===== Mnemonic
+
+ppaire.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14462,6 +14466,11 @@ PPAIRE.B is encoded in the OP-32 major opcode with packed-byte pairing.
 ]}
 ....
 
+===== Description
+
+The PPAIRE.B instruction forms packed 16-bit elements by pairing the low byte of each
+halfword element of `rs2` as the high byte with the low byte of the corresponding
+halfword element of `rs1` as the low byte.
 ===== Operation
 
 [source,pseudocode]
@@ -14477,18 +14486,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppaire.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PPAIRE.B instruction forms packed 16-bit elements by pairing the low byte of each
-halfword element of `rs2` as the high byte with the low byte of the corresponding
-halfword element of `rs1` as the low byte.
 
 <<<
 ==== PPAIRE.H
+
+===== Mnemonic
+
+ppaire.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14509,6 +14513,13 @@ On RV32, PPAIRE.H is a pseudoinstruction aliased to PACK.
 ]}
 ....
 
+===== Description
+
+PPAIRE.H (Pack Pair Even Halfwords) extracts the even (lower) halfword from
+each 32-bit word of `rs1` and `rs2`, and packs them together into the
+corresponding 32-bit word of `rd`. Within each 32-bit group, the lower halfword
+comes from `rs1` and the upper halfword comes from `rs2`. On RV32, this
+instruction is an alias for PACK.
 ===== Operation
 
 [source,pseudocode]
@@ -14524,20 +14535,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppaire.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PPAIRE.H (Pack Pair Even Halfwords) extracts the even (lower) halfword from
-each 32-bit word of `rs1` and `rs2`, and packs them together into the
-corresponding 32-bit word of `rd`. Within each 32-bit group, the lower halfword
-comes from `rs1` and the upper halfword comes from `rs2`. On RV32, this
-instruction is an alias for PACK.
 
 <<<
 ==== PPAIREO.B
+
+===== Mnemonic
+
+ppaireo.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14558,6 +14562,10 @@ PPAIREO.B is encoded in the OP-32 major opcode with packed-byte pairing.
 ]}
 ....
 
+===== Description
+
+The PPAIREO.B instruction pairs the high byte of each halfword element of `rs2` with
+the low byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 ===== Operation
 
 [source,pseudocode]
@@ -14573,17 +14581,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppaireo.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PPAIREO.B instruction pairs the high byte of each halfword element of `rs2` with
-the low byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 
 <<<
 ==== PPAIREO.H
+
+===== Mnemonic
+
+ppaireo.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14603,6 +14607,13 @@ PPAIREO.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PPAIREO.H (Pack Pair Even-Odd Halfwords) extracts the even (lower) halfword
+from each 32-bit word of `rs1` and the odd (upper) halfword from each 32-bit
+word of `rs2`, and packs them together into the corresponding 32-bit word of
+`rd`. Within each 32-bit group, the lower halfword comes from the even position
+of `rs1` and the upper halfword comes from the odd position of `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -14618,20 +14629,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppaireo.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PPAIREO.H (Pack Pair Even-Odd Halfwords) extracts the even (lower) halfword
-from each 32-bit word of `rs1` and the odd (upper) halfword from each 32-bit
-word of `rs2`, and packs them together into the corresponding 32-bit word of
-`rd`. Within each 32-bit group, the lower halfword comes from the even position
-of `rs1` and the upper halfword comes from the odd position of `rs2`.
 
 <<<
 ==== PPAIREO.W (RV64)
+
+===== Mnemonic
+
+ppaireo.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14652,6 +14656,12 @@ Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PPAIREO.W (Pack Pair Even-Odd Words) extracts the even (lower) 32-bit word from
+`rs1` and the odd (upper) 32-bit word from `rs2`, and packs them into `rd`. The
+lower word of the result comes from the even position of `rs1` and the upper word
+comes from the odd position of `rs2`. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -14665,19 +14675,13 @@ d = s2[63:32] @ s1[31:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppaireo.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PPAIREO.W (Pack Pair Even-Odd Words) extracts the even (lower) 32-bit word from
-`rs1` and the odd (upper) 32-bit word from `rs2`, and packs them into `rd`. The
-lower word of the result comes from the even position of `rs1` and the upper word
-comes from the odd position of `rs2`. Available only in RV64.
 
 <<<
 ==== PPAIROE.B
+
+===== Mnemonic
+
+ppairoe.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14698,6 +14702,10 @@ PPAIROE.B is encoded in the OP-32 major opcode with packed-byte pairing.
 ]}
 ....
 
+===== Description
+
+The PPAIROE.B instruction pairs the low byte of each halfword element of `rs2` with
+the high byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 ===== Operation
 
 [source,pseudocode]
@@ -14713,17 +14721,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppairoe.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PPAIROE.B instruction pairs the low byte of each halfword element of `rs2` with
-the high byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 
 <<<
 ==== PPAIROE.H
+
+===== Mnemonic
+
+ppairoe.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14743,6 +14747,13 @@ PPAIROE.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PPAIROE.H (Pack Pair Odd-Even Halfwords) extracts the odd (upper) halfword from
+each 32-bit word of `rs1` and the even (lower) halfword from each 32-bit word
+of `rs2`, and packs them together into the corresponding 32-bit word of `rd`.
+Within each 32-bit group, the lower halfword comes from the odd position of
+`rs1` and the upper halfword comes from the even position of `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -14758,20 +14769,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppairoe.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PPAIROE.H (Pack Pair Odd-Even Halfwords) extracts the odd (upper) halfword from
-each 32-bit word of `rs1` and the even (lower) halfword from each 32-bit word
-of `rs2`, and packs them together into the corresponding 32-bit word of `rd`.
-Within each 32-bit group, the lower halfword comes from the odd position of
-`rs1` and the upper halfword comes from the even position of `rs2`.
 
 <<<
 ==== PPAIROE.W (RV64)
+
+===== Mnemonic
+
+ppairoe.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14792,6 +14796,12 @@ Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PPAIROE.W (Pack Pair Odd-Even Words) extracts the odd (upper) 32-bit word from
+`rs1` and the even (lower) 32-bit word from `rs2`, and packs them into `rd`. The
+lower word of the result comes from the odd position of `rs1` and the upper word
+comes from the even position of `rs2`. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -14805,19 +14815,13 @@ d = s2[31:0] @ s1[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppairoe.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PPAIROE.W (Pack Pair Odd-Even Words) extracts the odd (upper) 32-bit word from
-`rs1` and the even (lower) 32-bit word from `rs2`, and packs them into `rd`. The
-lower word of the result comes from the odd position of `rs1` and the upper word
-comes from the even position of `rs2`. Available only in RV64.
 
 <<<
 ==== PPAIRO.B
+
+===== Mnemonic
+
+ppairo.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14838,6 +14842,10 @@ PPAIRO.B is encoded in the OP-32 major opcode with packed-byte pairing.
 ]}
 ....
 
+===== Description
+
+The PPAIRO.B instruction pairs the high byte of each halfword element of `rs2` with
+the high byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 ===== Operation
 
 [source,pseudocode]
@@ -14853,18 +14861,14 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppairo.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PPAIRO.B instruction pairs the high byte of each halfword element of `rs2` with
-the high byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 
 
 <<<
 ==== PPAIRO.H
+
+===== Mnemonic
+
+ppairo.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14884,6 +14888,13 @@ PPAIRO.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PPAIRO.H (Pack Pair Odd Halfwords) extracts the odd (upper) halfword from each
+32-bit word of `rs1` and `rs2`, and packs them together into the corresponding
+32-bit word of `rd`. Within each 32-bit group, the lower halfword comes from the
+odd position of `rs1` and the upper halfword comes from the odd position of
+`rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -14899,20 +14910,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppairo.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PPAIRO.H (Pack Pair Odd Halfwords) extracts the odd (upper) halfword from each
-32-bit word of `rs1` and `rs2`, and packs them together into the corresponding
-32-bit word of `rd`. Within each 32-bit group, the lower halfword comes from the
-odd position of `rs1` and the upper halfword comes from the odd position of
-`rs2`.
 
 <<<
 ==== PPAIRO.W (RV64)
+
+===== Mnemonic
+
+ppairo.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -14933,6 +14937,12 @@ Available only in RV64.
 ]}
 ....
 
+===== Description
+
+PPAIRO.W (Pack Pair Odd Words) extracts the odd (upper) 32-bit word from both
+`rs1` and `rs2`, and packs them into `rd`. The lower word of the result comes
+from the odd position of `rs1` and the upper word comes from the odd position of
+`rs2`. Available only in RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -14946,19 +14956,13 @@ d = s2[63:32] @ s1[63:32]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-ppairo.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PPAIRO.W (Pack Pair Odd Words) extracts the odd (upper) 32-bit word from both
-`rs1` and `rs2`, and packs them into `rd`. The lower word of the result comes
-from the odd position of `rs1` and the upper word comes from the odd position of
-`rs2`. Available only in RV64.
 
 <<<
 ==== PPAIRE.DB (RV32)
+
+===== Mnemonic
+
+ppaire.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -14981,6 +14985,13 @@ register-pair format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PPAIRE.DB performs packed byte even-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRE.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -15005,20 +15016,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-ppaire.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PPAIRE.DB performs packed byte even-element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIRE.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PPAIRE.DH (RV32)
+
+===== Mnemonic
+
+ppaire.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -15041,6 +15045,13 @@ register-pair format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PPAIRE.DH performs packed halfword even-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRE.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -15065,20 +15076,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-ppaire.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PPAIRE.DH performs packed halfword even-element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIRE.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PPAIREO.DB (RV32)
+
+===== Mnemonic
+
+ppaireo.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -15101,6 +15105,13 @@ register-pair format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PPAIREO.DB performs packed byte even-odd element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIREO.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -15125,20 +15136,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-ppaireo.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PPAIREO.DB performs packed byte even-odd element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIREO.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PPAIREO.DH (RV32)
+
+===== Mnemonic
+
+ppaireo.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -15161,6 +15165,13 @@ register-pair format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PPAIREO.DH performs packed halfword even-odd element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIREO.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -15185,20 +15196,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-ppaireo.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PPAIREO.DH performs packed halfword even-odd element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIREO.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PPAIROE.DB (RV32)
+
+===== Mnemonic
+
+ppairoe.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -15221,6 +15225,13 @@ register-pair format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PPAIROE.DB performs packed byte odd-even element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIROE.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -15245,20 +15256,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-ppairoe.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PPAIROE.DB performs packed byte odd-even element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIROE.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PPAIROE.DH (RV32)
+
+===== Mnemonic
+
+ppairoe.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -15281,6 +15285,13 @@ register-pair format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PPAIROE.DH performs packed halfword odd-even element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIROE.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -15305,20 +15316,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-ppairoe.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PPAIROE.DH performs packed halfword odd-even element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIROE.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PPAIRO.DB (RV32)
+
+===== Mnemonic
+
+ppairo.db _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -15341,6 +15345,13 @@ register-pair format with packed byte elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PPAIRO.DB performs packed byte odd-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRO.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -15365,20 +15376,13 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-ppairo.db _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PPAIRO.DB performs packed byte odd-element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIRO.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== PPAIRO.DH (RV32)
+
+===== Mnemonic
+
+ppairo.dh _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -15401,6 +15405,13 @@ register-pair format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PPAIRO.DH performs packed halfword odd-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRO.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -15425,22 +15436,15 @@ X[rd_p * 2]     = d_lo
 X[rd_p * 2 + 1] = d_hi
 ----
 
-===== Mnemonic
-
-ppairo.dh _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-PPAIRO.DH performs packed halfword odd-element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIRO.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 === Zip/Unzip and Byte-Reverse
 
 ==== ZIP8P (RV64)
+
+===== Mnemonic
+
+zip8p _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -15461,6 +15465,10 @@ ZIP8P is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The ZIP8P instruction interleaves bytes from `rs2` and `rs1` to form a packed 64-bit result:
+for each byte position, the corresponding byte from `rs2` is placed above the byte from `rs1`.
 ===== Operation
 
 [source,pseudocode]
@@ -15473,17 +15481,13 @@ X[rd] =
   @ s2[15:8]  @ s1[15:8]  @ s2[7:0]   @ s1[7:0]
 ----
 
-===== Mnemonic
-
-zip8p _rd_, _rs1_, _rs2_
-
-===== Description
-
-The ZIP8P instruction interleaves bytes from `rs2` and `rs1` to form a packed 64-bit result:
-for each byte position, the corresponding byte from `rs2` is placed above the byte from `rs1`.
 
 <<<
 ==== ZIP8HP (RV64)
+
+===== Mnemonic
+
+zip8hp _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -15504,6 +15508,10 @@ ZIP8HP is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The ZIP8HP instruction interleaves bytes from the high 32-bit halves of `rs2` and
+`rs1` to form a 64-bit result.
 ===== Operation
 
 [source,pseudocode]
@@ -15516,17 +15524,13 @@ X[rd] =
   @ s2[47:40] @ s1[47:40] @ s2[39:32] @ s1[39:32]
 ----
 
-===== Mnemonic
-
-zip8hp _rd_, _rs1_, _rs2_
-
-===== Description
-
-The ZIP8HP instruction interleaves bytes from the high 32-bit halves of `rs2` and
-`rs1` to form a 64-bit result.
 
 <<<
 ==== UNZIP8P (RV64)
+
+===== Mnemonic
+
+unzip8p _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -15547,6 +15551,10 @@ UNZIP8P is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The UNZIP8P instruction de-interleaves bytes from `rs2` and `rs1` to form a 64-bit
+result containing selected byte lanes from each source.
 ===== Operation
 
 [source,pseudocode]
@@ -15559,17 +15567,13 @@ X[rd] =
   @ s1[55:48] @ s1[39:32] @ s1[23:16] @ s1[7:0]
 ----
 
-===== Mnemonic
-
-unzip8p _rd_, _rs1_, _rs2_
-
-===== Description
-
-The UNZIP8P instruction de-interleaves bytes from `rs2` and `rs1` to form a 64-bit
-result containing selected byte lanes from each source.
 
 <<<
 ==== UNZIP8HP (RV64)
+
+===== Mnemonic
+
+unzip8hp _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -15590,6 +15594,10 @@ UNZIP8HP is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The UNZIP8HP instruction de-interleaves bytes from `rs2` and `rs1` using the
+high-part byte selection pattern and forms a 64-bit result.
 ===== Operation
 
 [source,pseudocode]
@@ -15602,17 +15610,13 @@ X[rd] =
   @ s1[63:56] @ s1[47:40] @ s1[31:24] @ s1[15:8]
 ----
 
-===== Mnemonic
-
-unzip8hp _rd_, _rs1_, _rs2_
-
-===== Description
-
-The UNZIP8HP instruction de-interleaves bytes from `rs2` and `rs1` using the
-high-part byte selection pattern and forms a 64-bit result.
 
 <<<
 ==== ZIP16P (RV64)
+
+===== Mnemonic
+
+zip16p _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -15633,6 +15637,10 @@ ZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The ZIP16P instruction interleaves 16-bit chunks from `rs2` and `rs1` to form a
+64-bit result.
 ===== Operation
 
 [source,pseudocode]
@@ -15643,17 +15651,13 @@ s2 = X[rs2]
 X[rd] = s2[31:16] @ s1[31:16] @ s2[15:0] @ s1[15:0]
 ----
 
-===== Mnemonic
-
-zip16p _rd_, _rs1_, _rs2_
-
-===== Description
-
-The ZIP16P instruction interleaves 16-bit chunks from `rs2` and `rs1` to form a
-64-bit result.
 
 <<<
 ==== ZIP16HP (RV64)
+
+===== Mnemonic
+
+zip16hp _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -15674,6 +15678,10 @@ ZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The ZIP16HP instruction interleaves 16-bit chunks from the high 32-bit halves of
+`rs2` and `rs1` to form a 64-bit result.
 ===== Operation
 
 [source,pseudocode]
@@ -15684,17 +15692,13 @@ s2 = X[rs2]
 X[rd] = s2[63:48] @ s1[63:48] @ s2[47:32] @ s1[47:32]
 ----
 
-===== Mnemonic
-
-zip16hp _rd_, _rs1_, _rs2_
-
-===== Description
-
-The ZIP16HP instruction interleaves 16-bit chunks from the high 32-bit halves of
-`rs2` and `rs1` to form a 64-bit result.
 
 <<<
 ==== UNZIP16P (RV64)
+
+===== Mnemonic
+
+unzip16p _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -15715,6 +15719,10 @@ UNZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The UNZIP16P instruction de-interleaves 16-bit chunks from `rs2` and `rs1` and
+forms a 64-bit result.
 ===== Operation
 
 [source,pseudocode]
@@ -15725,17 +15733,13 @@ s2 = X[rs2]
 X[rd] = s2[47:32] @ s2[15:0] @ s1[47:32] @ s1[15:0]
 ----
 
-===== Mnemonic
-
-unzip16p _rd_, _rs1_, _rs2_
-
-===== Description
-
-The UNZIP16P instruction de-interleaves 16-bit chunks from `rs2` and `rs1` and
-forms a 64-bit result.
 
 <<<
 ==== UNZIP16HP (RV64)
+
+===== Mnemonic
+
+unzip16hp _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -15756,6 +15760,10 @@ UNZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+The UNZIP16HP instruction de-interleaves 16-bit chunks from the high 32-bit halves
+of `rs2` and `rs1` and forms a 64-bit result.
 ===== Operation
 
 [source,pseudocode]
@@ -15766,17 +15774,13 @@ s2 = X[rs2]
 X[rd] = s2[63:48] @ s2[31:16] @ s1[63:48] @ s1[31:16]
 ----
 
-===== Mnemonic
-
-unzip16hp _rd_, _rs1_, _rs2_
-
-===== Description
-
-The UNZIP16HP instruction de-interleaves 16-bit chunks from the high 32-bit halves
-of `rs2` and `rs1` and forms a 64-bit result.
 
 <<<
 ==== REV16 (RV64)
+
+===== Mnemonic
+
+rev16 _rd_, _rs1_
 
 ===== Encoding
 
@@ -15793,6 +15797,9 @@ REV16 is a scalar instruction encoded in the OP-IMM major opcode and is availabl
 ]}
 ....
 
+===== Description
+
+The REV16 instruction reverses the order of 16-bit chunks within the 64-bit value in `rs1`.
 ===== Operation
 
 [source,pseudocode]
@@ -15801,17 +15808,14 @@ s1 = X[rs1]
 X[rd] = s1[15:0] @ s1[31:16] @ s1[47:32] @ s1[63:48]
 ----
 
-===== Mnemonic
-
-rev16 _rd_, _rs1_
-
-===== Description
-
-The REV16 instruction reverses the order of 16-bit chunks within the 64-bit value in `rs1`.
 
 
 <<<
 ==== REV
+
+===== Mnemonic
+
+rev _rd_, _rs1_
 
 ===== Encoding
 
@@ -15844,6 +15848,11 @@ RV64:
 ]}
 ....
 
+===== Description
+
+REV reverses the bit order of the full XLEN-wide value in `rs1` and writes
+the result to `rd`. Bit 0 of the source becomes bit XLEN-1 of the result,
+bit 1 becomes bit XLEN-2, and so on.
 ===== Operation
 
 [source,pseudocode]
@@ -15857,20 +15866,15 @@ for i = 0 .. (XLEN - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-rev _rd_, _rs1_
-
-===== Description
-
-REV reverses the bit order of the full XLEN-wide value in `rs1` and writes
-the result to `rd`. Bit 0 of the source becomes bit XLEN-1 of the result,
-bit 1 becomes bit XLEN-2, and so on.
 
 <<<
 === Miscellaneous Scalar
 
 ==== ABS
+
+===== Mnemonic
+
+abs _rd_, _rs1_, _imm12_
 
 ===== Encoding
 
@@ -15887,6 +15891,9 @@ ABS is encoded in the OP-IMM major opcode.
 ]}
 ....
 
+===== Description
+
+ABS writes the absolute value of `X[rs1]` to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -15895,16 +15902,13 @@ s1 = X[rs1]
 X[rd] = (signed(s1) < 0) ? (0 - s1) : s1
 ----
 
-===== Mnemonic
-
-abs _rd_, _rs1_, _imm12_
-
-===== Description
-
-ABS writes the absolute value of `X[rs1]` to `rd`.
 
 <<<
 ==== ABSW (RV64)
+
+===== Mnemonic
+
+absw _rd_, _rs1_, _simm12_
 
 ===== Encoding
 
@@ -15921,6 +15925,10 @@ ABSW is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+ABSW writes the absolute value of the low 32 bits of `rs1` (treated as signed)
+to `rd`, sign-extended to XLEN.
 ===== Operation
 
 [source,pseudocode]
@@ -15929,17 +15937,13 @@ w = X[rs1][31:0]
 X[rd] = sign_extend(64, (signed(w) <_s 0) ? (0 - w) : w)
 ----
 
-===== Mnemonic
-
-absw _rd_, _rs1_, _simm12_
-
-===== Description
-
-ABSW writes the absolute value of the low 32 bits of `rs1` (treated as signed)
-to `rd`, sign-extended to XLEN.
 
 <<<
 ==== CLS
+
+===== Mnemonic
+
+cls _rd_, _rs1_, _imm12_
 
 ===== Encoding
 
@@ -15956,6 +15960,9 @@ CLS is encoded in the OP-IMM major opcode.
 ]}
 ....
 
+===== Description
+
+CLS returns the count `c` produced by the Sail reference algorithm.
 ===== Operation
 
 [source,pseudocode]
@@ -15972,16 +15979,13 @@ while (c < XLEN - 1) & (v >=_s lo_bound) & (v <=_s hi_bound) do
 X[rd] = to_bits(XLEN, c)
 ----
 
-===== Mnemonic
-
-cls _rd_, _rs1_, _imm12_
-
-===== Description
-
-CLS returns the count `c` produced by the Sail reference algorithm.
 
 <<<
 ==== CLSW (RV64)
+
+===== Mnemonic
+
+clsw _rd_, _rs1_, _imm12_
 
 ===== Encoding
 
@@ -15998,6 +16002,10 @@ CLSW is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 ]}
 ....
 
+===== Description
+
+CLSW applies the CLS definition to the low 32 bits of `rs1` and writes the count
+as an XLEN value.
 ===== Operation
 
 [source,pseudocode]
@@ -16010,17 +16018,13 @@ while (c < 31) & (w >=_s 0xC0000000) & (w <=_s 0x3FFFFFFF) do
 X[rd] = to_bits(XLEN, c)
 ----
 
-===== Mnemonic
-
-clsw _rd_, _rs1_, _imm12_
-
-===== Description
-
-CLSW applies the CLS definition to the low 32 bits of `rs1` and writes the count
-as an XLEN value.
 
 <<<
 ==== SLX
+
+===== Mnemonic
+
+slx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16040,6 +16044,10 @@ SLX is encoded in the OP-32 major opcode.
 ]}
 ....
 
+===== Description
+
+SLX shifts the 2*XLEN-bit concatenation `X[rd] @ X[rs1]` left by `shamt` and
+writes the upper XLEN bits to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -16048,17 +16056,13 @@ shamt = X[rs2][log2(XLEN)-1:0]
 X[rd] = ((X[rd] @ X[rs1]) << shamt)[(2*XLEN-1):XLEN]
 ----
 
-===== Mnemonic
-
-slx _rd_, _rs1_, _rs2_
-
-===== Description
-
-SLX shifts the 2*XLEN-bit concatenation `X[rd] @ X[rs1]` left by `shamt` and
-writes the upper XLEN bits to `rd`.
 
 <<<
 ==== SRX
+
+===== Mnemonic
+
+srx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16078,6 +16082,10 @@ SRX is encoded in the OP-32 major opcode.
 ]}
 ....
 
+===== Description
+
+SRX shifts the 2*XLEN-bit concatenation `X[rs1] @ X[rd]` right by `shamt` and
+writes the lower XLEN bits to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -16086,17 +16094,13 @@ shamt = X[rs2][log2(XLEN)-1:0]
 X[rd] = ((X[rs1] @ X[rd]) >> shamt)[(XLEN-1):0]
 ----
 
-===== Mnemonic
-
-srx _rd_, _rs1_, _rs2_
-
-===== Description
-
-SRX shifts the 2*XLEN-bit concatenation `X[rs1] @ X[rd]` right by `shamt` and
-writes the lower XLEN bits to `rd`.
 
 <<<
 ==== MVM
+
+===== Mnemonic
+
+mvm _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16116,6 +16120,9 @@ MVM is encoded in the OP-32 major opcode.
 ]}
 ....
 
+===== Description
+
+MVM merges `rs1` and the prior value of `rd` under control of the mask `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -16124,16 +16131,13 @@ m = X[rs2]
 X[rd] = (~m & X[rd]) | (m & X[rs1])
 ----
 
-===== Mnemonic
-
-mvm _rd_, _rs1_, _rs2_
-
-===== Description
-
-MVM merges `rs1` and the prior value of `rd` under control of the mask `rs2`.
 
 <<<
 ==== MVMN
+
+===== Mnemonic
+
+mvmn _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16153,6 +16157,9 @@ MVMN is encoded in the OP-32 major opcode.
 ]}
 ....
 
+===== Description
+
+MVMN is like MVM, but swaps the roles of `rs1` and the prior `rd` value.
 ===== Operation
 
 [source,pseudocode]
@@ -16161,16 +16168,13 @@ m = X[rs2]
 X[rd] = (~m & X[rs1]) | (m & X[rd])
 ----
 
-===== Mnemonic
-
-mvmn _rd_, _rs1_, _rs2_
-
-===== Description
-
-MVMN is like MVM, but swaps the roles of `rs1` and the prior `rd` value.
 
 <<<
 ==== MERGE
+
+===== Mnemonic
+
+merge _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16190,6 +16194,9 @@ MERGE is encoded in the OP-32 major opcode.
 ]}
 ....
 
+===== Description
+
+MERGE uses the prior value of `rd` as the mask to select between `rs1` and `rs2`.
 ===== Operation
 
 [source,pseudocode]
@@ -16198,13 +16205,6 @@ d0 = X[rd]
 X[rd] = (~d0 & X[rs1]) | (d0 & X[rs2])
 ----
 
-===== Mnemonic
-
-merge _rd_, _rs1_, _rs2_
-
-===== Description
-
-MERGE uses the prior value of `rd` as the mask to select between `rs1` and `rs2`.
 
 
 <<<
@@ -16212,6 +16212,10 @@ MERGE uses the prior value of `rd` as the mask to select between `rs1` and `rs2`
 
 
 ==== ADDD (RV32)
+
+===== Mnemonic
+
+addd _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -16234,6 +16238,14 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+ADDD (Add Doubleword) performs a 64-bit addition of two register-pair operands
+on RV32. The 64-bit source values are formed by concatenating the odd (high) and
+even (low) registers of each pair. The 64-bit sum wraps modulo 2^64 and is
+written back to the register pair designated by `rd_p`. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -16248,21 +16260,13 @@ X[rd_p * 2]     = d[31:0]
 X[rd_p * 2 + 1] = d[63:32]
 ----
 
-===== Mnemonic
-
-addd _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-ADDD (Add Doubleword) performs a 64-bit addition of two register-pair operands
-on RV32. The 64-bit source values are formed by concatenating the odd (high) and
-even (low) registers of each pair. The 64-bit sum wraps modulo 2^64 and is
-written back to the register pair designated by `rd_p`. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
 
 <<<
 ==== SUBD (RV32)
+
+===== Mnemonic
+
+subd _rd_p_, _rs1_p_, _rs2_p_
 
 ===== Encoding
 
@@ -16285,6 +16289,13 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+SUBD performs a 64-bit integer subtraction using register pairs on RV32.
+The source operands `rs1_p` and `rs2_p` each designate a register pair
+forming a 64-bit value (even register = low word, odd register = high word).
+The 64-bit difference is written to the register pair designated by `rd_p`.
+All pair operands must specify even register numbers. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -16299,22 +16310,15 @@ X[rd_p * 2]     = d[31:0]
 X[rd_p * 2 + 1] = d[63:32]
 ----
 
-===== Mnemonic
-
-subd _rd_p_, _rs1_p_, _rs2_p_
-
-===== Description
-
-SUBD performs a 64-bit integer subtraction using register pairs on RV32.
-The source operands `rs1_p` and `rs2_p` each designate a register pair
-forming a 64-bit value (even register = low word, odd register = high word).
-The 64-bit difference is written to the register pair designated by `rd_p`.
-All pair operands must specify even register numbers. Available only in RV32.
 
 <<<
 === Widening Add/Subtract
 
 ==== PWADD.B (RV32)
+
+===== Mnemonic
+
+pwadd.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16336,6 +16340,11 @@ register pair specified by `rd_p`.
 ]}
 ....
 
+===== Description
+
+PWADD.B sign-extends corresponding packed 8-bit elements of `rs1` and `rs2` to
+signed values, adds them, and produces four packed 16-bit results. The 64-bit
+result is written to the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -16353,18 +16362,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwadd.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWADD.B sign-extends corresponding packed 8-bit elements of `rs1` and `rs2` to
-signed values, adds them, and produces four packed 16-bit results. The 64-bit
-result is written to the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
 
 <<<
 ==== PWADDA.B (RV32)
+
+===== Mnemonic
+
+pwadda.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16385,6 +16389,11 @@ PWADDA.B is available only in RV32. It accumulates into the destination register
 ]}
 ....
 
+===== Description
+
+PWADDA.B performs the same packed byte-to-halfword signed additions as PWADD.B,
+then adds each 16-bit result into the corresponding 16-bit element of the
+destination register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -16405,18 +16414,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwadda.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWADDA.B performs the same packed byte-to-halfword signed additions as PWADD.B,
-then adds each 16-bit result into the corresponding 16-bit element of the
-destination register pair.
 
 <<<
 ==== PWADDU.B (RV32)
+
+===== Mnemonic
+
+pwaddu.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16438,6 +16442,11 @@ register pair specified by `rd_p`.
 ]}
 ....
 
+===== Description
+
+PWADDU.B zero-extends corresponding packed 8-bit elements of `rs1` and `rs2` to
+unsigned values, adds them, and produces four packed 16-bit results, written to
+the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -16455,18 +16464,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwaddu.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWADDU.B zero-extends corresponding packed 8-bit elements of `rs1` and `rs2` to
-unsigned values, adds them, and produces four packed 16-bit results, written to
-the destination register pair when `rd_p != 0`.
 
 <<<
 ==== PWADDAU.B (RV32)
+
+===== Mnemonic
+
+pwaddau.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16487,6 +16491,11 @@ PWADDAU.B is available only in RV32. It accumulates into the destination registe
 ]}
 ....
 
+===== Description
+
+PWADDAU.B performs the same packed byte-to-halfword unsigned additions as PWADDU.B,
+then adds each 16-bit result into the corresponding 16-bit element of the
+destination register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -16507,18 +16516,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwaddau.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWADDAU.B performs the same packed byte-to-halfword unsigned additions as PWADDU.B,
-then adds each 16-bit result into the corresponding 16-bit element of the
-destination register pair.
 
 <<<
 ==== PWSUB.B (RV32)
+
+===== Mnemonic
+
+pwsub.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16540,6 +16544,12 @@ register pair specified by `rd_p`.
 ]}
 ....
 
+===== Description
+
+PWSUB.B sign-extends corresponding packed 8-bit elements of `rs1` and `rs2`,
+subtracts them, and produces four packed 16-bit results. When `rd_p != 0`,
+the 64-bit result is written to the destination register pair
+`{X[2*rd_p+1], X[2*rd_p]}`.
 ===== Operation
 
 [source,pseudocode]
@@ -16557,19 +16567,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwsub.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSUB.B sign-extends corresponding packed 8-bit elements of `rs1` and `rs2`,
-subtracts them, and produces four packed 16-bit results. When `rd_p != 0`,
-the 64-bit result is written to the destination register pair
-`{X[2*rd_p+1], X[2*rd_p]}`.
 
 <<<
 ==== PWSUBA.B (RV32)
+
+===== Mnemonic
+
+pwsuba.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16591,6 +16595,11 @@ register pair.
 ]}
 ....
 
+===== Description
+
+PWSUBA.B performs the same packed byte-to-halfword signed subtraction as
+PWSUB.B, then adds each 16-bit result into the corresponding 16-bit element
+of the destination register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -16611,18 +16620,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwsuba.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSUBA.B performs the same packed byte-to-halfword signed subtraction as
-PWSUB.B, then adds each 16-bit result into the corresponding 16-bit element
-of the destination register pair.
 
 <<<
 ==== PWSUBU.B (RV32)
+
+===== Mnemonic
+
+pwsubu.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16644,6 +16648,11 @@ register pair specified by `rd_p`.
 ]}
 ....
 
+===== Description
+
+PWSUBU.B zero-extends corresponding packed 8-bit elements of `rs1` and `rs2`,
+subtracts them as unsigned values, and produces four packed 16-bit results,
+written to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -16661,18 +16670,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwsubu.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSUBU.B zero-extends corresponding packed 8-bit elements of `rs1` and `rs2`,
-subtracts them as unsigned values, and produces four packed 16-bit results,
-written to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== PWSUBAU.B (RV32)
+
+===== Mnemonic
+
+pwsubau.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16694,6 +16698,11 @@ register pair.
 ]}
 ....
 
+===== Description
+
+PWSUBAU.B performs the same packed byte-to-halfword unsigned subtraction as
+PWSUBU.B, then adds each 16-bit result into the corresponding 16-bit element
+of the destination register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -16714,18 +16723,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwsubau.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSUBAU.B performs the same packed byte-to-halfword unsigned subtraction as
-PWSUBU.B, then adds each 16-bit result into the corresponding 16-bit element
-of the destination register pair.
 
 <<<
 ==== PWADD.H (RV32)
+
+===== Mnemonic
+
+pwadd.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16747,6 +16751,10 @@ pair specified by `rd_p`.
 ]}
 ....
 
+===== Description
+
+PWADD.H sign-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
+and writes two 32-bit results to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -16761,17 +16769,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwadd.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWADD.H sign-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
-and writes two 32-bit results to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== PWADDA.H (RV32)
+
+===== Mnemonic
+
+pwadda.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16792,6 +16796,10 @@ PWADDA.H is available only in RV32 and accumulates into the destination register
 ]}
 ....
 
+===== Description
+
+PWADDA.H performs PWADD.H and adds each 32-bit result into the corresponding
+32-bit element of the destination register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -16810,17 +16818,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Mnemonic
-
-pwadda.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWADDA.H performs PWADD.H and adds each 32-bit result into the corresponding
-32-bit element of the destination register pair.
 
 <<<
 ==== PWADDU.H (RV32)
+
+===== Mnemonic
+
+pwaddu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16841,6 +16845,10 @@ PWADDU.H is available only in RV32.
 ]}
 ....
 
+===== Description
+
+PWADDU.H zero-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
+and writes two 32-bit results to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -16855,17 +16863,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwaddu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWADDU.H zero-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
-and writes two 32-bit results to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== PWADDAU.H (RV32)
+
+===== Mnemonic
+
+pwaddau.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16886,6 +16890,10 @@ PWADDAU.H is available only in RV32 and accumulates into the destination registe
 ]}
 ....
 
+===== Description
+
+PWADDAU.H performs PWADDU.H and accumulates the two 32-bit results into the
+destination register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -16904,17 +16912,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Mnemonic
-
-pwaddau.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWADDAU.H performs PWADDU.H and accumulates the two 32-bit results into the
-destination register pair.
 
 <<<
 ==== PWSUB.H (RV32)
+
+===== Mnemonic
+
+pwsub.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16935,6 +16939,10 @@ PWSUB.H is available only in RV32.
 ]}
 ....
 
+===== Description
+
+PWSUB.H sign-extends each 16-bit halfword element, subtracts element-wise, and
+writes two 32-bit results to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -16949,17 +16957,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwsub.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSUB.H sign-extends each 16-bit halfword element, subtracts element-wise, and
-writes two 32-bit results to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== PWSUBA.H (RV32)
+
+===== Mnemonic
+
+pwsuba.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -16980,6 +16984,10 @@ PWSUBA.H is available only in RV32 and accumulates into the destination register
 ]}
 ....
 
+===== Description
+
+PWSUBA.H performs PWSUB.H and accumulates the two 32-bit results into the
+destination register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -16998,17 +17006,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Mnemonic
-
-pwsuba.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSUBA.H performs PWSUB.H and accumulates the two 32-bit results into the
-destination register pair.
 
 <<<
 ==== PWSUBU.H (RV32)
+
+===== Mnemonic
+
+pwsubu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17029,6 +17033,11 @@ PWSUBU.H is available only in RV32.
 ]}
 ....
 
+===== Description
+
+PWSUBU.H zero-extends each 16-bit halfword element, subtracts element-wise as
+unsigned values, and writes two 32-bit results to the destination register pair
+when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17043,18 +17052,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwsubu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSUBU.H zero-extends each 16-bit halfword element, subtracts element-wise as
-unsigned values, and writes two 32-bit results to the destination register pair
-when `rd_p != 0`.
 
 <<<
 ==== PWSUBAU.H (RV32)
+
+===== Mnemonic
+
+pwsubau.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17075,6 +17079,10 @@ PWSUBAU.H is available only in RV32 and accumulates into the destination registe
 ]}
 ....
 
+===== Description
+
+PWSUBAU.H performs PWSUBU.H and accumulates the two 32-bit results into the
+destination register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -17093,17 +17101,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Mnemonic
-
-pwsubau.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSUBAU.H performs PWSUBU.H and accumulates the two 32-bit results into the
-destination register pair.
 
 <<<
 ==== WADD (RV32)
+
+===== Mnemonic
+
+wadd _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17124,6 +17128,10 @@ WADD is available only in RV32 and writes a 64-bit result to register pair `rd_p
 ]}
 ....
 
+===== Description
+
+WADD adds `rs1` and `rs2` as signed XLEN values and writes the 64-bit sum to the
+destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17135,17 +17143,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wadd _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WADD adds `rs1` and `rs2` as signed XLEN values and writes the 64-bit sum to the
-destination register pair when `rd_p != 0`.
 
 <<<
 ==== WADDA (RV32)
+
+===== Mnemonic
+
+wadda _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17166,6 +17170,10 @@ WADDA is available only in RV32 and accumulates into the destination register pa
 ]}
 ....
 
+===== Description
+
+WADDA performs WADD and accumulates the 64-bit result into the destination
+register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -17178,17 +17186,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-wadda _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WADDA performs WADD and accumulates the 64-bit result into the destination
-register pair.
 
 <<<
 ==== WADDU (RV32)
+
+===== Mnemonic
+
+waddu _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17209,6 +17213,10 @@ WADDU is available only in RV32.
 ]}
 ....
 
+===== Description
+
+WADDU adds `rs1` and `rs2` as unsigned XLEN values and writes the 64-bit sum to
+the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17220,17 +17228,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-waddu _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WADDU adds `rs1` and `rs2` as unsigned XLEN values and writes the 64-bit sum to
-the destination register pair when `rd_p != 0`.
 
 <<<
 ==== WADDAU (RV32)
+
+===== Mnemonic
+
+waddau _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17251,6 +17255,10 @@ WADDAU is available only in RV32 and accumulates into the destination register p
 ]}
 ....
 
+===== Description
+
+WADDAU performs WADDU and accumulates the 64-bit result into the destination
+register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -17263,17 +17271,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-waddau _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WADDAU performs WADDU and accumulates the 64-bit result into the destination
-register pair.
 
 <<<
 ==== WSUB (RV32)
+
+===== Mnemonic
+
+wsub _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17294,6 +17298,10 @@ WSUB is available only in RV32.
 ]}
 ....
 
+===== Description
+
+WSUB subtracts `rs2` from `rs1` as signed XLEN values and writes the 64-bit
+difference to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17305,17 +17313,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wsub _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WSUB subtracts `rs2` from `rs1` as signed XLEN values and writes the 64-bit
-difference to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== WSUBA (RV32)
+
+===== Mnemonic
+
+wsuba _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17336,6 +17340,10 @@ WSUBA is available only in RV32 and accumulates into the destination register pa
 ]}
 ....
 
+===== Description
+
+WSUBA performs WSUB and accumulates the 64-bit result into the destination
+register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -17348,17 +17356,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-wsuba _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WSUBA performs WSUB and accumulates the 64-bit result into the destination
-register pair.
 
 <<<
 ==== WSUBU (RV32)
+
+===== Mnemonic
+
+wsubu _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17379,6 +17383,10 @@ WSUBU is available only in RV32.
 ]}
 ....
 
+===== Description
+
+WSUBU subtracts `rs2` from `rs1` as unsigned XLEN values and writes the 64-bit
+difference to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17390,17 +17398,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wsubu _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WSUBU subtracts `rs2` from `rs1` as unsigned XLEN values and writes the 64-bit
-difference to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== WSUBAU (RV32)
+
+===== Mnemonic
+
+wsubau _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17421,6 +17425,10 @@ WSUBAU is available only in RV32 and accumulates into the destination register p
 ]}
 ....
 
+===== Description
+
+WSUBAU performs WSUBU and accumulates the 64-bit result into the destination
+register pair.
 ===== Operation
 
 [source,pseudocode]
@@ -17433,20 +17441,16 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-wsubau _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WSUBAU performs WSUBU and accumulates the 64-bit result into the destination
-register pair.
 
 
 <<<
 === Widening Shift
 
 ==== PWSLLI.B (RV32)
+
+===== Mnemonic
+
+pwslli.b _rd_p_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -17469,6 +17473,10 @@ field. The destination is a register pair `rd_p`.
 ]}
 ....
 
+===== Description
+
+PWSLLI.B widens each 8-bit element of `rs1` to 16 bits by zero-extension, then
+shifts left by an immediate amount, producing four 16-bit results.
 ===== Operation
 
 [source,pseudocode]
@@ -17485,17 +17493,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwslli.b _rd_p_, _rs1_, _uimm4_
-
-===== Description
-
-PWSLLI.B widens each 8-bit element of `rs1` to 16 bits by zero-extension, then
-shifts left by an immediate amount, producing four 16-bit results.
 
 <<<
 ==== PWSLL.BS (RV32)
+
+===== Mnemonic
+
+pwsll.bs _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17517,6 +17521,10 @@ PWSLL.BS is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
+===== Description
+
+PWSLL.BS widens each 8-bit element of `rs1` to 16 bits by zero-extension, then
+shifts left by the amount in `rs2` (low 5 bits), producing four 16-bit results.
 ===== Operation
 
 [source,pseudocode]
@@ -17533,17 +17541,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwsll.bs _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSLL.BS widens each 8-bit element of `rs1` to 16 bits by zero-extension, then
-shifts left by the amount in `rs2` (low 5 bits), producing four 16-bit results.
 
 <<<
 ==== PWSLAI.B (RV32)
+
+===== Mnemonic
+
+pwslai.b _rd_p_, _rs1_, _uimm4_
 
 ===== Encoding
 
@@ -17565,6 +17569,10 @@ PWSLAI.B is available only in RV32. The shift amount is encoded in `uimm4`.
 ]}
 ....
 
+===== Description
+
+PWSLAI.B widens each 8-bit element of `rs1` to 16 bits by sign-extension, then
+shifts left by an immediate amount, producing four 16-bit results.
 ===== Operation
 
 [source,pseudocode]
@@ -17581,17 +17589,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwslai.b _rd_p_, _rs1_, _uimm4_
-
-===== Description
-
-PWSLAI.B widens each 8-bit element of `rs1` to 16 bits by sign-extension, then
-shifts left by an immediate amount, producing four 16-bit results.
 
 <<<
 ==== PWSLA.BS (RV32)
+
+===== Mnemonic
+
+pwsla.bs _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17613,6 +17617,10 @@ PWSLA.BS is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
+===== Description
+
+PWSLA.BS widens each 8-bit element of `rs1` to 16 bits by sign-extension, then
+shifts left by the amount in `rs2` (low 5 bits), producing four 16-bit results.
 ===== Operation
 
 [source,pseudocode]
@@ -17629,17 +17637,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwsla.bs _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSLA.BS widens each 8-bit element of `rs1` to 16 bits by sign-extension, then
-shifts left by the amount in `rs2` (low 5 bits), producing four 16-bit results.
 
 <<<
 ==== PWSLLI.H (RV32)
+
+===== Mnemonic
+
+pwslli.h _rd_p_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -17661,6 +17665,10 @@ PWSLLI.H is available only in RV32. The shift amount is encoded in `uimm5`.
 ]}
 ....
 
+===== Description
+
+PWSLLI.H widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
+shifts left by an immediate amount, producing two 32-bit results.
 ===== Operation
 
 [source,pseudocode]
@@ -17676,17 +17684,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwslli.h _rd_p_, _rs1_, _uimm5_
-
-===== Description
-
-PWSLLI.H widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
-shifts left by an immediate amount, producing two 32-bit results.
 
 <<<
 ==== PWSLL.HS (RV32)
+
+===== Mnemonic
+
+pwsll.hs _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17708,6 +17712,10 @@ PWSLL.HS is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
+===== Description
+
+PWSLL.HS widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
+shifts left by the amount in `rs2` (low 5 bits).
 ===== Operation
 
 [source,pseudocode]
@@ -17723,17 +17731,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwsll.hs _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSLL.HS widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
-shifts left by the amount in `rs2` (low 5 bits).
 
 <<<
 ==== PWSLAI.H (RV32)
+
+===== Mnemonic
+
+pwslai.h _rd_p_, _rs1_, _uimm5_
 
 ===== Encoding
 
@@ -17755,6 +17759,10 @@ PWSLAI.H is available only in RV32. The shift amount is encoded in `uimm5`.
 ]}
 ....
 
+===== Description
+
+PWSLAI.H widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
+shifts left by an immediate amount.
 ===== Operation
 
 [source,pseudocode]
@@ -17770,17 +17778,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwslai.h _rd_p_, _rs1_, _uimm5_
-
-===== Description
-
-PWSLAI.H widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
-shifts left by an immediate amount.
 
 <<<
 ==== PWSLA.HS (RV32)
+
+===== Mnemonic
+
+pwsla.hs _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17802,6 +17806,10 @@ PWSLA.HS is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
+===== Description
+
+PWSLA.HS widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
+shifts left by the amount in `rs2` (low 5 bits).
 ===== Operation
 
 [source,pseudocode]
@@ -17817,17 +17825,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwsla.hs _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWSLA.HS widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
-shifts left by the amount in `rs2` (low 5 bits).
 
 <<<
 ==== WSLL (RV32)
+
+===== Mnemonic
+
+wsll _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17849,6 +17853,10 @@ WSLL is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
+===== Description
+
+WSLL zero-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
+and writes the 64-bit result to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17861,17 +17869,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wsll _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WSLL zero-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
-and writes the 64-bit result to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== WSLLI (RV32)
+
+===== Mnemonic
+
+wslli _rd_p_, _rs1_, _uimm6_
 
 ===== Encoding
 
@@ -17893,6 +17897,10 @@ WSLLI is available only in RV32. The shift amount is encoded in `uimm6`.
 ]}
 ....
 
+===== Description
+
+WSLLI zero-extends `rs1` to 64 bits, shifts left by an immediate amount, and
+writes the 64-bit result to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17905,17 +17913,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wslli _rd_p_, _rs1_, _uimm6_
-
-===== Description
-
-WSLLI zero-extends `rs1` to 64 bits, shifts left by an immediate amount, and
-writes the 64-bit result to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== WSLA (RV32)
+
+===== Mnemonic
+
+wsla _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -17937,6 +17941,10 @@ WSLA is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
+===== Description
+
+WSLA sign-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
+and writes the 64-bit result to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17949,17 +17957,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wsla _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WSLA sign-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
-and writes the 64-bit result to the destination register pair when `rd_p != 0`.
 
 <<<
 ==== WSLAI (RV32)
+
+===== Mnemonic
+
+wslai _rd_p_, _rs1_, _uimm6_
 
 ===== Encoding
 
@@ -17981,6 +17985,10 @@ WSLAI is available only in RV32. The shift amount is encoded in `uimm6`.
 ]}
 ....
 
+===== Description
+
+WSLAI sign-extends `rs1` to 64 bits, shifts left by an immediate amount, and
+writes the 64-bit result to the destination register pair when `rd_p != 0`.
 ===== Operation
 
 [source,pseudocode]
@@ -17993,20 +18001,16 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wslai _rd_p_, _rs1_, _uimm6_
-
-===== Description
-
-WSLAI sign-extends `rs1` to 64 bits, shifts left by an immediate amount, and
-writes the 64-bit result to the destination register pair when `rd_p != 0`.
 
 
 <<<
 === Widening Zip
 
 ==== WZIP8P (RV32)
+
+===== Mnemonic
+
+wzip8p _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -18030,6 +18034,12 @@ It is encoded in the RV32 register-pair OP-IMM-32 format with `f=111` and `w=10`
 ]}
 ....
 
+===== Description
+
+WZIP8P interleaves the low four bytes of `rs1` and `rs2` into a 64-bit result,
+arranged as two 32-bit halves. The lower destination register receives the
+interleaving of bytes [15:0], and the upper destination register receives the
+interleaving of bytes [31:16].
 ===== Operation
 
 [source,pseudocode]
@@ -18045,19 +18055,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = hi
 ----
 
-===== Mnemonic
-
-wzip8p _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WZIP8P interleaves the low four bytes of `rs1` and `rs2` into a 64-bit result,
-arranged as two 32-bit halves. The lower destination register receives the
-interleaving of bytes [15:0], and the upper destination register receives the
-interleaving of bytes [31:16].
 
 <<<
 ==== WZIP16P (RV32)
+
+===== Mnemonic
+
+wzip16p _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -18081,6 +18085,11 @@ It is encoded in the RV32 register-pair OP-IMM-32 format with `f=111` and `w=11`
 ]}
 ....
 
+===== Description
+
+WZIP16P interleaves 16-bit halfwords from `rs1` and `rs2` into a 64-bit result.
+The lower destination register receives `{rs2[15:0], rs1[15:0]}`, and the upper
+destination register receives `{rs2[31:16], rs1[31:16]}`.
 ===== Operation
 
 [source,pseudocode]
@@ -18096,21 +18105,16 @@ if (rd_p != 0):
     X[2*rd_p+1] = hi
 ----
 
-===== Mnemonic
-
-wzip16p _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WZIP16P interleaves 16-bit halfwords from `rs1` and `rs2` into a 64-bit result.
-The lower destination register receives `{rs2[15:0], rs1[15:0]}`, and the upper
-destination register receives `{rs2[31:16], rs1[31:16]}`.
 
 
 <<<
 === Reduction Sum (double-wide)
 
 ==== PREDSUM.DBS (RV32)
+
+===== Mnemonic
+
+predsum.dbs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18136,6 +18140,11 @@ set to 1, and `rs1_p` selecting the source register pair.
 ]}
 ....
 
+===== Description
+
+PREDSUM.DBS adds the eight signed 8-bit elements contained in the 64-bit source
+register pair `rs1_p` to the signed scalar value in `rs2`, and writes the low
+32 bits of the resulting sum to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18152,18 +18161,13 @@ for i = 0 .. 7:
 X[rd] = to_bits(32, sum)
 ----
 
-===== Mnemonic
-
-predsum.dbs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PREDSUM.DBS adds the eight signed 8-bit elements contained in the 64-bit source
-register pair `rs1_p` to the signed scalar value in `rs2`, and writes the low
-32 bits of the resulting sum to `rd`.
 
 <<<
 ==== PREDSUMU.DBS (RV32)
+
+===== Mnemonic
+
+predsumu.dbs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18186,6 +18190,11 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
 ]}
 ....
 
+===== Description
+
+PREDSUMU.DBS adds the eight unsigned 8-bit elements contained in the 64-bit
+source register pair `rs1_p` to the unsigned scalar value in `rs2`, and writes
+the low 32 bits of the resulting sum to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18202,18 +18211,13 @@ for i = 0 .. 7:
 X[rd] = to_bits(32, sum)
 ----
 
-===== Mnemonic
-
-predsumu.dbs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PREDSUMU.DBS adds the eight unsigned 8-bit elements contained in the 64-bit
-source register pair `rs1_p` to the unsigned scalar value in `rs2`, and writes
-the low 32 bits of the resulting sum to `rd`.
 
 <<<
 ==== PREDSUM.DHS (RV32)
+
+===== Mnemonic
+
+predsum.dhs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18236,6 +18240,11 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
 ]}
 ....
 
+===== Description
+
+PREDSUM.DHS adds the four signed 16-bit elements contained in the 64-bit source
+register pair `rs1_p` to the signed scalar value in `rs2`, and writes the low
+32 bits of the resulting sum to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18252,18 +18261,13 @@ for i = 0 .. 3:
 X[rd] = to_bits(32, sum)
 ----
 
-===== Mnemonic
-
-predsum.dhs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PREDSUM.DHS adds the four signed 16-bit elements contained in the 64-bit source
-register pair `rs1_p` to the signed scalar value in `rs2`, and writes the low
-32 bits of the resulting sum to `rd`.
 
 <<<
 ==== PREDSUMU.DHS (RV32)
+
+===== Mnemonic
+
+predsumu.dhs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18286,6 +18290,11 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
 ]}
 ....
 
+===== Description
+
+PREDSUMU.DHS adds the four unsigned 16-bit elements contained in the 64-bit
+source register pair `rs1_p` to the unsigned scalar value in `rs2`, and writes
+the low 32 bits of the resulting sum to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18302,21 +18311,16 @@ for i = 0 .. 3:
 X[rd] = to_bits(32, sum)
 ----
 
-===== Mnemonic
-
-predsumu.dhs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PREDSUMU.DHS adds the four unsigned 16-bit elements contained in the 64-bit
-source register pair `rs1_p` to the unsigned scalar value in `rs2`, and writes
-the low 32 bits of the resulting sum to `rd`.
 
 
 <<<
 === Narrowing Shift
 
 ==== PNSRLI.B (RV32)
+
+===== Mnemonic
+
+pnsrli.b _rd_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -18341,6 +18345,11 @@ from the register pair selected by `rs1_p` and produces a packed byte result in
 
 `uimm4` provides the 4-bit shift amount.
 
+===== Description
+
+PNSRLI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
+a logical right shift by an immediate amount, and packs the low byte of each
+shifted lane into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18355,18 +18364,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrli.b _rd_, _rs1_p_, _uimm4_
-
-===== Description
-
-PNSRLI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
-a logical right shift by an immediate amount, and packs the low byte of each
-shifted lane into `rd`.
 
 <<<
 ==== PNSRL.BS (RV32)
+
+===== Mnemonic
+
+pnsrl.bs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18388,6 +18392,11 @@ from `rs1_p` and uses `rs2[4:0]` as the shift amount.
 ]}
 ....
 
+===== Description
+
+PNSRL.BS performs a per-lane logical right shift of four 16-bit lanes taken from
+a 64-bit register-pair source, using a shift amount from `rs2`. The low byte of
+each shifted lane is packed into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18402,18 +18411,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrl.bs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNSRL.BS performs a per-lane logical right shift of four 16-bit lanes taken from
-a 64-bit register-pair source, using a shift amount from `rs2`. The low byte of
-each shifted lane is packed into `rd`.
 
 <<<
 ==== PNSRAI.B (RV32)
+
+===== Mnemonic
+
+pnsrai.b _rd_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -18438,6 +18442,11 @@ from the register pair selected by `rs1_p` and produces a packed byte result in
 
 `uimm4` is the shift amount.
 
+===== Description
+
+PNSRAI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
+an arithmetic right shift by an immediate amount, and packs the low byte of each
+shifted lane into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18452,18 +18461,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrai.b _rd_, _rs1_p_, _uimm4_
-
-===== Description
-
-PNSRAI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
-an arithmetic right shift by an immediate amount, and packs the low byte of each
-shifted lane into `rd`.
 
 <<<
 ==== PNSRA.BS (RV32)
+
+===== Mnemonic
+
+pnsra.bs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18485,6 +18489,11 @@ from `rs1_p` and uses `rs2[4:0]` as the shift amount.
 ]}
 ....
 
+===== Description
+
+PNSRA.BS performs a per-lane arithmetic right shift of four 16-bit lanes taken
+from a 64-bit register-pair source, using a shift amount from `rs2`. The low
+byte of each shifted lane is packed into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18499,18 +18508,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsra.bs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNSRA.BS performs a per-lane arithmetic right shift of four 16-bit lanes taken
-from a 64-bit register-pair source, using a shift amount from `rs2`. The low
-byte of each shifted lane is packed into `rd`.
 
 <<<
 ==== PNSRARI.B (RV32)
+
+===== Mnemonic
+
+pnsrari.b _rd_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -18534,6 +18538,11 @@ from `rs1_p` and performs a rounded arithmetic right shift by an immediate amoun
 
 `uimm4` is the shift amount.
 
+===== Description
+
+PNSRARI.B performs a per-lane rounded arithmetic right shift of four 16-bit lanes
+from a 64-bit register-pair source using an immediate shift amount, and packs
+the resulting bytes into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18550,18 +18559,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrari.b _rd_, _rs1_p_, _uimm4_
-
-===== Description
-
-PNSRARI.B performs a per-lane rounded arithmetic right shift of four 16-bit lanes
-from a 64-bit register-pair source using an immediate shift amount, and packs
-the resulting bytes into `rd`.
 
 <<<
 ==== PNSRAR.BS (RV32)
+
+===== Mnemonic
+
+pnsrar.bs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18583,6 +18587,11 @@ from `rs1_p` and uses `rs2[4:0]` as the shift amount.
 ]}
 ....
 
+===== Description
+
+PNSRAR.BS performs a per-lane rounded arithmetic right shift of four 16-bit lanes
+from a 64-bit register-pair source using a shift amount from `rs2`, and packs
+the resulting bytes into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18598,18 +18607,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrar.bs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNSRAR.BS performs a per-lane rounded arithmetic right shift of four 16-bit lanes
-from a 64-bit register-pair source using a shift amount from `rs2`, and packs
-the resulting bytes into `rd`.
 
 <<<
 ==== PNSRLI.H (RV32)
+
+===== Mnemonic
+
+pnsrli.h _rd_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -18634,6 +18638,11 @@ the low 16 bits of each shifted word into `rd`.
 
 `uimm5` provides the 5-bit shift amount.
 
+===== Description
+
+PNSRLI.H performs a logical right shift of each 32-bit word lane in a 64-bit
+register-pair source by an immediate amount, then packs the low 16 bits of each
+shifted word into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18647,18 +18656,13 @@ d[31:16] = (s1[63:32] >> shamt)[15:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrli.h _rd_, _rs1_p_, _uimm5_
-
-===== Description
-
-PNSRLI.H performs a logical right shift of each 32-bit word lane in a 64-bit
-register-pair source by an immediate amount, then packs the low 16 bits of each
-shifted word into `rd`.
 
 <<<
 ==== PNSRL.HS (RV32)
+
+===== Mnemonic
+
+pnsrl.hs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18681,6 +18685,11 @@ from `rs1_p`, uses `rs2[4:0]` as the shift amount, and packs 16-bit results into
 ]}
 ....
 
+===== Description
+
+PNSRL.HS performs a logical right shift of each 32-bit word lane in a 64-bit
+register-pair source by a shift amount from `rs2`, then packs the low 16 bits of
+each shifted word into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18694,18 +18703,13 @@ d[31:16] = (s1[63:32] >> shamt)[15:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrl.hs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNSRL.HS performs a logical right shift of each 32-bit word lane in a 64-bit
-register-pair source by a shift amount from `rs2`, then packs the low 16 bits of
-each shifted word into `rd`.
 
 <<<
 ==== PNSRAI.H (RV32)
+
+===== Mnemonic
+
+pnsrai.h _rd_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -18730,6 +18734,11 @@ from `rs1_p`, performs an arithmetic right shift by an immediate amount on each
 
 `uimm5` provides a 5-bit shift amount.
 
+===== Description
+
+PNSRAI.H performs an arithmetic right shift of each 32-bit word lane in a 64-bit
+register-pair source by an immediate amount, then packs the low 16 bits of each
+shifted word into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18743,18 +18752,13 @@ d[31:16] = (sext_48(s1[63:32]) >> shamt)[15:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrai.h _rd_, _rs1_p_, _uimm5_
-
-===== Description
-
-PNSRAI.H performs an arithmetic right shift of each 32-bit word lane in a 64-bit
-register-pair source by an immediate amount, then packs the low 16 bits of each
-shifted word into `rd`.
 
 <<<
 ==== PNSRA.HS (RV32)
+
+===== Mnemonic
+
+pnsra.hs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18777,6 +18781,11 @@ right shifts, and packs 16-bit results into `rd`.
 ]}
 ....
 
+===== Description
+
+PNSRA.HS performs an arithmetic right shift of each 32-bit word lane in a 64-bit
+register-pair source by a shift amount from `rs2`, then packs the low 16 bits of
+each shifted word into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18790,18 +18799,13 @@ d[31:16] = (sext_48(s1[63:32]) >> shamt)[15:0]
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsra.hs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNSRA.HS performs an arithmetic right shift of each 32-bit word lane in a 64-bit
-register-pair source by a shift amount from `rs2`, then packs the low 16 bits of
-each shifted word into `rd`.
 
 <<<
 ==== PNSRARI.H (RV32)
+
+===== Mnemonic
+
+pnsrari.h _rd_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -18824,6 +18828,11 @@ into `rd`.
 ]}
 ....
 
+===== Description
+
+PNSRARI.H performs a per-word *rounded* arithmetic right shift of the 64-bit
+register-pair source by an immediate amount. The low 16 bits of each rounded
+shifted word are packed into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18839,18 +18848,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrari.h _rd_, _rs1_p_, _uimm5_
-
-===== Description
-
-PNSRARI.H performs a per-word *rounded* arithmetic right shift of the 64-bit
-register-pair source by an immediate amount. The low 16 bits of each rounded
-shifted word are packed into `rd`.
 
 <<<
 ==== PNSRAR.HS (RV32)
+
+===== Mnemonic
+
+pnsrar.hs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18872,6 +18876,11 @@ PNSRAR.HS is encoded using the OP-IMM-32 major opcode. It performs a per-word
 ]}
 ....
 
+===== Description
+
+PNSRAR.HS performs a per-word *rounded* arithmetic right shift of a 64-bit
+register-pair source using a shift amount from `rs2`, and packs 16-bit results
+into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -18887,18 +18896,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnsrar.hs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNSRAR.HS performs a per-word *rounded* arithmetic right shift of a 64-bit
-register-pair source using a shift amount from `rs2`, and packs 16-bit results
-into `rd`.
 
 <<<
 ==== NSRLI (RV32)
+
+===== Mnemonic
+
+nsrli _rd_, _rs1_p_, _uimm6_
 
 ===== Encoding
 
@@ -18923,6 +18927,10 @@ writes the low 32 bits to `rd`.
 
 For NSRLI, `uimm6` is the shift amount.
 
+===== Description
+
+NSRLI performs a 64-bit logical right shift of the register-pair source by an
+immediate amount and returns the low 32 bits.
 ===== Operation
 
 [source,pseudocode]
@@ -18932,17 +18940,13 @@ shamt = uimm6[5:0]
 X[rd] = (s1 >> shamt)[31:0]
 ----
 
-===== Mnemonic
-
-nsrli _rd_, _rs1_p_, _uimm6_
-
-===== Description
-
-NSRLI performs a 64-bit logical right shift of the register-pair source by an
-immediate amount and returns the low 32 bits.
 
 <<<
 ==== NSRL (RV32)
+
+===== Mnemonic
+
+nsrl _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -18964,6 +18968,10 @@ amount.
 ]}
 ....
 
+===== Description
+
+NSRL performs a 64-bit logical right shift of the register-pair source by a shift
+amount from `rs2` and returns the low 32 bits.
 ===== Operation
 
 [source,pseudocode]
@@ -18973,17 +18981,13 @@ shamt = X[rs2][5:0]
 X[rd] = (s1 >> shamt)[31:0]
 ----
 
-===== Mnemonic
-
-nsrl _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-NSRL performs a 64-bit logical right shift of the register-pair source by a shift
-amount from `rs2` and returns the low 32 bits.
 
 <<<
 ==== NSRAI (RV32)
+
+===== Mnemonic
+
+nsrai _rd_, _rs1_p_, _uimm6_
 
 ===== Encoding
 
@@ -19006,6 +19010,10 @@ the low 32 bits to `rd`.
 ]}
 ....
 
+===== Description
+
+NSRAI performs a 64-bit arithmetic right shift of the register-pair source by an
+immediate amount and returns the low 32 bits.
 ===== Operation
 
 [source,pseudocode]
@@ -19015,17 +19023,13 @@ shamt = uimm6[5:0]
 X[rd] = (sext_96(s1) >> shamt)[31:0]
 ----
 
-===== Mnemonic
-
-nsrai _rd_, _rs1_p_, _uimm6_
-
-===== Description
-
-NSRAI performs a 64-bit arithmetic right shift of the register-pair source by an
-immediate amount and returns the low 32 bits.
 
 <<<
 ==== NSRA (RV32)
+
+===== Mnemonic
+
+nsra _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19047,6 +19051,10 @@ amount.
 ]}
 ....
 
+===== Description
+
+NSRA performs a 64-bit arithmetic right shift of the register-pair source by a
+shift amount from `rs2` and returns the low 32 bits.
 ===== Operation
 
 [source,pseudocode]
@@ -19056,17 +19064,13 @@ shamt = X[rs2][5:0]
 X[rd] = (sext_96(s1) >> shamt)[31:0]
 ----
 
-===== Mnemonic
-
-nsra _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-NSRA performs a 64-bit arithmetic right shift of the register-pair source by a
-shift amount from `rs2` and returns the low 32 bits.
 
 <<<
 ==== NSRARI (RV32)
+
+===== Mnemonic
+
+nsrari _rd_, _rs1_p_, _uimm6_
 
 ===== Encoding
 
@@ -19088,6 +19092,10 @@ arithmetic right shift by an immediate amount on the 64-bit register-pair source
 ]}
 ....
 
+===== Description
+
+NSRARI performs a 64-bit *rounded* arithmetic right shift of the register-pair
+source by an immediate amount and returns the rounded low 32-bit result.
 ===== Operation
 
 [source,pseudocode]
@@ -19099,17 +19107,13 @@ shx = ((sext_96(s1) @ 0b0) >> shamt)[32:0]
 X[rd] = (shx + 1)[32:1]
 ----
 
-===== Mnemonic
-
-nsrari _rd_, _rs1_p_, _uimm6_
-
-===== Description
-
-NSRARI performs a 64-bit *rounded* arithmetic right shift of the register-pair
-source by an immediate amount and returns the rounded low 32-bit result.
 
 <<<
 ==== NSRAR (RV32)
+
+===== Mnemonic
+
+nsrar _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19131,6 +19135,10 @@ amount for a *rounded* arithmetic right shift.
 ]}
 ....
 
+===== Description
+
+NSRAR performs a 64-bit *rounded* arithmetic right shift of the register-pair
+source by a shift amount from `rs2` and returns the rounded low 32-bit result.
 ===== Operation
 
 [source,pseudocode]
@@ -19142,20 +19150,16 @@ shx = ((sext_96(s1) @ 0b0) >> shamt)[32:0]
 X[rd] = (shx + 1)[32:1]
 ----
 
-===== Mnemonic
-
-nsrar _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-NSRAR performs a 64-bit *rounded* arithmetic right shift of the register-pair
-source by a shift amount from `rs2` and returns the rounded low 32-bit result.
 
 
 <<<
 === Narrowing Clip
 
 ==== PNCLIPI.B (RV32)
+
+===== Mnemonic
+
+pnclipi.b _rd_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -19180,6 +19184,14 @@ writes packed clipped bytes to `rd`.
 
 `uimm4` provides the 4-bit shift amount.
 
+===== Description
+
+PNCLIPI.B performs a per-lane arithmetic right shift of four 16-bit lanes from a
+64-bit register-pair source using an immediate shift amount. Each shifted value
+is then clipped to the signed 8-bit range [-128, 127] and packed into `rd`.
+
+When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
+
 ===== Operation
 
 [source,pseudocode]
@@ -19203,18 +19215,6 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipi.b _rd_, _rs1_p_, _uimm4_
-
-===== Description
-
-PNCLIPI.B performs a per-lane arithmetic right shift of four 16-bit lanes from a
-64-bit register-pair source using an immediate shift amount. Each shifted value
-is then clipped to the signed 8-bit range [-128, 127] and packed into `rd`.
-
-When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
-
 ===== Notes
 
 * The source is taken from the register pair `{X[2*rs1_p+1], X[2*rs1_p]}`; if
@@ -19223,6 +19223,10 @@ When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
 <<<
 ==== PNCLIP.BS (RV32)
+
+===== Mnemonic
+
+pnclip.bs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19244,6 +19248,14 @@ and packed byte narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PNCLIP.BS performs a packed narrowing signed clip from 16-bit halfword elements
+to 8-bit byte elements with a scalar shift amount. The 64-bit source is read
+from the register pair designated by `rs1_p`. Each 16-bit element is
+arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
+signed 8-bit range [-128, 127]. Four byte results are packed into `rd`. If any
+element saturates, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -19265,21 +19277,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclip.bs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNCLIP.BS performs a packed narrowing signed clip from 16-bit halfword elements
-to 8-bit byte elements with a scalar shift amount. The 64-bit source is read
-from the register pair designated by `rs1_p`. Each 16-bit element is
-arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
-signed 8-bit range [-128, 127]. Four byte results are packed into `rd`. If any
-element saturates, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== PNCLIPRI.B (RV32)
+
+===== Mnemonic
+
+pnclipri.b _rd_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -19304,6 +19308,15 @@ PNCLIPI.B.
 ....
 
 `uimm4` provides the 4-bit shift amount.
+
+===== Description
+
+PNCLIPRI.B performs a per-lane *rounded* arithmetic right shift of four 16-bit
+lanes from a 64-bit register-pair source using an immediate shift amount. Each
+rounded shifted value is then clipped to the signed 8-bit range [-128, 127] and
+packed into `rd`.
+
+When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
 ===== Operation
 
@@ -19332,19 +19345,6 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipri.b _rd_, _rs1_p_, _uimm4_
-
-===== Description
-
-PNCLIPRI.B performs a per-lane *rounded* arithmetic right shift of four 16-bit
-lanes from a 64-bit register-pair source using an immediate shift amount. Each
-rounded shifted value is then clipped to the signed 8-bit range [-128, 127] and
-packed into `rd`.
-
-When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
-
 ===== Notes
 
 * The source is taken from the register pair `{X[2*rs1_p+1], X[2*rs1_p]}`; if
@@ -19353,6 +19353,10 @@ When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
 <<<
 ==== PNCLIPR.BS (RV32)
+
+===== Mnemonic
+
+pnclipr.bs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19375,6 +19379,15 @@ PNCLIP.BS.
     { bits: 1, name: 0x0 },
 ]}
 ....
+
+===== Description
+
+PNCLIPR.BS performs a per-lane *rounded* arithmetic right shift of four 16-bit
+lanes from a 64-bit register-pair source using the shift amount in `rs2[4:0]`.
+Each rounded shifted value is then clipped to the signed 8-bit range [-128, 127]
+and packed into `rd`.
+
+When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
 ===== Operation
 
@@ -19403,19 +19416,6 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipr.bs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNCLIPR.BS performs a per-lane *rounded* arithmetic right shift of four 16-bit
-lanes from a 64-bit register-pair source using the shift amount in `rs2[4:0]`.
-Each rounded shifted value is then clipped to the signed 8-bit range [-128, 127]
-and packed into `rd`.
-
-When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
-
 ===== Notes
 
 * The source is taken from the register pair `{X[2*rs1_p+1], X[2*rs1_p]}`; if
@@ -19424,6 +19424,10 @@ When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
 <<<
 ==== PNCLIPIU.B (RV32)
+
+===== Mnemonic
+
+pnclipiu.b _rd_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -19448,6 +19452,14 @@ writes packed *unsigned-clipped* bytes to `rd`.
 
 `uimm4` provides the 4-bit shift amount.
 
+===== Description
+
+PNCLIPIU.B performs a per-lane logical right shift of four 16-bit lanes from a
+64-bit register-pair source using an immediate shift amount. Each shifted value
+is then clipped to the unsigned 8-bit range [0, 255] and packed into `rd`.
+
+When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
+
 ===== Operation
 
 [source,pseudocode]
@@ -19468,18 +19480,6 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipiu.b _rd_, _rs1_p_, _uimm4_
-
-===== Description
-
-PNCLIPIU.B performs a per-lane logical right shift of four 16-bit lanes from a
-64-bit register-pair source using an immediate shift amount. Each shifted value
-is then clipped to the unsigned 8-bit range [0, 255] and packed into `rd`.
-
-When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
-
 ===== Notes
 
 * The source is taken from the register pair `{X[2*rs1_p+1], X[2*rs1_p]}`; if
@@ -19488,6 +19488,10 @@ When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
 <<<
 ==== PNCLIPU.BS (RV32)
+
+===== Mnemonic
+
+pnclipu.bs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19510,6 +19514,12 @@ and writes packed *unsigned-clipped* bytes to `rd`.
 ]}
 ....
 
+===== Description
+
+PNCLIPU.BS performs a per-lane logical right shift of four 16-bit lanes from a
+64-bit register-pair source using a shift amount from `rs2`. Each shifted value
+is clipped to the unsigned 8-bit range [0, 255] and packed into `rd`. The `vxsat`
+sticky flag is set if any lane saturates.
 ===== Operation
 
 [source,pseudocode]
@@ -19530,19 +19540,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipu.bs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNCLIPU.BS performs a per-lane logical right shift of four 16-bit lanes from a
-64-bit register-pair source using a shift amount from `rs2`. Each shifted value
-is clipped to the unsigned 8-bit range [0, 255] and packed into `rd`. The `vxsat`
-sticky flag is set if any lane saturates.
 
 <<<
 ==== PNCLIPRIU.B (RV32)
+
+===== Mnemonic
+
+pnclipriu.b _rd_, _rs1_p_, _uimm4_
 
 ===== Encoding
 
@@ -19567,6 +19571,12 @@ writes packed *rounded unsigned-clipped* bytes to `rd`.
 
 `uimm4` provides the 4-bit shift amount.
 
+===== Description
+
+PNCLIPRIU.B performs a per-lane *rounded* logical right shift of four 16-bit lanes
+from a 64-bit register-pair source using an immediate shift amount. Each rounded
+shifted value is clipped to the unsigned 8-bit range [0, 255] and packed into
+`rd`. The `vxsat` sticky flag is set if any lane saturates.
 ===== Operation
 
 [source,pseudocode]
@@ -19590,19 +19600,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipriu.b _rd_, _rs1_p_, _uimm4_
-
-===== Description
-
-PNCLIPRIU.B performs a per-lane *rounded* logical right shift of four 16-bit lanes
-from a 64-bit register-pair source using an immediate shift amount. Each rounded
-shifted value is clipped to the unsigned 8-bit range [0, 255] and packed into
-`rd`. The `vxsat` sticky flag is set if any lane saturates.
 
 <<<
 ==== PNCLIPRU.BS (RV32)
+
+===== Mnemonic
+
+pnclipru.bs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19625,6 +19629,12 @@ and writes packed *rounded unsigned-clipped* bytes to `rd`.
 ]}
 ....
 
+===== Description
+
+PNCLIPRU.BS performs a per-lane *rounded* logical right shift of four 16-bit lanes
+from a 64-bit register-pair source using a shift amount from `rs2`. Each rounded
+shifted value is clipped to [0, 255] and packed into `rd`. The `vxsat` sticky
+flag is set if any lane saturates.
 ===== Operation
 
 [source,pseudocode]
@@ -19647,19 +19657,13 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipru.bs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNCLIPRU.BS performs a per-lane *rounded* logical right shift of four 16-bit lanes
-from a 64-bit register-pair source using a shift amount from `rs2`. Each rounded
-shifted value is clipped to [0, 255] and packed into `rd`. The `vxsat` sticky
-flag is set if any lane saturates.
 
 <<<
 ==== PNCLIPI.H (RV32)
+
+===== Mnemonic
+
+pnclipi.h _rd_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -19681,6 +19685,14 @@ amount and packed halfword narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PNCLIPI.H performs a packed narrowing signed clip from 32-bit word elements
+to 16-bit halfword elements with an immediate shift amount. The 64-bit source
+is read from the register pair designated by `rs1_p`. Each 32-bit element is
+arithmetically right-shifted by the 5-bit immediate, then clamped to the signed
+16-bit range [-32768, 32767]. Two halfword results are packed into `rd`. If any
+element saturates, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -19702,21 +19714,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipi.h _rd_, _rs1_p_, _uimm5_
-
-===== Description
-
-PNCLIPI.H performs a packed narrowing signed clip from 32-bit word elements
-to 16-bit halfword elements with an immediate shift amount. The 64-bit source
-is read from the register pair designated by `rs1_p`. Each 32-bit element is
-arithmetically right-shifted by the 5-bit immediate, then clamped to the signed
-16-bit range [-32768, 32767]. Two halfword results are packed into `rd`. If any
-element saturates, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== PNCLIP.HS (RV32)
+
+===== Mnemonic
+
+pnclip.hs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19738,6 +19742,14 @@ and packed halfword narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PNCLIP.HS performs a packed narrowing signed clip from 32-bit word elements
+to 16-bit halfword elements with a scalar shift amount. The 64-bit source is
+read from the register pair designated by `rs1_p`. Each 32-bit element is
+arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
+signed 16-bit range [-32768, 32767]. Two halfword results are packed into `rd`.
+If any element saturates, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -19759,21 +19771,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclip.hs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNCLIP.HS performs a packed narrowing signed clip from 32-bit word elements
-to 16-bit halfword elements with a scalar shift amount. The 64-bit source is
-read from the register pair designated by `rs1_p`. Each 32-bit element is
-arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
-signed 16-bit range [-32768, 32767]. Two halfword results are packed into `rd`.
-If any element saturates, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== PNCLIPRI.H (RV32)
+
+===== Mnemonic
+
+pnclipri.h _rd_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -19795,6 +19799,14 @@ amount, rounding, and packed halfword narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PNCLIPRI.H performs a packed narrowing signed clip with rounding from 32-bit
+word elements to 16-bit halfword elements using an immediate shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is arithmetically right-shifted with round-to-nearest-up, then clamped
+to the signed 16-bit range [-32768, 32767]. Two halfword results are packed
+into `rd`. If any element saturates, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -19818,21 +19830,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipri.h _rd_, _rs1_p_, _uimm5_
-
-===== Description
-
-PNCLIPRI.H performs a packed narrowing signed clip with rounding from 32-bit
-word elements to 16-bit halfword elements using an immediate shift amount. The
-64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
-element is arithmetically right-shifted with round-to-nearest-up, then clamped
-to the signed 16-bit range [-32768, 32767]. Two halfword results are packed
-into `rd`. If any element saturates, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== PNCLIPR.HS (RV32)
+
+===== Mnemonic
+
+pnclipr.hs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19854,6 +19858,15 @@ amount, rounding, and packed halfword narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+PNCLIPR.HS performs a packed narrowing signed clip with rounding from 32-bit
+word elements to 16-bit halfword elements using a scalar shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is arithmetically right-shifted with round-to-nearest-up by the amount
+in `rs2[4:0]`, then clamped to the signed 16-bit range [-32768, 32767]. Two
+halfword results are packed into `rd`. If any element saturates, `vxsat` is
+set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -19877,22 +19890,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipr.hs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNCLIPR.HS performs a packed narrowing signed clip with rounding from 32-bit
-word elements to 16-bit halfword elements using a scalar shift amount. The
-64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
-element is arithmetically right-shifted with round-to-nearest-up by the amount
-in `rs2[4:0]`, then clamped to the signed 16-bit range [-32768, 32767]. Two
-halfword results are packed into `rd`. If any element saturates, `vxsat` is
-set. Available only in RV32.
 
 <<<
 ==== PNCLIPIU.H (RV32)
+
+===== Mnemonic
+
+pnclipiu.h _rd_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -19915,6 +19919,12 @@ logical right shift by an immediate amount and clips each result to the unsigned
 ]}
 ....
 
+===== Description
+
+PNCLIPIU.H shifts each 32-bit word lane of the 64-bit register-pair source right
+logically by an immediate amount, then clips each shifted value to unsigned
+16-bit and packs the two halfwords into `rd`. The `vxsat` sticky flag is set if
+any lane saturates.
 ===== Operation
 
 [source,pseudocode]
@@ -19935,19 +19945,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipiu.h _rd_, _rs1_p_, _uimm5_
-
-===== Description
-
-PNCLIPIU.H shifts each 32-bit word lane of the 64-bit register-pair source right
-logically by an immediate amount, then clips each shifted value to unsigned
-16-bit and packs the two halfwords into `rd`. The `vxsat` sticky flag is set if
-any lane saturates.
 
 <<<
 ==== PNCLIPU.HS (RV32)
+
+===== Mnemonic
+
+pnclipu.hs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -19969,6 +19973,11 @@ shift amount and clips to unsigned 16-bit.
 ]}
 ....
 
+===== Description
+
+PNCLIPU.HS performs a per-word logical right shift of a 64-bit register-pair
+source using `rs2` as the shift amount, clips each lane to unsigned 16-bit, and
+packs the results into `rd`. The `vxsat` sticky flag is set on saturation.
 ===== Operation
 
 [source,pseudocode]
@@ -19989,18 +19998,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipu.hs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNCLIPU.HS performs a per-word logical right shift of a 64-bit register-pair
-source using `rs2` as the shift amount, clips each lane to unsigned 16-bit, and
-packs the results into `rd`. The `vxsat` sticky flag is set on saturation.
 
 <<<
 ==== PNCLIPRIU.H (RV32)
+
+===== Mnemonic
+
+pnclipriu.h _rd_, _rs1_p_, _uimm5_
 
 ===== Encoding
 
@@ -20023,6 +20027,14 @@ RV32.
 ]}
 ....
 
+===== Description
+
+PNCLIPRIU.H performs a packed narrowing unsigned clip with rounding from 32-bit
+word elements to 16-bit halfword elements using an immediate shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is logically right-shifted with round-to-nearest-up, then clamped to
+the unsigned 16-bit range [0, 65535]. Two halfword results are packed into
+`rd`. If any element saturates, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20044,21 +20056,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipriu.h _rd_, _rs1_p_, _uimm5_
-
-===== Description
-
-PNCLIPRIU.H performs a packed narrowing unsigned clip with rounding from 32-bit
-word elements to 16-bit halfword elements using an immediate shift amount. The
-64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
-element is logically right-shifted with round-to-nearest-up, then clamped to
-the unsigned 16-bit range [0, 65535]. Two halfword results are packed into
-`rd`. If any element saturates, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== PNCLIPRU.HS (RV32)
+
+===== Mnemonic
+
+pnclipru.hs _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -20081,6 +20085,15 @@ RV32.
 ]}
 ....
 
+===== Description
+
+PNCLIPRU.HS performs a packed narrowing unsigned clip with rounding from 32-bit
+word elements to 16-bit halfword elements using a scalar shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is logically right-shifted with round-to-nearest-up by the amount in
+`rs2[4:0]`, then clamped to the unsigned 16-bit range [0, 65535]. Two halfword
+results are packed into `rd`. If any element saturates, `vxsat` is set.
+Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20102,22 +20115,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pnclipru.hs _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-PNCLIPRU.HS performs a packed narrowing unsigned clip with rounding from 32-bit
-word elements to 16-bit halfword elements using a scalar shift amount. The
-64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
-element is logically right-shifted with round-to-nearest-up by the amount in
-`rs2[4:0]`, then clamped to the unsigned 16-bit range [0, 65535]. Two halfword
-results are packed into `rd`. If any element saturates, `vxsat` is set.
-Available only in RV32.
 
 <<<
 ==== NCLIPI (RV32)
+
+===== Mnemonic
+
+nclipi _rd_, _rs1_p_, _uimm6_
 
 ===== Encoding
 
@@ -20139,6 +20143,13 @@ and XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+NCLIPI performs an XLEN-wide narrowing signed clip with an immediate shift
+amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is arithmetically right-shifted by the 6-bit immediate, then
+clamped to the signed 32-bit range [-2^31, 2^31 - 1]. The 32-bit result is
+written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20157,20 +20168,13 @@ else:
     X[rd] = shx[31:0]
 ----
 
-===== Mnemonic
-
-nclipi _rd_, _rs1_p_, _uimm6_
-
-===== Description
-
-NCLIPI performs an XLEN-wide narrowing signed clip with an immediate shift
-amount. The 64-bit source is read from the register pair designated by
-`rs1_p`. The value is arithmetically right-shifted by the 6-bit immediate, then
-clamped to the signed 32-bit range [-2^31, 2^31 - 1]. The 32-bit result is
-written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== NCLIP (RV32)
+
+===== Mnemonic
+
+nclip _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -20192,6 +20196,13 @@ XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+NCLIP performs an XLEN-wide narrowing signed clip with a scalar shift amount.
+The 64-bit source is read from the register pair designated by `rs1_p`. The
+value is arithmetically right-shifted by the amount in `rs2[5:0]`, then clamped
+to the signed 32-bit range [-2^31, 2^31 - 1]. The 32-bit result is written to
+`rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20210,20 +20221,13 @@ else:
     X[rd] = shx[31:0]
 ----
 
-===== Mnemonic
-
-nclip _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-NCLIP performs an XLEN-wide narrowing signed clip with a scalar shift amount.
-The 64-bit source is read from the register pair designated by `rs1_p`. The
-value is arithmetically right-shifted by the amount in `rs2[5:0]`, then clamped
-to the signed 32-bit range [-2^31, 2^31 - 1]. The 32-bit result is written to
-`rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== NCLIPRI (RV32)
+
+===== Mnemonic
+
+nclipri _rd_, _rs1_p_, _uimm6_
 
 ===== Encoding
 
@@ -20245,6 +20249,14 @@ amount, rounding, and XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+NCLIPRI performs an XLEN-wide narrowing signed clip with rounding using an
+immediate shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is arithmetically right-shifted with
+round-to-nearest-up by the 6-bit immediate, then clamped to the signed 32-bit
+range [-2^31, 2^31 - 1]. The 32-bit result is written to `rd`. If saturation
+occurs, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20265,21 +20277,13 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
-===== Mnemonic
-
-nclipri _rd_, _rs1_p_, _uimm6_
-
-===== Description
-
-NCLIPRI performs an XLEN-wide narrowing signed clip with rounding using an
-immediate shift amount. The 64-bit source is read from the register pair
-designated by `rs1_p`. The value is arithmetically right-shifted with
-round-to-nearest-up by the 6-bit immediate, then clamped to the signed 32-bit
-range [-2^31, 2^31 - 1]. The 32-bit result is written to `rd`. If saturation
-occurs, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== NCLIPR (RV32)
+
+===== Mnemonic
+
+nclipr _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -20301,6 +20305,14 @@ rounding, and XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+NCLIPR performs an XLEN-wide narrowing signed clip with rounding using a scalar
+shift amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is arithmetically right-shifted with round-to-nearest-up by
+the amount in `rs2[5:0]`, then clamped to the signed 32-bit range
+[-2^31, 2^31 - 1]. The 32-bit result is written to `rd`. If saturation occurs,
+`vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20321,21 +20333,13 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
-===== Mnemonic
-
-nclipr _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-NCLIPR performs an XLEN-wide narrowing signed clip with rounding using a scalar
-shift amount. The 64-bit source is read from the register pair designated by
-`rs1_p`. The value is arithmetically right-shifted with round-to-nearest-up by
-the amount in `rs2[5:0]`, then clamped to the signed 32-bit range
-[-2^31, 2^31 - 1]. The 32-bit result is written to `rd`. If saturation occurs,
-`vxsat` is set. Available only in RV32.
 
 <<<
 ==== NCLIPIU (RV32)
+
+===== Mnemonic
+
+nclipiu _rd_, _rs1_p_, _uimm6_
 
 ===== Encoding
 
@@ -20357,6 +20361,13 @@ amount and unsigned XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+NCLIPIU performs an XLEN-wide narrowing unsigned clip with an immediate shift
+amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is logically right-shifted by the 6-bit immediate, then
+clamped to the unsigned 32-bit range [0, 2^32 - 1]. The 32-bit result is
+written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20373,20 +20384,13 @@ else:
     X[rd] = shx[31:0]
 ----
 
-===== Mnemonic
-
-nclipiu _rd_, _rs1_p_, _uimm6_
-
-===== Description
-
-NCLIPIU performs an XLEN-wide narrowing unsigned clip with an immediate shift
-amount. The 64-bit source is read from the register pair designated by
-`rs1_p`. The value is logically right-shifted by the 6-bit immediate, then
-clamped to the unsigned 32-bit range [0, 2^32 - 1]. The 32-bit result is
-written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== NCLIPU (RV32)
+
+===== Mnemonic
+
+nclipu _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -20409,6 +20413,10 @@ unsigned 32-bit range, setting `vxsat` on saturation.
 ]}
 ....
 
+===== Description
+
+NCLIPU performs a 64-bit logical right shift of the register-pair source and clips
+the result to 32-bit unsigned. The `vxsat` sticky flag is set if clipping occurs.
 ===== Operation
 
 [source,pseudocode]
@@ -20425,18 +20433,14 @@ else:
     X[rd] = shx[31:0]
 ----
 
-===== Mnemonic
-
-nclipu _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-NCLIPU performs a 64-bit logical right shift of the register-pair source and clips
-the result to 32-bit unsigned. The `vxsat` sticky flag is set if clipping occurs.
 
 
 <<<
 ==== NCLIPRIU (RV32)
+
+===== Mnemonic
+
+nclipriu _rd_, _rs1_p_, _uimm6_
 
 ===== Encoding
 
@@ -20458,6 +20462,14 @@ amount, rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+NCLIPRIU performs an XLEN-wide narrowing unsigned clip with rounding using an
+immediate shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is logically right-shifted with
+round-to-nearest-up by the 6-bit immediate, then clamped to the unsigned
+32-bit range [0, 2^32 - 1]. The 32-bit result is written to `rd`. If
+saturation occurs, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20476,21 +20488,13 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
-===== Mnemonic
-
-nclipriu _rd_, _rs1_p_, _uimm6_
-
-===== Description
-
-NCLIPRIU performs an XLEN-wide narrowing unsigned clip with rounding using an
-immediate shift amount. The 64-bit source is read from the register pair
-designated by `rs1_p`. The value is logically right-shifted with
-round-to-nearest-up by the 6-bit immediate, then clamped to the unsigned
-32-bit range [0, 2^32 - 1]. The 32-bit result is written to `rd`. If
-saturation occurs, `vxsat` is set. Available only in RV32.
 
 <<<
 ==== NCLIPRU (RV32)
+
+===== Mnemonic
+
+nclipru _rd_, _rs1_p_, _rs2_
 
 ===== Encoding
 
@@ -20512,6 +20516,14 @@ rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
+===== Description
+
+NCLIPRU performs an XLEN-wide narrowing unsigned clip with rounding using a
+scalar shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is logically right-shifted with
+round-to-nearest-up by the amount in `rs2[5:0]`, then clamped to the unsigned
+32-bit range [0, 2^32 - 1]. The 32-bit result is written to `rd`. If
+saturation occurs, `vxsat` is set. Available only in RV32.
 ===== Operation
 
 [source,pseudocode]
@@ -20530,23 +20542,15 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
-===== Mnemonic
-
-nclipru _rd_, _rs1_p_, _rs2_
-
-===== Description
-
-NCLIPRU performs an XLEN-wide narrowing unsigned clip with rounding using a
-scalar shift amount. The 64-bit source is read from the register pair
-designated by `rs1_p`. The value is logically right-shifted with
-round-to-nearest-up by the amount in `rs2[5:0]`, then clamped to the unsigned
-32-bit range [0, 2^32 - 1]. The 32-bit result is written to `rd`. If
-saturation occurs, `vxsat` is set. Available only in RV32.
 
 <<<
 === Multiply High (same-width)
 
 ==== PMULH.H
+
+===== Mnemonic
+
+pmulh.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -20567,6 +20571,12 @@ elements and returns the high half of each signed 16×16 multiplication.
 ]}
 ....
 
+===== Description
+
+PMULH.H performs lane-wise signed multiplication of packed 16-bit elements from
+`rs1` and `rs2`. For each lane, the upper 16 bits of the 32-bit product are
+written to the corresponding 16-bit element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -20583,16 +20593,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulh.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULH.H performs lane-wise signed multiplication of packed 16-bit elements from
-`rs1` and `rs2`. For each lane, the upper 16 bits of the 32-bit product are
-written to the corresponding 16-bit element of `rd`.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -20601,6 +20601,10 @@ written to the corresponding 16-bit element of `rd`.
 
 <<<
 ==== PMULHR.H
+
+===== Mnemonic
+
+pmulhr.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -20621,6 +20625,13 @@ elements and returns the rounded high half of each signed 16×16 multiplication.
 ]}
 ....
 
+===== Description
+
+PMULHR.H performs lane-wise signed multiplication of packed 16-bit elements from
+`rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product and then
+writes the upper 16 bits of the adjusted value to the corresponding 16-bit
+element of `rd`, implementing rounding when extracting the high half.
+
 ===== Operation
 
 [source,pseudocode]
@@ -20638,17 +20649,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhr.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULHR.H performs lane-wise signed multiplication of packed 16-bit elements from
-`rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product and then
-writes the upper 16 bits of the adjusted value to the corresponding 16-bit
-element of `rd`, implementing rounding when extracting the high half.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -20657,6 +20657,10 @@ element of `rd`, implementing rounding when extracting the high half.
 
 <<<
 ==== PMULHSU.H
+
+===== Mnemonic
+
+pmulhsu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -20678,6 +20682,13 @@ multiplication.
 ]}
 ....
 
+===== Description
+
+PMULHSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
+and `rs2`, treating each element of `rs1` as signed and each element of `rs2` as
+unsigned. For each lane, the upper 16 bits of the 32-bit product are written to
+the corresponding 16-bit element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -20694,17 +20705,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhsu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULHSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
-and `rs2`, treating each element of `rs1` as signed and each element of `rs2` as
-unsigned. For each lane, the upper 16 bits of the 32-bit product are written to
-the corresponding 16-bit element of `rd`.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -20713,6 +20713,10 @@ the corresponding 16-bit element of `rd`.
 
 <<<
 ==== PMULHRSU.H
+
+===== Mnemonic
+
+pmulhrsu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -20734,6 +20738,14 @@ multiplication.
 ]}
 ....
 
+===== Description
+
+PMULHRSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
+and `rs2`, treating each element of `rs1` as signed and each element of `rs2` as
+unsigned. For each lane, it adds 2^15 to the 32-bit product and then writes the
+upper 16 bits of the adjusted value to the corresponding 16-bit element of
+`rd`, implementing rounding when extracting the high half.
+
 ===== Operation
 
 [source,pseudocode]
@@ -20750,18 +20762,6 @@ for i = 0 .. (XLEN/16 - 1):
 
 X[rd] = d
 ----
-
-===== Mnemonic
-
-pmulhrsu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULHRSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
-and `rs2`, treating each element of `rs1` as signed and each element of `rs2` as
-unsigned. For each lane, it adds 2^15 to the 32-bit product and then writes the
-upper 16 bits of the adjusted value to the corresponding 16-bit element of
-`rd`, implementing rounding when extracting the high half.
 
 ===== Notes
 
@@ -20812,6 +20812,10 @@ PMULQR.H:
 <<<
 ==== PMULHU.H
 
+===== Mnemonic
+
+pmulhu.h _rd_, _rs1_, _rs2_
+
 ===== Encoding
 
 PMULHU.H is encoded in the OP-32 major opcode with packed halfword elements.
@@ -20830,6 +20834,11 @@ PMULHU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMULHU.H multiplies corresponding unsigned packed 16-bit halfword elements of
+`rs1` and `rs2`, producing 32-bit intermediate products, and writes the upper
+16 bits of each product to the corresponding halfword element of `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -20845,18 +20854,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULHU.H multiplies corresponding unsigned packed 16-bit halfword elements of
-`rs1` and `rs2`, producing 32-bit intermediate products, and writes the upper
-16 bits of each product to the corresponding halfword element of `rd`.
 
 <<<
 ==== PMULHRU.H
+
+===== Mnemonic
+
+pmulhru.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -20877,6 +20881,13 @@ elements and returns the rounded high half of each unsigned 16×16 multiplicatio
 ]}
 ....
 
+===== Description
+
+PMULHRU.H performs lane-wise unsigned multiplication of packed 16-bit elements
+from `rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product and then
+writes the upper 16 bits of the adjusted value to the corresponding 16-bit
+element of `rd`, implementing rounding when extracting the high half.
+
 ===== Operation
 
 [source,pseudocode]
@@ -20894,17 +20905,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhru.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULHRU.H performs lane-wise unsigned multiplication of packed 16-bit elements
-from `rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product and then
-writes the upper 16 bits of the adjusted value to the corresponding 16-bit
-element of `rd`, implementing rounding when extracting the high half.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -20913,6 +20913,10 @@ element of `rd`, implementing rounding when extracting the high half.
 
 <<<
 ==== PMULH.W (RV64)
+
+===== Mnemonic
+
+pmulh.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -20932,6 +20936,12 @@ PMULH.W is encoded in the OP-32 major opcode with packed word elements (RV64 onl
 ]}
 ....
 
+===== Description
+
+PMULH.W multiplies corresponding signed packed 32-bit word elements of `rs1`
+and `rs2`, producing 64-bit intermediate products, and writes the upper 32 bits
+of each product to the corresponding word element of `rd`. This instruction is
+available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -20948,19 +20958,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulh.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULH.W multiplies corresponding signed packed 32-bit word elements of `rs1`
-and `rs2`, producing 64-bit intermediate products, and writes the upper 32 bits
-of each product to the corresponding word element of `rd`. This instruction is
-available only on RV64.
 
 <<<
 ==== PMULHR.W (RV64)
+
+===== Mnemonic
+
+pmulhr.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -20980,6 +20984,12 @@ PMULHR.W is encoded in the OP-32 major opcode with packed word elements (RV64 on
 ]}
 ....
 
+===== Description
+
+PMULHR.W multiplies corresponding signed packed 32-bit word elements of `rs1`
+and `rs2`, producing 64-bit intermediate products, adds a rounding constant
+of 2^31, and writes the upper 32 bits of each rounded product to the
+corresponding word element of `rd`. This instruction is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -20996,19 +21006,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhr.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULHR.W multiplies corresponding signed packed 32-bit word elements of `rs1`
-and `rs2`, producing 64-bit intermediate products, adds a rounding constant
-of 2^31, and writes the upper 32 bits of each rounded product to the
-corresponding word element of `rd`. This instruction is available only on RV64.
 
 <<<
 ==== PMULHSU.W (RV64)
+
+===== Mnemonic
+
+pmulhsu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21028,6 +21032,11 @@ PMULHSU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+The PMULHSU.W instruction multiplies corresponding 32-bit elements of `rs1`
+(signed) and `rs2` (unsigned), and writes the upper 32 bits of each product
+to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -21043,18 +21052,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhsu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMULHSU.W instruction multiplies corresponding 32-bit elements of `rs1`
-(signed) and `rs2` (unsigned), and writes the upper 32 bits of each product
-to `rd`.
 
 <<<
 ==== PMULHRSU.W (RV64)
+
+===== Mnemonic
+
+pmulhrsu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21075,6 +21079,12 @@ with rounding.
 ]}
 ....
 
+===== Description
+
+The PMULHRSU.W instruction performs signed×unsigned packed multiplication on
+32-bit elements, applies rounding, and writes the upper 32 bits of each result
+to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -21090,22 +21100,16 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhrsu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMULHRSU.W instruction performs signed×unsigned packed multiplication on
-32-bit elements, applies rounding, and writes the upper 32 bits of each result
-to `rd`.
-
 ===== Notes
 
 * Rounding is performed by adding 2^31 before extracting bits [63:32].
 
 <<<
 ==== PMULHU.W (RV64)
+
+===== Mnemonic
+
+pmulhu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21125,6 +21129,10 @@ PMULHU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+The PMULHU.W instruction multiplies corresponding unsigned 32-bit elements of
+`rs1` and `rs2`, writing the upper 32 bits of each product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -21140,17 +21148,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMULHU.W instruction multiplies corresponding unsigned 32-bit elements of
-`rs1` and `rs2`, writing the upper 32 bits of each product to `rd`.
 
 <<<
 ==== PMULHRU.W (RV64)
+
+===== Mnemonic
+
+pmulhru.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21171,6 +21175,11 @@ with rounding.
 ]}
 ....
 
+===== Description
+
+The PMULHRU.W instruction multiplies corresponding unsigned 32-bit elements,
+applies rounding, and writes the upper 32 bits of each product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -21186,21 +21195,16 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhru.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMULHRU.W instruction multiplies corresponding unsigned 32-bit elements,
-applies rounding, and writes the upper 32 bits of each product to `rd`.
-
 ===== Notes
 
 * Rounding is performed by adding 2^31.
 
 <<<
 ==== MULHR (RV32)
+
+===== Mnemonic
+
+mulhr _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21220,6 +21224,11 @@ MULHR is encoded in the OP-32 major opcode as an XLEN-wide operation.
 ]}
 ....
 
+===== Description
+
+MULHR multiplies the full signed XLEN-bit values of `rs1` and `rs2`, producing
+a 2*XLEN-bit intermediate product, adds a rounding constant of 2^(XLEN-1),
+and writes the upper XLEN bits of the rounded product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -21231,18 +21240,13 @@ X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^31)[63:32]
 X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^63)[127:64]
 ----
 
-===== Mnemonic
-
-mulhr _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULHR multiplies the full signed XLEN-bit values of `rs1` and `rs2`, producing
-a 2*XLEN-bit intermediate product, adds a rounding constant of 2^(XLEN-1),
-and writes the upper XLEN bits of the rounded product to `rd`.
 
 <<<
 ==== MULHRSU (RV32)
+
+===== Mnemonic
+
+mulhrsu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21263,6 +21267,12 @@ multiply-high rounded sub-encoding.
 ]}
 ....
 
+===== Description
+
+The MULHRSU instruction multiplies `rs1` as a signed value by `rs2` as an
+unsigned value, adds 2^31 for rounding, and writes the upper 32 bits of the
+result to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -21273,22 +21283,16 @@ prod = a64 * b64
 X[rd] = (prod + 2^31)[63:32]
 ----
 
-===== Mnemonic
-
-mulhrsu _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MULHRSU instruction multiplies `rs1` as a signed value by `rs2` as an
-unsigned value, adds 2^31 for rounding, and writes the upper 32 bits of the
-result to `rd`.
-
 ===== Notes
 
 * Rounding is performed by adding 2^31 before extracting bits [63:32].
 
 <<<
 ==== MULHRU (RV32)
+
+===== Mnemonic
+
+mulhru _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21309,6 +21313,9 @@ multiply-high rounded sub-encoding.
 ]}
 ....
 
+===== Description
+
+The MULHRU instruction multiplie
 ===== Operation
 
 [source,pseudocode]
@@ -21319,19 +21326,16 @@ prod = a64 * b64
 X[rd] = (prod + 2^31)[63:32]
 ----
 
-===== Mnemonic
-
-mulhru _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MULHRU instruction multiplie
 
 
 <<<
 === Q-format Multiply
 
 ==== PMULQ.H
+
+===== Mnemonic
+
+pmulq.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21351,6 +21355,12 @@ PMULQ.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMULQ.H performs a Q-format multiply on corresponding signed packed 16-bit
+halfword elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
+upper 16 bits. When both inputs are the most negative value (0x8000), the
+result saturates to 0x7FFF and the `vxsat` overflow flag is set.
 ===== Operation
 
 [source,pseudocode]
@@ -21370,19 +21380,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulq.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULQ.H performs a Q-format multiply on corresponding signed packed 16-bit
-halfword elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
-upper 16 bits. When both inputs are the most negative value (0x8000), the
-result saturates to 0x7FFF and the `vxsat` overflow flag is set.
 
 <<<
 ==== PMULQR.H
+
+===== Mnemonic
+
+pmulqr.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21402,6 +21406,14 @@ elements and produces a signed Q15-style rounded product with saturation.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+PMULQR.H performs lane-wise signed multiplication of packed 16-bit elements and
+returns a Q15-style rounded result per lane. For each lane, it adds 2^14 to the
+32-bit product and extracts bits [30:15] (equivalently, a rounded arithmetic
+right shift by 15). If both inputs are `0x8000`, the result saturates to
+`0x7FFF` and the `vxsat` sticky flag is set.
 
 ===== Operation
 
@@ -21425,18 +21437,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulqr.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULQR.H performs lane-wise signed multiplication of packed 16-bit elements and
-returns a Q15-style rounded result per lane. For each lane, it adds 2^14 to the
-32-bit product and extracts bits [30:15] (equivalently, a rounded arithmetic
-right shift by 15). If both inputs are `0x8000`, the result saturates to
-`0x7FFF` and the `vxsat` sticky flag is set.
-
 ===== Notes
 
 * `vxsat` is set if any lane saturates; it is not cleared by this instruction.
@@ -21446,6 +21446,10 @@ right shift by 15). If both inputs are `0x8000`, the result saturates to
 
 <<<
 ==== PMULQ.W (RV64)
+
+===== Mnemonic
+
+pmulq.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21465,6 +21469,13 @@ PMULQ.W is encoded in the OP-32 major opcode with packed word elements (RV64 onl
 ]}
 ....
 
+===== Description
+
+PMULQ.W performs a Q-format multiply on corresponding signed packed 32-bit
+word elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
+upper 32 bits. When both inputs are the most negative value (0x80000000), the
+result saturates to 0x7FFFFFFF and the `vxsat` overflow flag is set. This
+instruction is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -21485,20 +21496,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulq.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULQ.W performs a Q-format multiply on corresponding signed packed 32-bit
-word elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
-upper 32 bits. When both inputs are the most negative value (0x80000000), the
-result saturates to 0x7FFFFFFF and the `vxsat` overflow flag is set. This
-instruction is available only on RV64.
 
 <<<
 ==== PMULQR.W (RV64)
+
+===== Mnemonic
+
+pmulqr.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21518,6 +21522,14 @@ PMULQR.W is encoded in the OP-32 major opcode with packed word elements (RV64 on
 ]}
 ....
 
+===== Description
+
+PMULQR.W performs a rounding Q-format multiply on corresponding signed packed
+32-bit word elements of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a
+rounding constant of 2^30 before the shift, and keeps the upper 32 bits. When
+both inputs are the most negative value (0x80000000), the result saturates to
+0x7FFFFFFF and the `vxsat` overflow flag is set. This instruction is available
+only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -21538,21 +21550,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulqr.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULQR.W performs a rounding Q-format multiply on corresponding signed packed
-32-bit word elements of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a
-rounding constant of 2^30 before the shift, and keeps the upper 32 bits. When
-both inputs are the most negative value (0x80000000), the result saturates to
-0x7FFFFFFF and the `vxsat` overflow flag is set. This instruction is available
-only on RV64.
 
 <<<
 ==== MULQ (RV32)
+
+===== Mnemonic
+
+mulq _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21572,6 +21576,12 @@ MULQ is encoded in the OP-32 major opcode as an XLEN-wide operation.
 ]}
 ....
 
+===== Description
+
+MULQ performs a Q-format multiply on the full signed XLEN-bit values of `rs1`
+and `rs2`. It computes `(a * b) << 1` and keeps the upper XLEN bits. When both
+inputs are the most negative value, the result saturates to the most positive
+value and the `vxsat` overflow flag is set.
 ===== Operation
 
 [source,pseudocode]
@@ -21595,19 +21605,13 @@ else:
     X[rd] = (signed(a) * signed(b))[126:63]
 ----
 
-===== Mnemonic
-
-mulq _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULQ performs a Q-format multiply on the full signed XLEN-bit values of `rs1`
-and `rs2`. It computes `(a * b) << 1` and keeps the upper XLEN bits. When both
-inputs are the most negative value, the result saturates to the most positive
-value and the `vxsat` overflow flag is set.
 
 <<<
 ==== MULQR (RV32)
+
+===== Mnemonic
+
+mulqr _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21627,6 +21631,13 @@ MULQR is encoded in the OP-32 major opcode as an XLEN-wide operation.
 ]}
 ....
 
+===== Description
+
+MULQR performs a rounding Q-format multiply on the full signed XLEN-bit values
+of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a rounding constant of
+2^(XLEN-2) before the shift, and keeps the upper XLEN bits. When both inputs
+are the most negative value, the result saturates to the most positive value
+and the `vxsat` overflow flag is set.
 ===== Operation
 
 [source,pseudocode]
@@ -21650,22 +21661,15 @@ else:
     X[rd] = (signed(a) * signed(b) + 2^62)[126:63]
 ----
 
-===== Mnemonic
-
-mulqr _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULQR performs a rounding Q-format multiply on the full signed XLEN-bit values
-of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a rounding constant of
-2^(XLEN-2) before the shift, and keeps the upper XLEN bits. When both inputs
-are the most negative value, the result saturates to the most positive value
-and the `vxsat` overflow flag is set.
 
 <<<
 === Multiply-High Accumulate
 
 ==== PMHACC.H
+
+===== Mnemonic
+
+pmhacc.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21687,6 +21691,13 @@ elements and accumulates the high half of each signed 16×16 multiplication into
 ]}
 ....
 
+===== Description
+
+PMHACC.H performs lane-wise signed multiplication of packed 16-bit elements from
+`rs1` and `rs2`. For each lane, it extracts the upper 16 bits of the 32-bit
+product and adds that value to the corresponding 16-bit element of `rd`. The
+accumulated packed result is written back to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -21706,17 +21717,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhacc.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMHACC.H performs lane-wise signed multiplication of packed 16-bit elements from
-`rs1` and `rs2`. For each lane, it extracts the upper 16 bits of the 32-bit
-product and adds that value to the corresponding 16-bit element of `rd`. The
-accumulated packed result is written back to `rd`.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -21724,6 +21724,10 @@ accumulated packed result is written back to `rd`.
 
 <<<
 ==== PMHRACC.H
+
+===== Mnemonic
+
+pmhracc.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21745,6 +21749,14 @@ multiplication into `rd`.
 ]}
 ....
 
+===== Description
+
+PMHRACC.H performs lane-wise signed multiplication of packed 16-bit elements from
+`rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product, extracts the
+upper 16 bits of the adjusted value, and accumulates that into the corresponding
+16-bit element of `rd`. The packed accumulated result is written back to `rd`,
+implementing rounding when extracting the high half.
+
 ===== Operation
 
 [source,pseudocode]
@@ -21764,18 +21776,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhracc.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMHRACC.H performs lane-wise signed multiplication of packed 16-bit elements from
-`rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product, extracts the
-upper 16 bits of the adjusted value, and accumulates that into the corresponding
-16-bit element of `rd`. The packed accumulated result is written back to `rd`,
-implementing rounding when extracting the high half.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -21783,6 +21783,10 @@ implementing rounding when extracting the high half.
 
 <<<
 ==== PMHACCSU.H
+
+===== Mnemonic
+
+pmhaccsu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21804,6 +21808,14 @@ multiplication into `rd`.
 ]}
 ....
 
+===== Description
+
+PMHACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
+and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
+each lane, it extracts the upper 16 bits of the 32-bit product and accumulates
+that value into the corresponding 16-bit element of `rd`. The packed accumulated
+result is written back to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -21823,18 +21835,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhaccsu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMHACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
-and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
-each lane, it extracts the upper 16 bits of the 32-bit product and accumulates
-that value into the corresponding 16-bit element of `rd`. The packed accumulated
-result is written back to `rd`.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -21842,6 +21842,10 @@ result is written back to `rd`.
 
 <<<
 ==== PMHRACCSU.H
+
+===== Mnemonic
+
+pmhraccsu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21863,6 +21867,15 @@ elements and accumulates the rounded high half of each mixed signed×unsigned
 ]}
 ....
 
+===== Description
+
+PMHRACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
+and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
+each lane, it adds 2^15 to the 32-bit product, extracts the upper 16 bits of the
+adjusted value, and accumulates that into the corresponding 16-bit element of
+`rd`. The packed accumulated result is written back to `rd`, implementing
+rounding when extracting the high half.
+
 ===== Operation
 
 [source,pseudocode]
@@ -21882,19 +21895,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhraccsu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMHRACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
-and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
-each lane, it adds 2^15 to the 32-bit product, extracts the upper 16 bits of the
-adjusted value, and accumulates that into the corresponding 16-bit element of
-`rd`. The packed accumulated result is written back to `rd`, implementing
-rounding when extracting the high half.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -21902,6 +21902,10 @@ rounding when extracting the high half.
 
 <<<
 ==== PMHACCU.H
+
+===== Mnemonic
+
+pmhaccu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21923,6 +21927,13 @@ into `rd`.
 ]}
 ....
 
+===== Description
+
+PMHACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
+from `rs1` and `rs2`. For each lane, it extracts the upper 16 bits of the 32-bit
+product and accumulates that value into the corresponding 16-bit element of
+`rd`. The packed accumulated result is written back to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -21942,17 +21953,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhaccu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMHACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
-from `rs1` and `rs2`. For each lane, it extracts the upper 16 bits of the 32-bit
-product and accumulates that value into the corresponding 16-bit element of
-`rd`. The packed accumulated result is written back to `rd`.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -21960,6 +21960,10 @@ product and accumulates that value into the corresponding 16-bit element of
 
 <<<
 ==== PMHRACCU.H
+
+===== Mnemonic
+
+pmhraccu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -21981,6 +21985,14 @@ multiplication into `rd`.
 ]}
 ....
 
+===== Description
+
+PMHRACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
+from `rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product, extracts
+the upper 16 bits of the adjusted value, and accumulates that into the
+corresponding 16-bit element of `rd`. The packed accumulated result is written
+back to `rd`, implementing rounding when extracting the high half.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22000,18 +22012,6 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhraccu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMHRACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
-from `rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product, extracts
-the upper 16 bits of the adjusted value, and accumulates that into the
-corresponding 16-bit element of `rd`. The packed accumulated result is written
-back to `rd`, implementing rounding when extracting the high half.
-
 ===== Notes
 
 * This instruction does not set `vxsat`.
@@ -22019,6 +22019,10 @@ back to `rd`, implementing rounding when extracting the high half.
 
 <<<
 ==== PMHACC.W (RV64)
+
+===== Mnemonic
+
+pmhacc.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22039,6 +22043,11 @@ accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The PMHACC.W instruction multiplies signed packed 32-bit elements and
+accumulates the upper 32 bits of each product into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22056,21 +22065,16 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhacc.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACC.W instruction multiplies signed packed 32-bit elements and
-accumulates the upper 32 bits of each product into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHRACC.W (RV64)
+
+===== Mnemonic
+
+pmhracc.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22091,6 +22095,10 @@ rounded accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The PMHRACC.W instruction performs signed packed multiplication with rounding
+and accumulates the upper 32 bits of each product into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22108,17 +22116,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhracc.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHRACC.W instruction performs signed packed multiplication with rounding
-and accumulates the upper 32 bits of each product into `rd`.
 
 <<<
 ==== PMHACCSU.W (RV64)
+
+===== Mnemonic
+
+pmhaccsu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22139,6 +22143,10 @@ multiply-high accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The PMHACCSU.W instruction multiplies signed elements of `rs1` with unsigned
+elements of `rs2` and accumulates the upper 32 bits into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22156,17 +22164,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhaccsu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACCSU.W instruction multiplies signed elements of `rs1` with unsigned
-elements of `rs2` and accumulates the upper 32 bits into `rd`.
 
 <<<
 ==== PMHRACCSU.W (RV64)
+
+===== Mnemonic
+
+pmhraccsu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22187,6 +22191,10 @@ multiply-high rounded accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The PMHRACCSU.W instruction performs signed×unsigned packed multiplication with
+rounding and accumulates the upper 32 bits into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22204,17 +22212,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhraccsu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHRACCSU.W instruction performs signed×unsigned packed multiplication with
-rounding and accumulates the upper 32 bits into `rd`.
 
 <<<
 ==== PMHACCU.W (RV64)
+
+===== Mnemonic
+
+pmhaccu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22235,6 +22239,10 @@ multiply-high accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The PMHACCU.W instruction multiplies unsigned packed 32-bit elements and
+accumulates the upper 32 bits of each product into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22252,17 +22260,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhaccu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACCU.W instruction multiplies unsigned packed 32-bit elements and
-accumulates the upper 32 bits of each product into `rd`.
 
 <<<
 ==== PMHRACCU.W (RV64)
+
+===== Mnemonic
+
+pmhraccu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22283,6 +22287,10 @@ multiply-high rounded accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The PMHRACCU.W instruction multiplies unsigned packed 32-bit elements with
+rounding and accumulates the upper 32 bits of each product into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22300,17 +22308,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhraccu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHRACCU.W instruction multiplies unsigned packed 32-bit elements with
-rounding and accumulates the upper 32 bits of each product into `rd`.
 
 <<<
 ==== MHACC (RV32)
+
+===== Mnemonic
+
+mhacc _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22331,6 +22335,11 @@ multiply-high accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The MHACC instruction multiplies `rs1` and `rs2` as signed values, extracts
+the upper 32 bits of the product, and accumulates the result into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22341,21 +22350,16 @@ hi  = (a64 * b64)[63:32]
 X[rd] = X[rd] + hi
 ----
 
-===== Mnemonic
-
-mhacc _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MHACC instruction multiplies `rs1` and `rs2` as signed values, extracts
-the upper 32 bits of the product, and accumulates the result into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MHRACC (RV32)
+
+===== Mnemonic
+
+mhracc _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22376,6 +22380,11 @@ multiply-high rounded accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The MHRACC instruction multiplies `rs1` and `rs2` as signed values,
+rounds the product, and accumulates the upper 32 bits into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22386,15 +22395,6 @@ hi_rnd = (a64 * b64 + 2^31)[63:32]
 X[rd] = X[rd] + hi_rnd
 ----
 
-===== Mnemonic
-
-mhracc _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MHRACC instruction multiplies `rs1` and `rs2` as signed values,
-rounds the product, and accumulates the upper 32 bits into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -22402,6 +22402,10 @@ rounds the product, and accumulates the upper 32 bits into `rd`.
 
 <<<
 ==== MHACCSU (RV32)
+
+===== Mnemonic
+
+mhaccsu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22422,6 +22426,10 @@ signed×unsigned multiply-high accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The MHACCSU instruction multiplies `rs1` as signed by `rs2` as unsigned,
+extracts the upper 32 bits of the product, and accumulates the result.
 ===== Operation
 
 [source,pseudocode]
@@ -22432,17 +22440,13 @@ hi  = (a64 * b64)[63:32]
 X[rd] = X[rd] + hi
 ----
 
-===== Mnemonic
-
-mhaccsu _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MHACCSU instruction multiplies `rs1` as signed by `rs2` as unsigned,
-extracts the upper 32 bits of the product, and accumulates the result.
 
 <<<
 ==== MHRACCSU (RV32)
+
+===== Mnemonic
+
+mhraccsu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22463,6 +22467,10 @@ signed×unsigned multiply-high rounded accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The MHRACCSU instruction performs a signed×unsigned multiply, rounds the
+product, and accumulates the upper 32 bits into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22473,17 +22481,13 @@ hi_rnd = (a64 * b64 + 2^31)[63:32]
 X[rd] = X[rd] + hi_rnd
 ----
 
-===== Mnemonic
-
-mhraccsu _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MHRACCSU instruction performs a signed×unsigned multiply, rounds the
-product, and accumulates the upper 32 bits into `rd`.
 
 <<<
 ==== MHACCU (RV32)
+
+===== Mnemonic
+
+mhaccu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22504,6 +22508,10 @@ unsigned×unsigned multiply-high accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The MHACCU instruction multiplies `rs1` and `rs2` as unsigned values and
+accumulates the upper 32 bits of the product into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22514,17 +22522,13 @@ hi  = (a64 * b64)[63:32]
 X[rd] = X[rd] + hi
 ----
 
-===== Mnemonic
-
-mhaccu _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MHACCU instruction multiplies `rs1` and `rs2` as unsigned values and
-accumulates the upper 32 bits of the product into `rd`.
 
 <<<
 ==== MHRACCU (RV32)
+
+===== Mnemonic
+
+mhraccu _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22545,6 +22549,10 @@ unsigned×unsigned multiply-high rounded accumulate instruction.
 ]}
 ....
 
+===== Description
+
+The MHRACCU instruction multiplies `rs1` and `rs2` as unsigned values,
+rounds the product, and accumulates the upper 32 bits into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22555,20 +22563,16 @@ hi_rnd = (a64 * b64 + 2^31)[63:32]
 X[rd] = X[rd] + hi_rnd
 ----
 
-===== Mnemonic
-
-mhraccu _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MHRACCU instruction multiplies `rs1` and `rs2` as unsigned values,
-rounds the product, and accumulates the upper 32 bits into `rd`.
 
 
 <<<
 === Q-format Multiply-Accumulate
 
 ==== MQACC.H00 (RV32)
+
+===== Mnemonic
+
+mqacc.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22589,6 +22593,12 @@ instruction operating on the low halfwords of `rs1` and `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQACC.H00 instruction multiplies the low 16-bit halfwords of `rs1` and `rs2`
+as signed values, extracts bits [46:15] of the 47-bit product, and accumulates
+the extracted value into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22599,22 +22609,16 @@ q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqacc.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQACC.H00 instruction multiplies the low 16-bit halfwords of `rs1` and `rs2`
-as signed values, extracts bits [46:15] of the 47-bit product, and accumulates
-the extracted value into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQACC.H01 (RV32)
+
+===== Mnemonic
+
+mqacc.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22636,6 +22640,12 @@ instruction operating on the low halfword of `rs1` and the high halfword of
 ]}
 ....
 
+===== Description
+
+The MQACC.H01 instruction multiplies `rs1[15:0]` by `rs2[31:16]` as signed
+halfwords, extracts bits [46:15] of the product, and accumulates the extracted
+value into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22646,22 +22656,16 @@ q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqacc.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQACC.H01 instruction multiplies `rs1[15:0]` by `rs2[31:16]` as signed
-halfwords, extracts bits [46:15] of the product, and accumulates the extracted
-value into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQACC.H11 (RV32)
+
+===== Mnemonic
+
+mqacc.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22682,6 +22686,12 @@ instruction operating on the high halfwords of `rs1` and `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQACC.H11 instruction multiplies the high 16-bit halfwords of `rs1` and
+`rs2` as signed values, extracts bits [46:15] of the product, and accumulates
+the extracted value into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22692,22 +22702,16 @@ q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqacc.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQACC.H11 instruction multiplies the high 16-bit halfwords of `rs1` and
-`rs2` as signed values, extracts bits [46:15] of the product, and accumulates
-the extracted value into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQRACC.H00 (RV32)
+
+===== Mnemonic
+
+mqracc.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22728,6 +22732,11 @@ accumulate instruction operating on the low halfwords of `rs1` and `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQRACC.H00 instruction is like MQACC.H00 but applies rounding by adding
+2^14 before extracting bits [46:15], and then accumulates into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22738,15 +22747,6 @@ q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqracc.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQRACC.H00 instruction is like MQACC.H00 but applies rounding by adding
-2^14 before extracting bits [46:15], and then accumulates into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -22754,6 +22754,10 @@ The MQRACC.H00 instruction is like MQACC.H00 but applies rounding by adding
 
 <<<
 ==== MQRACC.H01 (RV32)
+
+===== Mnemonic
+
+mqracc.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22774,6 +22778,11 @@ accumulate instruction operating on `rs1[15:0]` and `rs2[31:16]`.
 ]}
 ....
 
+===== Description
+
+The MQRACC.H01 instruction is like MQACC.H01 but applies rounding by adding
+2^14 before extracting bits [46:15], and then accumulates into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22784,15 +22793,6 @@ q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqracc.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQRACC.H01 instruction is like MQACC.H01 but applies rounding by adding
-2^14 before extracting bits [46:15], and then accumulates into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -22800,6 +22800,10 @@ The MQRACC.H01 instruction is like MQACC.H01 but applies rounding by adding
 
 <<<
 ==== MQRACC.H11 (RV32)
+
+===== Mnemonic
+
+mqracc.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22820,6 +22824,11 @@ accumulate instruction operating on the high halfwords of `rs1` and `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQRACC.H11 instruction is like MQACC.H11 but applies rounding by adding
+2^14 before extracting bits [46:15], and then accumulates into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22830,15 +22839,6 @@ q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqracc.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQRACC.H11 instruction is like MQACC.H11 but applies rounding by adding
-2^14 before extracting bits [46:15], and then accumulates into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -22846,6 +22846,10 @@ The MQRACC.H11 instruction is like MQACC.H11 but applies rounding by adding
 
 <<<
 ==== PMQACC.W.H00 (RV64)
+
+===== Mnemonic
+
+pmqacc.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22866,6 +22870,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+The PMQACC.W.H00 instruction, for each 32-bit lane, multiplies the low 16-bit
+halfwords of `rs1` and `rs2` as signed values, extracts bits [46:15] of the
+product, and accumulates into the corresponding 32-bit element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -22883,22 +22893,16 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmqacc.w.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQACC.W.H00 instruction, for each 32-bit lane, multiplies the low 16-bit
-halfwords of `rs1` and `rs2` as signed values, extracts bits [46:15] of the
-product, and accumulates into the corresponding 32-bit element of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMQACC.W.H01 (RV64)
+
+===== Mnemonic
+
+pmqacc.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22919,6 +22923,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+The PMQACC.W.H01 instruction, for each 32-bit lane, multiplies the low halfword
+of `rs1` by the high halfword of `rs2` (both signed), extracts bits [46:15] of
+the product, and accumulates into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22936,18 +22945,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmqacc.w.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQACC.W.H01 instruction, for each 32-bit lane, multiplies the low halfword
-of `rs1` by the high halfword of `rs2` (both signed), extracts bits [46:15] of
-the product, and accumulates into `rd`.
 
 <<<
 ==== PMQACC.W.H11 (RV64)
+
+===== Mnemonic
+
+pmqacc.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -22968,6 +22972,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+The PMQACC.W.H11 instruction, for each 32-bit lane, multiplies the high 16-bit
+halfwords of `rs1` and `rs2` as signed values, extracts bits [46:15] of the
+product, and accumulates into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -22985,18 +22994,13 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmqacc.w.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQACC.W.H11 instruction, for each 32-bit lane, multiplies the high 16-bit
-halfwords of `rs1` and `rs2` as signed values, extracts bits [46:15] of the
-product, and accumulates into `rd`.
 
 <<<
 ==== PMQRACC.W.H00 (RV64)
+
+===== Mnemonic
+
+pmqracc.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23017,6 +23021,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+The PMQRACC.W.H00 instruction is like PMQACC.W.H00 but applies rounding by
+adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23034,15 +23043,6 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmqracc.w.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQRACC.W.H00 instruction is like PMQACC.W.H00 but applies rounding by
-adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -23050,6 +23050,10 @@ adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
 <<<
 ==== PMQRACC.W.H01 (RV64)
+
+===== Mnemonic
+
+pmqracc.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23070,6 +23074,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+The PMQRACC.W.H01 instruction is like PMQACC.W.H01 but applies rounding by
+adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23087,15 +23096,6 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmqracc.w.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQRACC.W.H01 instruction is like PMQACC.W.H01 but applies rounding by
-adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -23103,6 +23103,10 @@ adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
 <<<
 ==== PMQRACC.W.H11 (RV64)
+
+===== Mnemonic
+
+pmqracc.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23123,6 +23127,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+The PMQRACC.W.H11 instruction is like PMQACC.W.H11 but applies rounding by
+adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23140,15 +23149,6 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmqracc.w.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQRACC.W.H11 instruction is like PMQACC.W.H11 but applies rounding by
-adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -23156,6 +23156,10 @@ adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
 <<<
 ==== PMQ2ADD.H
+
+===== Mnemonic
+
+pmq2add.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23176,6 +23180,11 @@ and producing packed 32-bit results (one per halfword pair).
 ]}
 ....
 
+===== Description
+
+The PMQ2ADD.H instruction computes, for each 32-bit lane, the sum of two
+Q-format multiply-high results: one from the low halfword pair and one from the
+high halfword pair, and writes the packed 32-bit sums to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -23196,18 +23205,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmq2add.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQ2ADD.H instruction computes, for each 32-bit lane, the sum of two
-Q-format multiply-high results: one from the low halfword pair and one from the
-high halfword pair, and writes the packed 32-bit sums to `rd`.
 
 <<<
 ==== PMQ2ADDA.H
+
+===== Mnemonic
+
+pmq2adda.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23228,6 +23232,11 @@ PMQ2ADD.H.
 ]}
 ....
 
+===== Description
+
+The PMQ2ADDA.H instruction adds the PMQ2ADD.H result into the corresponding
+packed 32-bit elements of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23249,21 +23258,16 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmq2adda.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQ2ADDA.H instruction adds the PMQ2ADD.H result into the corresponding
-packed 32-bit elements of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMQR2ADD.H
+
+===== Mnemonic
+
+pmqr2add.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23283,6 +23287,12 @@ and producing packed 32-bit results with rounding.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The PMQR2ADD.H instruction is like PMQ2ADD.H but applies rounding (adding 2^14)
+to each Q-format product before extracting bits [46:15], and then sums the two
+terms per 32-bit lane.
 
 ===== Operation
 
@@ -23304,22 +23314,16 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmqr2add.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQR2ADD.H instruction is like PMQ2ADD.H but applies rounding (adding 2^14)
-to each Q-format product before extracting bits [46:15], and then sums the two
-terms per 32-bit lane.
-
 ===== Notes
 
 * Rounding is performed by adding 2^14.
 
 <<<
 ==== PMQR2ADDA.H
+
+===== Mnemonic
+
+pmqr2adda.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23339,6 +23343,11 @@ PMQR2ADD.H.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The PMQR2ADDA.H instruction adds the PMQR2ADD.H result into the corresponding
+packed 32-bit elements of `rd`.
 
 ===== Operation
 
@@ -23361,15 +23370,6 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmqr2adda.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQR2ADDA.H instruction adds the PMQR2ADD.H result into the corresponding
-packed 32-bit elements of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -23377,6 +23377,10 @@ packed 32-bit elements of `rd`.
 
 <<<
 ==== MQACC.W00 (RV64)
+
+===== Mnemonic
+
+mqacc.w00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23397,6 +23401,12 @@ instruction operating on the low words of `rs1` and `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQACC.W00 instruction multiplies `rs1[31:0]` and `rs2[31:0]` as signed
+32-bit values, extracts bits [94:31] of the 95-bit product, and accumulates the
+extracted value into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23407,22 +23417,16 @@ q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqacc.w00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQACC.W00 instruction multiplies `rs1[31:0]` and `rs2[31:0]` as signed
-32-bit values, extracts bits [94:31] of the 95-bit product, and accumulates the
-extracted value into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQACC.W01 (RV64)
+
+===== Mnemonic
+
+mqacc.w01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23443,6 +23447,12 @@ instruction operating on the low word of `rs1` and the high word of `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQACC.W01 instruction multiplies `rs1[31:0]` by `rs2[63:32]` as signed
+32-bit values, extracts bits [94:31] of the product, and accumulates the result
+into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23453,22 +23463,16 @@ q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqacc.w01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQACC.W01 instruction multiplies `rs1[31:0]` by `rs2[63:32]` as signed
-32-bit values, extracts bits [94:31] of the product, and accumulates the result
-into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQACC.W11 (RV64)
+
+===== Mnemonic
+
+mqacc.w11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23489,6 +23493,12 @@ instruction operating on the high words of `rs1` and `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQACC.W11 instruction multiplies `rs1[63:32]` and `rs2[63:32]` as signed
+32-bit values, extracts bits [94:31] of the product, and accumulates the result
+into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23499,22 +23509,16 @@ q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqacc.w11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQACC.W11 instruction multiplies `rs1[63:32]` and `rs2[63:32]` as signed
-32-bit values, extracts bits [94:31] of the product, and accumulates the result
-into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQRACC.W00 (RV64)
+
+===== Mnemonic
+
+mqracc.w00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23535,6 +23539,12 @@ accumulate instruction operating on the low words of `rs1` and `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQRACC.W00 instruction is like MQACC.W00 but applies rounding by adding 2^30
+before extracting bits [94:31], and then accumulates the extracted value into
+`rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23545,16 +23555,6 @@ q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqracc.w00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQRACC.W00 instruction is like MQACC.W00 but applies rounding by adding 2^30
-before extracting bits [94:31], and then accumulates the extracted value into
-`rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -23562,6 +23562,10 @@ before extracting bits [94:31], and then accumulates the extracted value into
 
 <<<
 ==== MQRACC.W01 (RV64)
+
+===== Mnemonic
+
+mqracc.w01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23582,6 +23586,11 @@ accumulate instruction operating on `rs1[31:0]` and `rs2[63:32]`.
 ]}
 ....
 
+===== Description
+
+The MQRACC.W01 instruction is like MQACC.W01 but applies rounding by adding 2^30
+before extracting bits [94:31], and then accumulates into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23592,15 +23601,6 @@ q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqracc.w01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQRACC.W01 instruction is like MQACC.W01 but applies rounding by adding 2^30
-before extracting bits [94:31], and then accumulates into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -23608,6 +23608,10 @@ before extracting bits [94:31], and then accumulates into `rd`.
 
 <<<
 ==== MQRACC.W11 (RV64)
+
+===== Mnemonic
+
+mqracc.w11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23628,6 +23632,11 @@ accumulate instruction operating on the high words of `rs1` and `rs2`.
 ]}
 ....
 
+===== Description
+
+The MQRACC.W11 instruction is like MQACC.W11 but applies rounding by adding 2^30
+before extracting bits [94:31], and then accumulates into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23638,15 +23647,6 @@ q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Mnemonic
-
-mqracc.w11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The MQRACC.W11 instruction is like MQACC.W11 but applies rounding by adding 2^30
-before extracting bits [94:31], and then accumulates into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -23654,6 +23654,10 @@ before extracting bits [94:31], and then accumulates into `rd`.
 
 <<<
 ==== PMQ2ADD.W (RV64)
+
+===== Mnemonic
+
+pmq2add.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23674,6 +23678,11 @@ that sums two word products to produce a scalar XLEN result.
 ]}
 ....
 
+===== Description
+
+The PMQ2ADD.W instruction multiplies the low words and the high words of `rs1`
+and `rs2` as signed 32-bit values, extracts bits [94:31] from each product, and
+adds the two extracted values to produce the result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -23689,18 +23698,13 @@ q1 = (a1 * b1)[94:31]
 X[rd] = q0 + q1
 ----
 
-===== Mnemonic
-
-pmq2add.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQ2ADD.W instruction multiplies the low words and the high words of `rs1`
-and `rs2` as signed 32-bit values, extracts bits [94:31] from each product, and
-adds the two extracted values to produce the result in `rd`.
 
 <<<
 ==== PMQ2ADDA.W (RV64)
+
+===== Mnemonic
+
+pmq2adda.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23721,6 +23725,10 @@ PMQ2ADD.W.
 ]}
 ....
 
+===== Description
+
+The PMQ2ADDA.W instruction adds the PMQ2ADD.W result into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23736,20 +23744,16 @@ q1 = (a1 * b1)[94:31]
 X[rd] = X[rd] + q0 + q1
 ----
 
-===== Mnemonic
-
-pmq2adda.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQ2ADDA.W instruction adds the PMQ2ADD.W result into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMQR2ADD.W (RV64)
+
+===== Mnemonic
+
+pmqr2add.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23769,6 +23773,12 @@ PMQR2ADD.W is encoded in the OP-32 major opcode as a rounded form of PMQ2ADD.W.
 ]}
 ....
 
+===== Description
+
+The PMQR2ADD.W instruction is like PMQ2ADD.W but applies rounding by adding 2^30
+to each product before extracting bits [94:31], and then sums the two extracted
+values.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23784,22 +23794,16 @@ q1 = (a1 * b1 + 2^30)[94:31]
 X[rd] = q0 + q1
 ----
 
-===== Mnemonic
-
-pmqr2add.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQR2ADD.W instruction is like PMQ2ADD.W but applies rounding by adding 2^30
-to each product before extracting bits [94:31], and then sums the two extracted
-values.
-
 ===== Notes
 
 * Rounding is performed by adding 2^30.
 
 <<<
 ==== PMQR2ADDA.W (RV64)
+
+===== Mnemonic
+
+pmqr2adda.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23820,6 +23824,10 @@ PMQR2ADD.W.
 ]}
 ....
 
+===== Description
+
+The PMQR2ADDA.W instruction adds the PMQR2ADD.W result into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -23835,14 +23843,6 @@ q1 = (a1 * b1 + 2^30)[94:31]
 X[rd] = X[rd] + q0 + q1
 ----
 
-===== Mnemonic
-
-pmqr2adda.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMQR2ADDA.W instruction adds the PMQR2ADD.W result into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -23853,6 +23853,10 @@ The PMQR2ADDA.W instruction adds the PMQR2ADD.W result into `rd`.
 === Cross-element Multiply
 
 ==== PMUL.H.B00
+
+===== Mnemonic
+
+pmul.h.b00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23872,6 +23876,10 @@ PMUL.H.B00 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMUL.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` and `rs2` as
+signed 8-bit values and writes the 16-bit products to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -23887,17 +23895,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmul.h.b00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMUL.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` and `rs2` as
-signed 8-bit values and writes the 16-bit products to `rd`.
 
 <<<
 ==== PMUL.H.B01
+
+===== Mnemonic
+
+pmul.h.b01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23917,6 +23921,11 @@ PMUL.H.B01 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMUL.H.B01 multiplies the low byte of each 16-bit lane of `rs1` by the high byte
+of the corresponding lane of `rs2` (signed×signed), producing packed 16-bit
+products in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -23932,18 +23941,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmul.h.b01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMUL.H.B01 multiplies the low byte of each 16-bit lane of `rs1` by the high byte
-of the corresponding lane of `rs2` (signed×signed), producing packed 16-bit
-products in `rd`.
 
 <<<
 ==== PMUL.H.B11
+
+===== Mnemonic
+
+pmul.h.b11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -23963,6 +23967,10 @@ PMUL.H.B11 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMUL.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` and `rs2`
+as signed 8-bit values and writes packed 16-bit products to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -23978,17 +23986,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmul.h.b11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMUL.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` and `rs2`
-as signed 8-bit values and writes packed 16-bit products to `rd`.
 
 <<<
 ==== PMULSU.H.B00
+
+===== Mnemonic
+
+pmulsu.h.b00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24008,6 +24012,10 @@ PMULSU.H.B00 is encoded in the OP-32 major opcode using packed halfword elements
 ]}
 ....
 
+===== Description
+
+PMULSU.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` (signed) and
+`rs2` (unsigned), producing packed 16-bit products in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24023,17 +24031,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulsu.h.b00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULSU.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` (signed) and
-`rs2` (unsigned), producing packed 16-bit products in `rd`.
 
 <<<
 ==== PMULSU.H.B11
+
+===== Mnemonic
+
+pmulsu.h.b11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24053,6 +24057,10 @@ PMULSU.H.B11 is encoded in the OP-32 major opcode using packed halfword elements
 ]}
 ....
 
+===== Description
+
+PMULSU.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` (signed) and
+`rs2` (unsigned), producing packed 16-bit products in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24068,17 +24076,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulsu.h.b11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULSU.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` (signed) and
-`rs2` (unsigned), producing packed 16-bit products in `rd`.
 
 <<<
 ==== PMULU.H.B00
+
+===== Mnemonic
+
+pmulu.h.b00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24098,6 +24102,10 @@ PMULU.H.B00 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMULU.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` and `rs2`
+as unsigned 8-bit values, producing packed 16-bit products in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24113,17 +24121,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulu.h.b00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULU.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` and `rs2`
-as unsigned 8-bit values, producing packed 16-bit products in `rd`.
 
 <<<
 ==== PMULU.H.B01
+
+===== Mnemonic
+
+pmulu.h.b01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24143,6 +24147,11 @@ PMULU.H.B01 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMULU.H.B01 multiplies the low byte of each 16-bit lane of `rs1` by the high
+byte of the corresponding lane of `rs2` (unsigned×unsigned), producing packed
+16-bit products in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24158,18 +24167,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulu.h.b01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULU.H.B01 multiplies the low byte of each 16-bit lane of `rs1` by the high
-byte of the corresponding lane of `rs2` (unsigned×unsigned), producing packed
-16-bit products in `rd`.
 
 <<<
 ==== PMULU.H.B11
+
+===== Mnemonic
+
+pmulu.h.b11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24189,6 +24193,10 @@ PMULU.H.B11 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PMULU.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` and `rs2`
+as unsigned 8-bit values, producing packed 16-bit products in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24204,17 +24212,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulu.h.b11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULU.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` and `rs2`
-as unsigned 8-bit values, producing packed 16-bit products in `rd`.
 
 <<<
 ==== MUL.H00 (RV32)
+
+===== Mnemonic
+
+mul.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24234,6 +24238,11 @@ MUL.H00 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword mult
 ]}
 ....
 
+===== Description
+
+MUL.H00 multiplies the low 16-bit halfword (h0) of `rs1` by the low 16-bit
+halfword (h0) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24244,18 +24253,13 @@ s2_h0 = X[rs2][15:0]
 X[rd] = signed(s1_h0) * signed(s2_h0)
 ----
 
-===== Mnemonic
-
-mul.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MUL.H00 multiplies the low 16-bit halfword (h0) of `rs1` by the low 16-bit
-halfword (h0) of `rs2`, both treated as signed, producing a full 32-bit signed
-product that is written to `rd`.
 
 <<<
 ==== MUL.H01 (RV32)
+
+===== Mnemonic
+
+mul.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24275,6 +24279,11 @@ MUL.H01 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword mult
 ]}
 ....
 
+===== Description
+
+MUL.H01 multiplies the low 16-bit halfword (h0) of `rs1` by the high 16-bit
+halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24285,18 +24294,13 @@ s2_h1 = X[rs2][31:16]
 X[rd] = signed(s1_h0) * signed(s2_h1)
 ----
 
-===== Mnemonic
-
-mul.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MUL.H01 multiplies the low 16-bit halfword (h0) of `rs1` by the high 16-bit
-halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
-product that is written to `rd`.
 
 <<<
 ==== MUL.H11 (RV32)
+
+===== Mnemonic
+
+mul.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24316,6 +24320,11 @@ MUL.H11 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword mult
 ]}
 ....
 
+===== Description
+
+MUL.H11 multiplies the high 16-bit halfword (h1) of `rs1` by the high 16-bit
+halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24326,18 +24335,13 @@ s2_h1 = X[rs2][31:16]
 X[rd] = signed(s1_h1) * signed(s2_h1)
 ----
 
-===== Mnemonic
-
-mul.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MUL.H11 multiplies the high 16-bit halfword (h1) of `rs1` by the high 16-bit
-halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
-product that is written to `rd`.
 
 <<<
 ==== MULSU.H00 (RV32)
+
+===== Mnemonic
+
+mulsu.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24358,6 +24362,10 @@ MULSU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
+===== Description
+
+MULSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and writes
+the 32-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24367,17 +24375,13 @@ b = zext_32(X[rs2][15:0])
 X[rd] = to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-mulsu.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and writes
-the 32-bit product to `rd`.
 
 <<<
 ==== MULSU.H11 (RV32)
+
+===== Mnemonic
+
+mulsu.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24398,6 +24402,10 @@ MULSU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
+===== Description
+
+MULSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and writes
+the 32-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24407,17 +24415,13 @@ b = zext_32(X[rs2][31:16])
 X[rd] = to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-mulsu.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and writes
-the 32-bit product to `rd`.
 
 <<<
 ==== MULU.H00 (RV32)
+
+===== Mnemonic
+
+mulu.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24438,6 +24442,10 @@ MULU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
+===== Description
+
+MULU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and writes
+the 32-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24447,17 +24455,13 @@ b = zext_32(X[rs2][15:0])
 X[rd] = to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-mulu.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and writes
-the 32-bit product to `rd`.
 
 <<<
 ==== MULU.H01 (RV32)
+
+===== Mnemonic
+
+mulu.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24478,6 +24482,10 @@ MULU.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
+===== Description
+
+MULU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and writes
+the 32-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24487,17 +24495,13 @@ b = zext_32(X[rs2][31:16])
 X[rd] = to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-mulu.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and writes
-the 32-bit product to `rd`.
 
 <<<
 ==== MULU.H11 (RV32)
+
+===== Mnemonic
+
+mulu.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24518,6 +24522,10 @@ MULU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
+===== Description
+
+MULU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
+writes the 32-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24527,17 +24535,13 @@ b = zext_32(X[rs2][31:16])
 X[rd] = to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-mulu.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
-writes the 32-bit product to `rd`.
 
 <<<
 ==== PMUL.W.H00 (RV64)
+
+===== Mnemonic
+
+pmul.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24557,6 +24561,12 @@ PMUL.W.H00 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
+===== Description
+
+PMUL.W.H00 multiplies the low halfword (h0) of each packed 32-bit word element
+in `rs1` by the low halfword (h0) of the corresponding word element in `rs2`,
+both treated as signed, producing a 32-bit product per element that is written
+to the corresponding word of `rd`. This instruction is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -24569,19 +24579,13 @@ d_w1 = signed(s1[47:32]) * signed(s2[47:32])
 X[rd] = d_w1 @ d_w0
 ----
 
-===== Mnemonic
-
-pmul.w.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMUL.W.H00 multiplies the low halfword (h0) of each packed 32-bit word element
-in `rs1` by the low halfword (h0) of the corresponding word element in `rs2`,
-both treated as signed, producing a 32-bit product per element that is written
-to the corresponding word of `rd`. This instruction is available only on RV64.
 
 <<<
 ==== PMUL.W.H01 (RV64)
+
+===== Mnemonic
+
+pmul.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24601,6 +24605,12 @@ PMUL.W.H01 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
+===== Description
+
+PMUL.W.H01 multiplies the low halfword (h0) of each packed 32-bit word element
+in `rs1` by the high halfword (h1) of the corresponding word element in `rs2`,
+both treated as signed, producing a 32-bit product per element that is written
+to the corresponding word of `rd`. This instruction is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -24613,19 +24623,13 @@ d_w1 = signed(s1[47:32]) * signed(s2[63:48])
 X[rd] = d_w1 @ d_w0
 ----
 
-===== Mnemonic
-
-pmul.w.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMUL.W.H01 multiplies the low halfword (h0) of each packed 32-bit word element
-in `rs1` by the high halfword (h1) of the corresponding word element in `rs2`,
-both treated as signed, producing a 32-bit product per element that is written
-to the corresponding word of `rd`. This instruction is available only on RV64.
 
 <<<
 ==== PMUL.W.H11 (RV64)
+
+===== Mnemonic
+
+pmul.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24645,6 +24649,13 @@ PMUL.W.H11 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
+===== Description
+
+PMUL.W.H11 multiplies the high halfword (h1) of each packed 32-bit word
+element in `rs1` by the high halfword (h1) of the corresponding word element in
+`rs2`, both treated as signed, producing a 32-bit product per element that is
+written to the corresponding word of `rd`. This instruction is available only
+on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -24657,20 +24668,13 @@ d_w1 = signed(s1[63:48]) * signed(s2[63:48])
 X[rd] = d_w1 @ d_w0
 ----
 
-===== Mnemonic
-
-pmul.w.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMUL.W.H11 multiplies the high halfword (h1) of each packed 32-bit word
-element in `rs1` by the high halfword (h1) of the corresponding word element in
-`rs2`, both treated as signed, producing a 32-bit product per element that is
-written to the corresponding word of `rd`. This instruction is available only
-on RV64.
 
 <<<
 ==== PMULSU.W.H00 (RV64)
+
+===== Mnemonic
+
+pmulsu.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24691,6 +24695,10 @@ elements from halfword operands (signed×unsigned).
 ]}
 ....
 
+===== Description
+
+PMULSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
+and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24704,17 +24712,13 @@ d1 = to_bits(32, sext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmulsu.w.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
-and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
 
 <<<
 ==== PMULSU.W.H11 (RV64)
+
+===== Mnemonic
+
+pmulsu.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24735,6 +24739,10 @@ elements from halfword operands (signed×unsigned).
 ]}
 ....
 
+===== Description
+
+PMULSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
+and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24748,17 +24756,13 @@ d1 = to_bits(32, sext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmulsu.w.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
-and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
 
 <<<
 ==== PMULU.W.H00 (RV64)
+
+===== Mnemonic
+
+pmulu.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24779,6 +24783,10 @@ elements from halfword operands (unsigned×unsigned).
 ]}
 ....
 
+===== Description
+
+PMULU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2` as
+unsigned values and writes packed 32-bit products to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24792,17 +24800,13 @@ d1 = to_bits(32, zext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmulu.w.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2` as
-unsigned values and writes packed 32-bit products to `rd`.
 
 <<<
 ==== PMULU.W.H01 (RV64)
+
+===== Mnemonic
+
+pmulu.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24823,6 +24827,10 @@ elements from halfword operands (unsigned×unsigned).
 ]}
 ....
 
+===== Description
+
+PMULU.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
+halfword of `rs2` (unsigned×unsigned) and writes packed 32-bit products to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24836,17 +24844,13 @@ d1 = to_bits(32, zext_32(s1[47:32]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmulu.w.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULU.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
-halfword of `rs2` (unsigned×unsigned) and writes packed 32-bit products to `rd`.
 
 <<<
 ==== PMULU.W.H11 (RV64)
+
+===== Mnemonic
+
+pmulu.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24867,6 +24871,10 @@ elements from halfword operands (unsigned×unsigned).
 ]}
 ....
 
+===== Description
+
+PMULU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
+as unsigned values and writes packed 32-bit products to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -24880,17 +24888,13 @@ d1 = to_bits(32, zext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmulu.w.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
-as unsigned values and writes packed 32-bit products to `rd`.
 
 <<<
 ==== MUL.W00 (RV64)
+
+===== Mnemonic
+
+mul.w00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24910,6 +24914,11 @@ MUL.W00 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only
 ]}
 ....
 
+===== Description
+
+MUL.W00 multiplies the low 32-bit word (w0) of `rs1` by the low 32-bit word
+(w0) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -24920,18 +24929,13 @@ s2_w0 = X[rs2][31:0]
 X[rd] = signed(s1_w0) * signed(s2_w0)
 ----
 
-===== Mnemonic
-
-mul.w00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MUL.W00 multiplies the low 32-bit word (w0) of `rs1` by the low 32-bit word
-(w0) of `rs2`, both treated as signed, producing a full 64-bit signed product
-that is written to `rd`. This instruction is available only on RV64.
 
 <<<
 ==== MUL.W01 (RV64)
+
+===== Mnemonic
+
+mul.w01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24951,6 +24955,11 @@ MUL.W01 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only
 ]}
 ....
 
+===== Description
+
+MUL.W01 multiplies the low 32-bit word (w0) of `rs1` by the high 32-bit word
+(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -24961,18 +24970,13 @@ s2_w1 = X[rs2][63:32]
 X[rd] = signed(s1_w0) * signed(s2_w1)
 ----
 
-===== Mnemonic
-
-mul.w01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MUL.W01 multiplies the low 32-bit word (w0) of `rs1` by the high 32-bit word
-(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
-that is written to `rd`. This instruction is available only on RV64.
 
 <<<
 ==== MUL.W11 (RV64)
+
+===== Mnemonic
+
+mul.w11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -24992,6 +24996,11 @@ MUL.W11 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only
 ]}
 ....
 
+===== Description
+
+MUL.W11 multiplies the high 32-bit word (w1) of `rs1` by the high 32-bit word
+(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -25002,18 +25011,13 @@ s2_w1 = X[rs2][63:32]
 X[rd] = signed(s1_w1) * signed(s2_w1)
 ----
 
-===== Mnemonic
-
-mul.w11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MUL.W11 multiplies the high 32-bit word (w1) of `rs1` by the high 32-bit word
-(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
-that is written to `rd`. This instruction is available only on RV64.
 
 <<<
 ==== MULSU.W00 (RV64)
+
+===== Mnemonic
+
+mulsu.w00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25034,6 +25038,10 @@ MULSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
+===== Description
+
+MULSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and writes
+the 64-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -25043,17 +25051,13 @@ b = zext_64(X[rs2][31:0])
 X[rd] = to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-mulsu.w00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and writes
-the 64-bit product to `rd`.
 
 <<<
 ==== MULSU.W11 (RV64)
+
+===== Mnemonic
+
+mulsu.w11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25074,6 +25078,10 @@ MULSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
+===== Description
+
+MULSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and writes
+the 64-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -25083,17 +25091,13 @@ b = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-mulsu.w11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and writes
-the 64-bit product to `rd`.
 
 <<<
 ==== MULU.W00 (RV64)
+
+===== Mnemonic
+
+mulu.w00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25114,6 +25118,10 @@ MULU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
+===== Description
+
+MULU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
+writes the 64-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -25123,17 +25131,13 @@ b = zext_64(X[rs2][31:0])
 X[rd] = to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-mulu.w00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
-writes the 64-bit product to `rd`.
 
 <<<
 ==== MULU.W01 (RV64)
+
+===== Mnemonic
+
+mulu.w01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25154,6 +25158,10 @@ MULU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
+===== Description
+
+MULU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
+writes the 64-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -25163,17 +25171,13 @@ b = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-mulu.w01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
-writes the 64-bit product to `rd`.
 
 <<<
 ==== MULU.W11 (RV64)
+
+===== Mnemonic
+
+mulu.w11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25194,6 +25198,10 @@ MULU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
+===== Description
+
+MULU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
+writes the 64-bit product to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -25203,20 +25211,16 @@ b = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-mulu.w11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
-writes the 64-bit product to `rd`.
 
 
 <<<
 === Cross-element Multiply-Accumulate
 
 ==== MACC.H00 (RV32)
+
+===== Mnemonic
+
+macc.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25237,6 +25241,11 @@ accumulate (signed×signed).
 ]}
 ....
 
+===== Description
+
+MACC.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as signed halfwords and adds the
+32-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25246,21 +25255,16 @@ b = sext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-macc.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACC.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as signed halfwords and adds the
-32-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.H01 (RV32)
+
+===== Mnemonic
+
+macc.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25281,6 +25285,11 @@ accumulate (signed×signed).
 ]}
 ....
 
+===== Description
+
+MACC.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as signed halfwords and adds the
+32-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25290,21 +25299,16 @@ b = sext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-macc.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACC.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as signed halfwords and adds the
-32-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.H11 (RV32)
+
+===== Mnemonic
+
+macc.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25325,6 +25329,11 @@ accumulate (signed×signed).
 ]}
 ....
 
+===== Description
+
+MACC.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as signed halfwords and adds
+the 32-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25334,21 +25343,16 @@ b = sext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-macc.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACC.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as signed halfwords and adds
-the 32-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCSU.H00 (RV32)
+
+===== Mnemonic
+
+maccsu.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25369,6 +25373,11 @@ accumulate (signed×unsigned).
 ]}
 ....
 
+===== Description
+
+MACCSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and adds
+the 32-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25378,21 +25387,16 @@ b = zext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-maccsu.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and adds
-the 32-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCSU.H11 (RV32)
+
+===== Mnemonic
+
+maccsu.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25413,6 +25417,11 @@ accumulate (signed×unsigned).
 ]}
 ....
 
+===== Description
+
+MACCSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and adds
+the 32-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25422,21 +25431,16 @@ b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-maccsu.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and adds
-the 32-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.H00 (RV32)
+
+===== Mnemonic
+
+maccu.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25457,6 +25461,11 @@ accumulate (unsigned×unsigned).
 ]}
 ....
 
+===== Description
+
+MACCU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and adds
+the 32-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25466,21 +25475,16 @@ b = zext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-maccu.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and adds
-the 32-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.H01 (RV32)
+
+===== Mnemonic
+
+maccu.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25501,6 +25505,11 @@ accumulate (unsigned×unsigned).
 ]}
 ....
 
+===== Description
+
+MACCU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and adds
+the 32-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25510,21 +25519,16 @@ b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-maccu.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and adds
-the 32-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.H11 (RV32)
+
+===== Mnemonic
+
+maccu.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25545,6 +25549,11 @@ accumulate (unsigned×unsigned).
 ]}
 ....
 
+===== Description
+
+MACCU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
+adds the 32-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25554,21 +25563,16 @@ b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Mnemonic
-
-maccu.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
-adds the 32-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACC.W.H00 (RV64)
+
+===== Mnemonic
+
+pmacc.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25589,6 +25593,11 @@ instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+PMACC.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2` as
+signed values and accumulates the 32-bit products into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25603,21 +25612,16 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * sext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmacc.w.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMACC.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2` as
-signed values and accumulates the 32-bit products into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACC.W.H01 (RV64)
+
+===== Mnemonic
+
+pmacc.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25638,6 +25642,11 @@ instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+PMACC.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
+halfword of `rs2` (signed×signed) and accumulates the 32-bit products into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25652,21 +25661,16 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * sext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmacc.w.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMACC.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
-halfword of `rs2` (signed×signed) and accumulates the 32-bit products into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACC.W.H11 (RV64)
+
+===== Mnemonic
+
+pmacc.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25687,6 +25691,11 @@ instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+PMACC.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
+as signed values and accumulates the 32-bit products into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25701,21 +25710,16 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[63:48]) * sext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmacc.w.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMACC.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
-as signed values and accumulates the 32-bit products into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCSU.W.H00 (RV64)
+
+===== Mnemonic
+
+pmaccsu.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25736,6 +25740,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+PMACCSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
+and `rs2` (unsigned) and accumulates the 32-bit products into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25750,21 +25759,16 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmaccsu.w.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMACCSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
-and `rs2` (unsigned) and accumulates the 32-bit products into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCSU.W.H11 (RV64)
+
+===== Mnemonic
+
+pmaccsu.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25785,6 +25789,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+PMACCSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
+and `rs2` (unsigned) and accumulates the 32-bit products into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25799,21 +25808,16 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmaccsu.w.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMACCSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
-and `rs2` (unsigned) and accumulates the 32-bit products into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCU.W.H00 (RV64)
+
+===== Mnemonic
+
+pmaccu.w.h00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25834,6 +25838,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+PMACCU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2`
+as unsigned values and accumulates the 32-bit products into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25848,21 +25857,16 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmaccu.w.h00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMACCU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2`
-as unsigned values and accumulates the 32-bit products into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCU.W.H01 (RV64)
+
+===== Mnemonic
+
+pmaccu.w.h01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25883,6 +25887,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+PMACCU.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
+halfword of `rs2` (unsigned×unsigned) and accumulates the 32-bit products into
+`rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25897,22 +25907,16 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[47:32]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmaccu.w.h01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMACCU.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
-halfword of `rs2` (unsigned×unsigned) and accumulates the 32-bit products into
-`rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCU.W.H11 (RV64)
+
+===== Mnemonic
+
+pmaccu.w.h11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25933,6 +25937,11 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
+===== Description
+
+PMACCU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
+as unsigned values and accumulates the 32-bit products into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25947,21 +25956,16 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmaccu.w.h11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMACCU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
-as unsigned values and accumulates the 32-bit products into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.W00 (RV64)
+
+===== Mnemonic
+
+macc.w00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -25982,6 +25986,11 @@ accumulate (signed×signed) producing a 64-bit result.
 ]}
 ....
 
+===== Description
+
+MACC.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as signed 32-bit values and adds
+the 64-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -25991,21 +26000,16 @@ b = sext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-macc.w00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACC.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as signed 32-bit values and adds
-the 64-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.W01 (RV64)
+
+===== Mnemonic
+
+macc.w01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26026,6 +26030,11 @@ accumulate (signed×signed) producing a 64-bit result.
 ]}
 ....
 
+===== Description
+
+MACC.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as signed 32-bit values and adds
+the 64-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26035,21 +26044,16 @@ b = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-macc.w01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACC.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as signed 32-bit values and adds
-the 64-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.W11 (RV64)
+
+===== Mnemonic
+
+macc.w11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26070,6 +26074,11 @@ accumulate (signed×signed) producing a 64-bit result.
 ]}
 ....
 
+===== Description
+
+MACC.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as signed 32-bit values and
+adds the 64-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26079,21 +26088,16 @@ b = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-macc.w11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACC.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as signed 32-bit values and
-adds the 64-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCSU.W00 (RV64)
+
+===== Mnemonic
+
+maccsu.w00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26114,6 +26118,11 @@ accumulate (signed×unsigned) producing a 64-bit result.
 ]}
 ....
 
+===== Description
+
+MACCSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and adds the
+64-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26123,21 +26132,16 @@ b = zext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-maccsu.w00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and adds the
-64-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCSU.W11 (RV64)
+
+===== Mnemonic
+
+maccsu.w11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26158,6 +26162,11 @@ accumulate (signed×unsigned) producing a 64-bit result.
 ]}
 ....
 
+===== Description
+
+MACCSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and adds
+the 64-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26167,21 +26176,16 @@ b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-maccsu.w11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and adds
-the 64-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.W00 (RV64)
+
+===== Mnemonic
+
+maccu.w00 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26202,6 +26206,11 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
 ]}
 ....
 
+===== Description
+
+MACCU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
+adds the 64-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26211,21 +26220,16 @@ b = zext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-maccu.w00 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
-adds the 64-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.W01 (RV64)
+
+===== Mnemonic
+
+maccu.w01 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26246,6 +26250,11 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
 ]}
 ....
 
+===== Description
+
+MACCU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
+adds the 64-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26255,21 +26264,16 @@ b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Mnemonic
-
-maccu.w01 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
-adds the 64-bit product to `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.W11 (RV64)
+
+===== Mnemonic
+
+maccu.w11 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26290,6 +26294,11 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
 ]}
 ....
 
+===== Description
+
+MACCU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
+adds the 64-bit product to `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26298,15 +26307,6 @@ a = zext_64(X[rs1][63:32])
 b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
-
-===== Mnemonic
-
-maccu.w11 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MACCU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
-adds the 64-bit product to `rd`.
 
 ===== Notes
 
@@ -26317,6 +26317,10 @@ adds the 64-bit product to `rd`.
 === PM2 Horizontal Multiply-Add/Subtract
 
 ==== PM2ADD.H
+
+===== Mnemonic
+
+pm2add.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26337,6 +26341,11 @@ producing packed 32-bit results (one per halfword pair).
 ]}
 ....
 
+===== Description
+
+The PM2ADD.H instruction multiplies corresponding packed halfwords in each
+32-bit lane (low×low and high×high), and adds the two 32-bit products to form
+each packed 32-bit result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -26356,18 +26365,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2add.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2ADD.H instruction multiplies corresponding packed halfwords in each
-32-bit lane (low×low and high×high), and adds the two 32-bit products to form
-each packed 32-bit result in `rd`.
 
 <<<
 ==== PM2ADDA.H
+
+===== Mnemonic
+
+pm2adda.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26388,6 +26392,11 @@ PM2ADD.H.
 ]}
 ....
 
+===== Description
+
+The PM2ADDA.H instruction adds the PM2ADD.H result into the corresponding packed
+32-bit elements of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26408,21 +26417,16 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2adda.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2ADDA.H instruction adds the PM2ADD.H result into the corresponding packed
-32-bit elements of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADDSU.H
+
+===== Mnemonic
+
+pm2addsu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26443,6 +26447,11 @@ performing signed×unsigned multiplies per halfword pair.
 ]}
 ....
 
+===== Description
+
+The PM2ADDSU.H instruction performs signed×unsigned halfword multiplications
+(low×low and high×high within each 32-bit lane) and sums the two 32-bit products
+to produce each packed 32-bit result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -26462,18 +26471,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2addsu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2ADDSU.H instruction performs signed×unsigned halfword multiplications
-(low×low and high×high within each 32-bit lane) and sums the two 32-bit products
-to produce each packed 32-bit result in `rd`.
 
 <<<
 ==== PM2ADDASU.H
+
+===== Mnemonic
+
+pm2addasu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26494,6 +26498,11 @@ PM2ADDSU.H.
 ]}
 ....
 
+===== Description
+
+The PM2ADDASU.H instruction adds the PM2ADDSU.H result into the corresponding
+packed 32-bit elements of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26514,21 +26523,16 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2addasu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2ADDASU.H instruction adds the PM2ADDSU.H result into the corresponding
-packed 32-bit elements of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADDU.H
+
+===== Mnemonic
+
+pm2addu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26549,6 +26553,11 @@ performing unsigned×unsigned multiplies per halfword pair.
 ]}
 ....
 
+===== Description
+
+The PM2ADDU.H instruction performs unsigned×unsigned halfword multiplications
+(low×low and high×high within each 32-bit lane) and sums the two 32-bit products
+to produce each packed 32-bit result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -26568,18 +26577,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2addu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2ADDU.H instruction performs unsigned×unsigned halfword multiplications
-(low×low and high×high within each 32-bit lane) and sums the two 32-bit products
-to produce each packed 32-bit result in `rd`.
 
 <<<
 ==== PM2ADDAU.H
+
+===== Mnemonic
+
+pm2addau.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26599,6 +26603,11 @@ PM2ADDU.H.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The PM2ADDAU.H instruction adds the PM2ADDU.H result into the corresponding
+packed 32-bit elements of `rd`.
 
 ===== Operation
 
@@ -26620,21 +26629,16 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2addau.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2ADDAU.H instruction adds the PM2ADDU.H result into the corresponding
-packed 32-bit elements of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADD.HX
+
+===== Mnemonic
+
+pm2add.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26655,6 +26659,11 @@ producing packed 32-bit results from cross products (low×high and high×low).
 ]}
 ....
 
+===== Description
+
+The PM2ADD.HX instruction multiplies cross halfword pairs within each 32-bit
+lane (low of `rs1` × high of `rs2`, and high of `rs1` × low of `rs2`) and sums the
+two 32-bit products to produce each packed 32-bit result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -26674,18 +26683,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2add.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2ADD.HX instruction multiplies cross halfword pairs within each 32-bit
-lane (low of `rs1` × high of `rs2`, and high of `rs1` × low of `rs2`) and sums the
-two 32-bit products to produce each packed 32-bit result in `rd`.
 
 <<<
 ==== PM2ADDA.HX
+
+===== Mnemonic
+
+pm2adda.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26705,6 +26709,11 @@ PM2ADD.HX.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The PM2ADDA.HX instruction adds the PM2ADD.HX result into the corresponding
+packed 32-bit elements of `rd`.
 
 ===== Operation
 
@@ -26726,21 +26735,16 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2adda.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2ADDA.HX instruction adds the PM2ADD.HX result into the corresponding
-packed 32-bit elements of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUBA.H
+
+===== Mnemonic
+
+pm2suba.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26760,6 +26764,11 @@ multiply-add-subtract instruction using packed halfword operands.
     { bits: 1, name: 0x1 },
 ]}
 ....
+
+===== Description
+
+The PM2SUBA.H instruction updates each packed 32-bit element of `rd` by adding
+the low×low halfword product and subtracting the high×high halfword product.
 
 ===== Operation
 
@@ -26781,21 +26790,16 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2suba.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2SUBA.H instruction updates each packed 32-bit element of `rd` by adding
-the low×low halfword product and subtracting the high×high halfword product.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUBA.HX
+
+===== Mnemonic
+
+pm2suba.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26817,6 +26821,11 @@ products.
 ]}
 ....
 
+===== Description
+
+The PM2SUBA.HX instruction updates each packed 32-bit element of `rd` by adding
+the low×high cross product and subtracting the high×low cross product.
+
 ===== Operation
 
 [source,pseudocode]
@@ -26837,21 +26846,16 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2suba.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM2SUBA.HX instruction updates each packed 32-bit element of `rd` by adding
-the low×high cross product and subtracting the high×low cross product.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUB.H
+
+===== Mnemonic
+
+pm2sub.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26871,6 +26875,12 @@ PM2SUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
+===== Description
+
+PM2SUB.H multiplies two pairs of signed 16-bit halfword elements from `rs1` and
+`rs2` within each 32-bit group, then subtracts the upper product from the lower
+product. The 32-bit difference for each group is written to the corresponding
+32-bit position in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -26892,19 +26902,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2sub.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2SUB.H multiplies two pairs of signed 16-bit halfword elements from `rs1` and
-`rs2` within each 32-bit group, then subtracts the upper product from the lower
-product. The 32-bit difference for each group is written to the corresponding
-32-bit position in `rd`.
 
 <<<
 ==== PM2SUB.HX
+
+===== Mnemonic
+
+pm2sub.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26925,6 +26929,14 @@ and crossed operands.
 ]}
 ....
 
+===== Description
+
+PM2SUB.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
+and `rs2` within each 32-bit group using crossed `rs2` operands, then subtracts
+the upper product from the lower product. The lower halfword of `rs1` is
+multiplied with the upper halfword of `rs2`, and vice versa. The 32-bit
+difference for each group is written to the corresponding 32-bit position
+in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -26946,21 +26958,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2sub.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2SUB.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
-and `rs2` within each 32-bit group using crossed `rs2` operands, then subtracts
-the upper product from the lower product. The lower halfword of `rs1` is
-multiplied with the upper halfword of `rs2`, and vice versa. The 32-bit
-difference for each group is written to the corresponding 32-bit position
-in `rd`.
 
 <<<
 ==== PM2SADD.H
+
+===== Mnemonic
+
+pm2sadd.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -26981,6 +26985,12 @@ and saturating addition.
 ]}
 ....
 
+===== Description
+
+PM2SADD.H multiplies two pairs of signed 16-bit halfword elements from `rs1`
+and `rs2` within each 32-bit group, sums the two products, and saturates the
+result to the signed 32-bit range [-2^31, 2^31-1]. The saturated 32-bit result
+for each group is written to the corresponding 32-bit position in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27001,19 +27011,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2sadd.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2SADD.H multiplies two pairs of signed 16-bit halfword elements from `rs1`
-and `rs2` within each 32-bit group, sums the two products, and saturates the
-result to the signed 32-bit range [-2^31, 2^31-1]. The saturated 32-bit result
-for each group is written to the corresponding 32-bit position in `rd`.
 
 <<<
 ==== PM2SADD.HX
+
+===== Mnemonic
+
+pm2sadd.hx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27034,6 +27038,14 @@ crossed operands, and saturating addition.
 ]}
 ....
 
+===== Description
+
+PM2SADD.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
+and `rs2` within each 32-bit group using crossed `rs2` operands, sums the two
+products, and saturates the result to the signed 32-bit range [-2^31, 2^31-1].
+The lower halfword of `rs1` is multiplied with the upper halfword of `rs2`, and
+vice versa. The saturated 32-bit result for each group is written to the
+corresponding 32-bit position in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27054,21 +27066,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm2sadd.hx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2SADD.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
-and `rs2` within each 32-bit group using crossed `rs2` operands, sums the two
-products, and saturates the result to the signed 32-bit range [-2^31, 2^31-1].
-The lower halfword of `rs1` is multiplied with the upper halfword of `rs2`, and
-vice versa. The saturated 32-bit result for each group is written to the
-corresponding 32-bit position in `rd`.
 
 <<<
 ==== PM2ADD.W (RV64)
+
+===== Mnemonic
+
+pm2add.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27089,6 +27093,10 @@ instruction producing a scalar 64-bit result.
 ]}
 ....
 
+===== Description
+
+PM2ADD.W multiplies the low words and high words of `rs1` and `rs2` as signed
+32-bit values and adds the two 64-bit products to produce the result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27101,17 +27109,13 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
-===== Mnemonic
-
-pm2add.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2ADD.W multiplies the low words and high words of `rs1` and `rs2` as signed
-32-bit values and adds the two 64-bit products to produce the result in `rd`.
 
 <<<
 ==== PM2ADDA.W (RV64)
+
+===== Mnemonic
+
+pm2adda.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27131,6 +27135,11 @@ PM2ADDA.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 ]}
 ....
 
+===== Description
+
+PM2ADDA.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
+`rs1` and `rs2`, sums the two 64-bit products, and accumulates the result into
+`rd`. This instruction is the accumulating variant of PM2ADD.W.
 ===== Operation
 
 [source,pseudocode]
@@ -27145,18 +27154,13 @@ X[rd] = X[rd]
       + sext64(signed(s1[63:32]) * signed(s2[63:32]))
 ----
 
-===== Mnemonic
-
-pm2adda.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2ADDA.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
-`rs1` and `rs2`, sums the two 64-bit products, and accumulates the result into
-`rd`. This instruction is the accumulating variant of PM2ADD.W.
 
 <<<
 ==== PM2ADDSU.W (RV64)
+
+===== Mnemonic
+
+pm2addsu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27177,6 +27181,10 @@ signed×unsigned multiply-add instruction.
 ]}
 ....
 
+===== Description
+
+PM2ADDSU.W multiplies corresponding word pairs as signed×unsigned (low×low and
+high×high) and adds the two 64-bit products to produce the result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27189,17 +27197,13 @@ b1 = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
-===== Mnemonic
-
-pm2addsu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2ADDSU.W multiplies corresponding word pairs as signed×unsigned (low×low and
-high×high) and adds the two 64-bit products to produce the result in `rd`.
 
 <<<
 ==== PM2ADDASU.W (RV64)
+
+===== Mnemonic
+
+pm2addasu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27220,6 +27224,10 @@ PM2ADDSU.W.
 ]}
 ....
 
+===== Description
+
+PM2ADDASU.W adds the PM2ADDSU.W result into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -27232,20 +27240,16 @@ b1 = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
-===== Mnemonic
-
-pm2addasu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2ADDASU.W adds the PM2ADDSU.W result into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADDU.W (RV64)
+
+===== Mnemonic
+
+pm2addu.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27266,6 +27270,10 @@ unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
 ]}
 ....
 
+===== Description
+
+PM2ADDU.W multiplies corresponding word pairs as unsigned×unsigned and adds the
+two 64-bit products to produce the result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27278,17 +27286,13 @@ b1 = zext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
-===== Mnemonic
-
-pm2addu.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2ADDU.W multiplies corresponding word pairs as unsigned×unsigned and adds the
-two 64-bit products to produce the result in `rd`.
 
 <<<
 ==== PM2ADDAU.W (RV64)
+
+===== Mnemonic
+
+pm2addau.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27308,6 +27312,11 @@ PM2ADDAU.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 ]}
 ....
 
+===== Description
+
+PM2ADDAU.W (RV64 only) multiplies two pairs of unsigned 32-bit word elements
+from `rs1` and `rs2`, sums the two 64-bit products, and accumulates the result
+into `rd`. This instruction is the unsigned accumulating variant of PM2ADDU.W.
 ===== Operation
 
 [source,pseudocode]
@@ -27322,18 +27331,13 @@ X[rd] = X[rd]
       + zext64(unsigned(s1[63:32]) * unsigned(s2[63:32]))
 ----
 
-===== Mnemonic
-
-pm2addau.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2ADDAU.W (RV64 only) multiplies two pairs of unsigned 32-bit word elements
-from `rs1` and `rs2`, sums the two 64-bit products, and accumulates the result
-into `rd`. This instruction is the unsigned accumulating variant of PM2ADDU.W.
 
 <<<
 ==== PM2ADD.WX (RV64)
+
+===== Mnemonic
+
+pm2add.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27354,6 +27358,10 @@ instruction using cross products.
 ]}
 ....
 
+===== Description
+
+PM2ADD.WX multiplies cross word pairs (low of `rs1` × high of `rs2`, and high of
+`rs1` × low of `rs2`) as signed values and sums the two 64-bit products.
 ===== Operation
 
 [source,pseudocode]
@@ -27366,17 +27374,13 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
 ----
 
-===== Mnemonic
-
-pm2add.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2ADD.WX multiplies cross word pairs (low of `rs1` × high of `rs2`, and high of
-`rs1` × low of `rs2`) as signed values and sums the two 64-bit products.
 
 <<<
 ==== PM2ADDA.WX (RV64)
+
+===== Mnemonic
+
+pm2adda.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27397,6 +27401,10 @@ PM2ADD.WX.
 ]}
 ....
 
+===== Description
+
+PM2ADDA.WX adds the PM2ADD.WX result into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -27409,20 +27417,16 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
 ----
 
-===== Mnemonic
-
-pm2adda.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2ADDA.WX adds the PM2ADD.WX result into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUBA.W (RV64)
+
+===== Mnemonic
+
+pm2suba.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27443,6 +27447,11 @@ multiply-add-subtract instruction using packed word pairs.
 ]}
 ....
 
+===== Description
+
+PM2SUBA.W updates `rd` by adding the low×low signed word product and subtracting
+the high×high signed word product.
+
 ===== Operation
 
 [source,pseudocode]
@@ -27455,21 +27464,16 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b0) - to_bits(64, a1 * b1)
 ----
 
-===== Mnemonic
-
-pm2suba.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2SUBA.W updates `rd` by adding the low×low signed word product and subtracting
-the high×high signed word product.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUBA.WX (RV64)
+
+===== Mnemonic
+
+pm2suba.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27490,6 +27494,11 @@ multiply-add-subtract instruction using cross word products.
 ]}
 ....
 
+===== Description
+
+PM2SUBA.WX updates `rd` by adding the low×high signed word product and
+subtracting the high×low signed word product.
+
 ===== Operation
 
 [source,pseudocode]
@@ -27502,15 +27511,6 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b1) - to_bits(64, a1 * b0)
 ----
 
-===== Mnemonic
-
-pm2suba.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2SUBA.WX updates `rd` by adding the low×high signed word product and
-subtracting the high×low signed word product.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -27518,6 +27518,10 @@ subtracting the high×low signed word product.
 
 <<<
 ==== PM2SUB.W (RV64)
+
+===== Mnemonic
+
+pm2sub.w _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27537,6 +27541,11 @@ PM2SUB.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 ]}
 ....
 
+===== Description
+
+PM2SUB.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
+`rs1` and `rs2`, then subtracts the upper product from the lower product. The
+64-bit difference is written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27550,18 +27559,13 @@ X[rd] = sext64(signed(s1[31:0])  * signed(s2[31:0]))
       - sext64(signed(s1[63:32]) * signed(s2[63:32]))
 ----
 
-===== Mnemonic
-
-pm2sub.w _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2SUB.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
-`rs1` and `rs2`, then subtracts the upper product from the lower product. The
-64-bit difference is written to `rd`.
 
 <<<
 ==== PM2SUB.WX (RV64)
+
+===== Mnemonic
+
+pm2sub.wx _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27582,6 +27586,12 @@ operands (RV64 only).
 ]}
 ....
 
+===== Description
+
+PM2SUB.WX (RV64 only) multiplies two pairs of signed 32-bit word elements from
+`rs1` and `rs2` using crossed `rs2` operands, then subtracts the upper product
+from the lower product. The lower word of `rs1` is multiplied with the upper
+word of `rs2`, and vice versa. The 64-bit difference is written to `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27595,21 +27605,15 @@ X[rd] = sext64(signed(s1[31:0])  * signed(s2[63:32]))
       - sext64(signed(s1[63:32]) * signed(s2[31:0]))
 ----
 
-===== Mnemonic
-
-pm2sub.wx _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM2SUB.WX (RV64 only) multiplies two pairs of signed 32-bit word elements from
-`rs1` and `rs2` using crossed `rs2` operands, then subtracts the upper product
-from the lower product. The lower word of `rs1` is multiplied with the upper
-word of `rs2`, and vice versa. The 64-bit difference is written to `rd`.
 
 <<<
 === PM4 Horizontal Multiply-Add
 
 ==== PM4ADD.B
+
+===== Mnemonic
+
+pm4add.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27630,6 +27634,11 @@ producing packed 32-bit results (one per 4-byte group).
 ]}
 ....
 
+===== Description
+
+The PM4ADD.B instruction multiplies corresponding packed bytes within each
+32-bit lane as signed values and sums the four 32-bit products to produce one
+packed 32-bit result per lane in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27654,18 +27663,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm4add.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM4ADD.B instruction multiplies corresponding packed bytes within each
-32-bit lane as signed values and sums the four 32-bit products to produce one
-packed 32-bit result per lane in `rd`.
 
 <<<
 ==== PM4ADDSU.B
+
+===== Mnemonic
+
+pm4addsu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27686,6 +27690,11 @@ performing signed×unsigned byte multiplies within each 32-bit lane.
 ]}
 ....
 
+===== Description
+
+The PM4ADDSU.B instruction multiplies corresponding packed bytes within each
+32-bit lane as signed×unsigned and sums the four 32-bit products to form one
+packed 32-bit result per lane in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27710,18 +27719,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm4addsu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM4ADDSU.B instruction multiplies corresponding packed bytes within each
-32-bit lane as signed×unsigned and sums the four 32-bit products to form one
-packed 32-bit result per lane in `rd`.
 
 <<<
 ==== PM4ADDU.B
+
+===== Mnemonic
+
+pm4addu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27742,6 +27746,11 @@ performing unsigned×unsigned byte multiplies within each 32-bit lane.
 ]}
 ....
 
+===== Description
+
+The PM4ADDU.B instruction multiplies corresponding packed bytes within each
+32-bit lane as unsigned values and sums the four 32-bit products to produce one
+packed 32-bit result per lane in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27766,18 +27775,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm4addu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM4ADDU.B instruction multiplies corresponding packed bytes within each
-32-bit lane as unsigned values and sums the four 32-bit products to produce one
-packed 32-bit result per lane in `rd`.
 
 <<<
 ==== PM4ADDA.B
+
+===== Mnemonic
+
+pm4adda.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27797,6 +27801,12 @@ PM4ADDA.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
+===== Description
+
+PM4ADDA.B multiplies four pairs of signed 8-bit byte elements from `rs1` and
+`rs2` within each 32-bit group, sums the four products, and accumulates the
+result into the corresponding 32-bit element of `rd`. This instruction is the
+accumulating variant of PM4ADD.B.
 ===== Operation
 
 [source,pseudocode]
@@ -27826,19 +27836,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm4adda.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM4ADDA.B multiplies four pairs of signed 8-bit byte elements from `rs1` and
-`rs2` within each 32-bit group, sums the four products, and accumulates the
-result into the corresponding 32-bit element of `rd`. This instruction is the
-accumulating variant of PM4ADD.B.
 
 <<<
 ==== PM4ADDASU.B
+
+===== Mnemonic
+
+pm4addasu.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27859,6 +27863,12 @@ signed-unsigned multiplication.
 ]}
 ....
 
+===== Description
+
+PM4ADDASU.B multiplies four pairs of byte elements from `rs1` (signed) and
+`rs2` (unsigned) within each 32-bit group, sums the four products, and
+accumulates the result into the corresponding 32-bit element of `rd`. This
+instruction is the signed-unsigned accumulating variant of PM4ADDSU.B.
 ===== Operation
 
 [source,pseudocode]
@@ -27888,19 +27898,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm4addasu.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM4ADDASU.B multiplies four pairs of byte elements from `rs1` (signed) and
-`rs2` (unsigned) within each 32-bit group, sums the four products, and
-accumulates the result into the corresponding 32-bit element of `rd`. This
-instruction is the signed-unsigned accumulating variant of PM4ADDSU.B.
 
 <<<
 ==== PM4ADDAU.B
+
+===== Mnemonic
+
+pm4addau.b _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27921,6 +27925,12 @@ unsigned multiplication.
 ]}
 ....
 
+===== Description
+
+PM4ADDAU.B multiplies four pairs of unsigned 8-bit byte elements from `rs1` and
+`rs2` within each 32-bit group, sums the four products, and accumulates the
+result into the corresponding 32-bit element of `rd`. This instruction is the
+unsigned accumulating variant of PM4ADDU.B.
 ===== Operation
 
 [source,pseudocode]
@@ -27950,19 +27960,13 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pm4addau.b _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM4ADDAU.B multiplies four pairs of unsigned 8-bit byte elements from `rs1` and
-`rs2` within each 32-bit group, sums the four products, and accumulates the
-result into the corresponding 32-bit element of `rd`. This instruction is the
-unsigned accumulating variant of PM4ADDU.B.
 
 <<<
 ==== PM4ADD.H (RV64)
+
+===== Mnemonic
+
+pm4add.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -27983,6 +27987,11 @@ multiply-add instruction producing a scalar 64-bit result.
 ]}
 ....
 
+===== Description
+
+The PM4ADD.H instruction multiplies the four packed 16-bit halfwords of `rs1`
+and `rs2` as signed values and sums the four 64-bit products to produce the
+result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -27997,18 +28006,13 @@ X[rd] =
     + to_bits(64, sext_64(s1[63:48]) * sext_64(s2[63:48]))
 ----
 
-===== Mnemonic
-
-pm4add.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM4ADD.H instruction multiplies the four packed 16-bit halfwords of `rs1`
-and `rs2` as signed values and sums the four 64-bit products to produce the
-result in `rd`.
 
 <<<
 ==== PM4ADDSU.H (RV64)
+
+===== Mnemonic
+
+pm4addsu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28029,6 +28033,11 @@ signed×unsigned multiply-add instruction producing a scalar 64-bit result.
 ]}
 ....
 
+===== Description
+
+The PM4ADDSU.H instruction multiplies the four packed halfwords of `rs1` (signed)
+with the four packed halfwords of `rs2` (unsigned) and sums the products to
+produce the 64-bit result in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -28043,18 +28052,13 @@ X[rd] =
     + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
 
-===== Mnemonic
-
-pm4addsu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM4ADDSU.H instruction multiplies the four packed halfwords of `rs1` (signed)
-with the four packed halfwords of `rs2` (unsigned) and sums the products to
-produce the 64-bit result in `rd`.
 
 <<<
 ==== PM4ADDASU.H (RV64)
+
+===== Mnemonic
+
+pm4addasu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28075,6 +28079,10 @@ PM4ADDSU.H.
 ]}
 ....
 
+===== Description
+
+The PM4ADDASU.H instruction adds the PM4ADDSU.H sum-of-products result into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28090,20 +28098,16 @@ X[rd] =
   + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
 
-===== Mnemonic
-
-pm4addasu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM4ADDASU.H instruction adds the PM4ADDSU.H sum-of-products result into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM4ADDU.H (RV64)
+
+===== Mnemonic
+
+pm4addu.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28124,6 +28128,11 @@ unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
 ]}
 ....
 
+===== Description
+
+The PM4ADDU.H instruction multiplies the four packed 16-bit halfwords of `rs1`
+and `rs2` as unsigned values and sums the products to produce the 64-bit result
+in `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -28138,18 +28147,13 @@ X[rd] =
     + to_bits(64, zext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
 
-===== Mnemonic
-
-pm4addu.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM4ADDU.H instruction multiplies the four packed 16-bit halfwords of `rs1`
-and `rs2` as unsigned values and sums the products to produce the 64-bit result
-in `rd`.
 
 <<<
 ==== PM4ADDAU.H (RV64)
+
+===== Mnemonic
+
+pm4addau.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28170,6 +28174,10 @@ PM4ADDU.H.
 ]}
 ....
 
+===== Description
+
+The PM4ADDAU.H instruction adds the PM4ADDU.H sum-of-products result into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28185,14 +28193,6 @@ X[rd] =
   + to_bits(64, zext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
 
-===== Mnemonic
-
-pm4addau.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PM4ADDAU.H instruction adds the PM4ADDU.H sum-of-products result into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -28200,6 +28200,10 @@ The PM4ADDAU.H instruction adds the PM4ADDU.H sum-of-products result into `rd`.
 
 <<<
 ==== PM4ADDA.H (RV64)
+
+===== Mnemonic
+
+pm4adda.h _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28220,6 +28224,11 @@ PM4ADDA.H is encoded in the OP-32 major opcode with packed halfword elements
 ]}
 ....
 
+===== Description
+
+PM4ADDA.H (RV64 only) multiplies four pairs of signed 16-bit halfword elements
+from `rs1` and `rs2`, sums the four 64-bit products, and accumulates the result
+into `rd`. This instruction is the accumulating variant of PM4ADD.H.
 ===== Operation
 
 [source,pseudocode]
@@ -28236,20 +28245,15 @@ X[rd] = X[rd]
       + sext64(signed(s1[63:48])  * signed(s2[63:48]))
 ----
 
-===== Mnemonic
-
-pm4adda.h _rd_, _rs1_, _rs2_
-
-===== Description
-
-PM4ADDA.H (RV64 only) multiplies four pairs of signed 16-bit halfword elements
-from `rs1` and `rs2`, sums the four 64-bit products, and accumulates the result
-into `rd`. This instruction is the accumulating variant of PM4ADD.H.
 
 <<<
 === Mixed-width Multiply-High
 
 ==== PMULH.H.B0
+
+===== Mnemonic
+
+pmulh.h.b0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28272,6 +28276,11 @@ product.
 ]}
 ....
 
+===== Description
+
+The PMULH.H.B0 instruction multiplies each packed 16-bit element of `rs1` by the
+low byte of the corresponding element of `rs2` (signed×signed) and writes the
+upper 16 bits of each 24-bit product into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -28288,18 +28297,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulh.h.b0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMULH.H.B0 instruction multiplies each packed 16-bit element of `rs1` by the
-low byte of the corresponding element of `rs2` (signed×signed) and writes the
-upper 16 bits of each 24-bit product into `rd`.
 
 <<<
 ==== PMULH.H.B1
+
+===== Mnemonic
+
+pmulh.h.b1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28322,6 +28326,11 @@ product.
 ]}
 ....
 
+===== Description
+
+The PMULH.H.B1 instruction multiplies each packed 16-bit element of `rs1` by the
+high byte of the corresponding element of `rs2` (signed×signed) and writes the
+upper 16 bits of each 24-bit product into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -28338,18 +28347,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulh.h.b1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMULH.H.B1 instruction multiplies each packed 16-bit element of `rs1` by the
-high byte of the corresponding element of `rs2` (signed×signed) and writes the
-upper 16 bits of each 24-bit product into `rd`.
 
 <<<
 ==== PMULHSU.H.B0
+
+===== Mnemonic
+
+pmulhsu.h.b0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28372,6 +28376,11 @@ corresponding element of `rs2` (unsigned) and returns the high 16 bits of the
 ]}
 ....
 
+===== Description
+
+The PMULHSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
+(signed) by the low byte of the corresponding element of `rs2` (unsigned), and
+writes the upper 16 bits of each 24-bit product into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -28388,18 +28397,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhsu.h.b0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMULHSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
-(signed) by the low byte of the corresponding element of `rs2` (unsigned), and
-writes the upper 16 bits of each 24-bit product into `rd`.
 
 <<<
 ==== PMULHSU.H.B1
+
+===== Mnemonic
+
+pmulhsu.h.b1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28422,6 +28426,11 @@ corresponding element of `rs2` (unsigned) and returns the high 16 bits of the
 ]}
 ....
 
+===== Description
+
+The PMULHSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
+(signed) by the high byte of the corresponding element of `rs2` (unsigned), and
+writes the upper 16 bits of each 24-bit product into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -28438,18 +28447,13 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmulhsu.h.b1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMULHSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
-(signed) by the high byte of the corresponding element of `rs2` (unsigned), and
-writes the upper 16 bits of each 24-bit product into `rd`.
 
 <<<
 ==== PMHACC.H.B0
+
+===== Mnemonic
+
+pmhacc.h.b0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28470,6 +28474,13 @@ PMULH.H.B0.
 ]}
 ....
 
+===== Description
+
+The PMHACC.H.B0 instruction multiplies each packed 16-bit element of `rs1` by
+the low byte of the corresponding element of `rs2` (signed×signed), takes the
+upper 16 bits of the 24-bit product, and accumulates it into the corresponding
+halfword element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28488,23 +28499,16 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhacc.h.b0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACC.H.B0 instruction multiplies each packed 16-bit element of `rs1` by
-the low byte of the corresponding element of `rs2` (signed×signed), takes the
-upper 16 bits of the 24-bit product, and accumulates it into the corresponding
-halfword element of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACC.H.B1
+
+===== Mnemonic
+
+pmhacc.h.b1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28525,6 +28529,13 @@ PMULH.H.B1.
 ]}
 ....
 
+===== Description
+
+The PMHACC.H.B1 instruction multiplies each packed 16-bit element of `rs1` by
+the high byte of the corresponding element of `rs2` (signed×signed), takes the
+upper 16 bits of the 24-bit product, and accumulates it into the corresponding
+halfword element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28543,23 +28554,16 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhacc.h.b1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACC.H.B1 instruction multiplies each packed 16-bit element of `rs1` by
-the high byte of the corresponding element of `rs2` (signed×signed), takes the
-upper 16 bits of the 24-bit product, and accumulates it into the corresponding
-halfword element of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACCSU.H.B0
+
+===== Mnemonic
+
+pmhaccsu.h.b0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28580,6 +28584,12 @@ PMULHSU.H.B0.
 ]}
 ....
 
+===== Description
+
+The PMHACCSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
+(signed) by the low byte of the corresponding element of `rs2` (unsigned), takes
+the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28598,22 +28608,16 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhaccsu.h.b0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACCSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
-(signed) by the low byte of the corresponding element of `rs2` (unsigned), takes
-the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACCSU.H.B1
+
+===== Mnemonic
+
+pmhaccsu.h.b1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28634,6 +28638,12 @@ PMULHSU.H.B1.
 ]}
 ....
 
+===== Description
+
+The PMHACCSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
+(signed) by the high byte of the corresponding element of `rs2` (unsigned), takes
+the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28652,22 +28662,16 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Mnemonic
-
-pmhaccsu.h.b1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACCSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
-(signed) by the high byte of the corresponding element of `rs2` (unsigned), takes
-the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MULH.H0 (RV32)
+
+===== Mnemonic
+
+mulh.h0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28687,6 +28691,12 @@ MULH.H0 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using
 ]}
 ....
 
+===== Description
+
+MULH.H0 multiplies the full signed XLEN-bit value of `rs1` by the low 16-bit
+halfword (h0) of `rs2` treated as signed, producing a (XLEN+16)-bit
+intermediate product, and writes bits [47:16] to `rd`, effectively providing
+the upper XLEN bits of the product after discarding the low 16 bits.
 ===== Operation
 
 [source,pseudocode]
@@ -28696,19 +28706,13 @@ s2_h0 = X[rs2][15:0]
 X[rd] = (signed(X[rs1]) * signed(s2_h0))[47:16]
 ----
 
-===== Mnemonic
-
-mulh.h0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULH.H0 multiplies the full signed XLEN-bit value of `rs1` by the low 16-bit
-halfword (h0) of `rs2` treated as signed, producing a (XLEN+16)-bit
-intermediate product, and writes bits [47:16] to `rd`, effectively providing
-the upper XLEN bits of the product after discarding the low 16 bits.
 
 <<<
 ==== MULH.H1 (RV32)
+
+===== Mnemonic
+
+mulh.h1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28728,6 +28732,12 @@ MULH.H1 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using
 ]}
 ....
 
+===== Description
+
+MULH.H1 multiplies the full signed XLEN-bit value of `rs1` by the high 16-bit
+halfword (h1) of `rs2` treated as signed, producing a (XLEN+16)-bit
+intermediate product, and writes bits [47:16] to `rd`, effectively providing
+the upper XLEN bits of the product after discarding the low 16 bits.
 ===== Operation
 
 [source,pseudocode]
@@ -28737,19 +28747,13 @@ s2_h1 = X[rs2][31:16]
 X[rd] = (signed(X[rs1]) * signed(s2_h1))[47:16]
 ----
 
-===== Mnemonic
-
-mulh.h1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULH.H1 multiplies the full signed XLEN-bit value of `rs1` by the high 16-bit
-halfword (h1) of `rs2` treated as signed, producing a (XLEN+16)-bit
-intermediate product, and writes bits [47:16] to `rd`, effectively providing
-the upper XLEN bits of the product after discarding the low 16 bits.
 
 <<<
 ==== MULHSU.H0 (RV32)
+
+===== Mnemonic
+
+mulhsu.h0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28771,6 +28775,11 @@ halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
 ]}
 ....
 
+===== Description
+
+MULHSU.H0 multiplies the 32-bit signed value in `rs1` by the low halfword of
+`rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
+`rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -28781,18 +28790,13 @@ p  = a * b0
 X[rd] = to_bits(48, p)[47:16]
 ----
 
-===== Mnemonic
-
-mulhsu.h0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULHSU.H0 multiplies the 32-bit signed value in `rs1` by the low halfword of
-`rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
-`rd`.
 
 <<<
 ==== MULHSU.H1 (RV32)
+
+===== Mnemonic
+
+mulhsu.h1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28814,6 +28818,11 @@ halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
 ]}
 ....
 
+===== Description
+
+MULHSU.H1 multiplies the 32-bit signed value in `rs1` by the high halfword of
+`rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
+`rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -28824,18 +28833,13 @@ p  = a * b1
 X[rd] = to_bits(48, p)[47:16]
 ----
 
-===== Mnemonic
-
-mulhsu.h1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MULHSU.H1 multiplies the 32-bit signed value in `rs1` by the high halfword of
-`rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
-`rd`.
 
 <<<
 ==== MHACC.H0 (RV32)
+
+===== Mnemonic
+
+mhacc.h0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28856,6 +28860,12 @@ MULH.H0 (signed×signed), producing the high 32 bits of a 48-bit product.
 ]}
 ....
 
+===== Description
+
+MHACC.H0 multiplies the signed 32-bit value in `rs1` by the low halfword of
+`rs2` treated as signed, takes bits [47:16] of the 48-bit product, and
+accumulates the extracted value into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28866,22 +28876,16 @@ p  = a * b0
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
-===== Mnemonic
-
-mhacc.h0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MHACC.H0 multiplies the signed 32-bit value in `rs1` by the low halfword of
-`rs2` treated as signed, takes bits [47:16] of the 48-bit product, and
-accumulates the extracted value into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MHACC.H1 (RV32)
+
+===== Mnemonic
+
+mhacc.h1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28902,6 +28906,12 @@ MULH.H1 (signed×signed), producing the high 32 bits of a 48-bit product.
 ]}
 ....
 
+===== Description
+
+MHACC.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
+`rs2` treated as signed, takes bits [47:16] of the 48-bit product, and
+accumulates the extracted value into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28912,22 +28922,16 @@ p  = a * b1
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
-===== Mnemonic
-
-mhacc.h1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MHACC.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
-`rs2` treated as signed, takes bits [47:16] of the 48-bit product, and
-accumulates the extracted value into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MHACCSU.H0 (RV32)
+
+===== Mnemonic
+
+mhaccsu.h0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28948,6 +28952,12 @@ MULHSU.H0 (signed×unsigned), producing the high 32 bits of a 48-bit product.
 ]}
 ....
 
+===== Description
+
+MHACCSU.H0 multiplies the signed 32-bit value in `rs1` by the low halfword of
+`rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
+accumulates the extracted value into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -28958,22 +28968,16 @@ p  = a * b0
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
-===== Mnemonic
-
-mhaccsu.h0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MHACCSU.H0 multiplies the signed 32-bit value in `rs1` by the low halfword of
-`rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
-accumulates the extracted value into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MHACCSU.H1 (RV32)
+
+===== Mnemonic
+
+mhaccsu.h1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -28994,6 +28998,12 @@ MULHSU.H1 (signed×unsigned), producing the high 32 bits of a 48-bit product.
 ]}
 ....
 
+===== Description
+
+MHACCSU.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
+`rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
+accumulates the extracted value into `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29004,22 +29014,16 @@ p  = a * b1
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
-===== Mnemonic
-
-mhaccsu.h1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-MHACCSU.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
-`rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
-accumulates the extracted value into `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMULH.W.H0 (RV64)
+
+===== Mnemonic
+
+pmulh.w.h0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29039,6 +29043,13 @@ PMULH.W.H0 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
+===== Description
+
+PMULH.W.H0 multiplies each signed packed 32-bit word element of `rs1` by the
+low halfword (h0) of the corresponding word element of `rs2` treated as signed,
+producing a 48-bit intermediate product per element, and writes bits [47:16] of
+each product to the corresponding word of `rd`. This instruction is available
+only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -29051,20 +29062,13 @@ d_w1 = (signed(s1[63:32]) * signed(s2[47:32]))[47:16]
 X[rd] = d_w1 @ d_w0
 ----
 
-===== Mnemonic
-
-pmulh.w.h0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULH.W.H0 multiplies each signed packed 32-bit word element of `rs1` by the
-low halfword (h0) of the corresponding word element of `rs2` treated as signed,
-producing a 48-bit intermediate product per element, and writes bits [47:16] of
-each product to the corresponding word of `rd`. This instruction is available
-only on RV64.
 
 <<<
 ==== PMULH.W.H1 (RV64)
+
+===== Mnemonic
+
+pmulh.w.h1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29084,6 +29088,13 @@ PMULH.W.H1 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
+===== Description
+
+PMULH.W.H1 multiplies each signed packed 32-bit word element of `rs1` by the
+high halfword (h1) of the corresponding word element of `rs2` treated as
+signed, producing a 48-bit intermediate product per element, and writes bits
+[47:16] of each product to the corresponding word of `rd`. This instruction is
+available only on RV64.
 ===== Operation
 
 [source,pseudocode]
@@ -29096,20 +29107,13 @@ d_w1 = (signed(s1[63:32]) * signed(s2[63:48]))[47:16]
 X[rd] = d_w1 @ d_w0
 ----
 
-===== Mnemonic
-
-pmulh.w.h1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULH.W.H1 multiplies each signed packed 32-bit word element of `rs1` by the
-high halfword (h1) of the corresponding word element of `rs2` treated as
-signed, producing a 48-bit intermediate product per element, and writes bits
-[47:16] of each product to the corresponding word of `rd`. This instruction is
-available only on RV64.
 
 <<<
 ==== PMULHSU.W.H0 (RV64)
+
+===== Mnemonic
+
+pmulhsu.w.h0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29131,6 +29135,11 @@ of each 48-bit product.
 ]}
 ....
 
+===== Description
+
+PMULHSU.W.H0 multiplies each 32-bit word of `rs1` (signed) by the low halfword of
+the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of each
+48-bit product, and packs the two 32-bit results into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -29147,18 +29156,13 @@ d1 = to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmulhsu.w.h0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULHSU.W.H0 multiplies each 32-bit word of `rs1` (signed) by the low halfword of
-the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of each
-48-bit product, and packs the two 32-bit results into `rd`.
 
 <<<
 ==== PMULHSU.W.H1 (RV64)
+
+===== Mnemonic
+
+pmulhsu.w.h1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29180,6 +29184,11 @@ of each 48-bit product.
 ]}
 ....
 
+===== Description
+
+PMULHSU.W.H1 multiplies each 32-bit word of `rs1` (signed) by the high halfword
+of the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of
+each 48-bit product, and packs the two 32-bit results into `rd`.
 ===== Operation
 
 [source,pseudocode]
@@ -29196,18 +29205,13 @@ d1 = to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmulhsu.w.h1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-PMULHSU.W.H1 multiplies each 32-bit word of `rs1` (signed) by the high halfword
-of the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of
-each 48-bit product, and packs the two 32-bit results into `rd`.
 
 <<<
 ==== PMHACC.W.H0 (RV64)
+
+===== Mnemonic
+
+pmhacc.w.h0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29230,6 +29234,13 @@ halfword operands selected from `rs2` (H0 selection per word), producing packed
 ]}
 ....
 
+===== Description
+
+The PMHACC.W.H0 instruction multiplies each signed 32-bit word of `rs1` by the
+low halfword (H0) of the corresponding 32-bit word of `rs2` as signed, extracts
+bits [47:16] of each 48-bit product (the “high” 32 bits), and accumulates the
+result into the corresponding 32-bit element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29248,23 +29259,16 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmhacc.w.h0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACC.W.H0 instruction multiplies each signed 32-bit word of `rs1` by the
-low halfword (H0) of the corresponding 32-bit word of `rs2` as signed, extracts
-bits [47:16] of each 48-bit product (the “high” 32 bits), and accumulates the
-result into the corresponding 32-bit element of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACC.W.H1 (RV64)
+
+===== Mnemonic
+
+pmhacc.w.h1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29287,6 +29291,13 @@ halfword operands selected from `rs2` (H1 selection per word), producing packed
 ]}
 ....
 
+===== Description
+
+The PMHACC.W.H1 instruction multiplies each signed 32-bit word of `rs1` by the
+high halfword (H1) of the corresponding 32-bit word of `rs2` as signed, extracts
+bits [47:16] of each 48-bit product, and accumulates the result into the
+corresponding 32-bit element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29305,23 +29316,16 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmhacc.w.h1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACC.W.H1 instruction multiplies each signed 32-bit word of `rs1` by the
-high halfword (H1) of the corresponding 32-bit word of `rs2` as signed, extracts
-bits [47:16] of each 48-bit product, and accumulates the result into the
-corresponding 32-bit element of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACCSU.W.H0 (RV64)
+
+===== Mnemonic
+
+pmhaccsu.w.h0 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29344,6 +29348,13 @@ halfword operands selected from `rs2` (H0 selection per word), producing packed
 ]}
 ....
 
+===== Description
+
+The PMHACCSU.W.H0 instruction multiplies each signed 32-bit word of `rs1` by the
+low halfword (H0) of the corresponding 32-bit word of `rs2` treated as unsigned,
+extracts bits [47:16] of each 48-bit product, and accumulates the result into
+the corresponding 32-bit element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29362,23 +29373,16 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmhaccsu.w.h0 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACCSU.W.H0 instruction multiplies each signed 32-bit word of `rs1` by the
-low halfword (H0) of the corresponding 32-bit word of `rs2` treated as unsigned,
-extracts bits [47:16] of each 48-bit product, and accumulates the result into
-the corresponding 32-bit element of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACCSU.W.H1 (RV64)
+
+===== Mnemonic
+
+pmhaccsu.w.h1 _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29401,6 +29405,13 @@ halfword operands selected from `rs2` (H1 selection per word), producing packed
 ]}
 ....
 
+===== Description
+
+The PMHACCSU.W.H1 instruction multiplies each signed 32-bit word of `rs1` by the
+high halfword (H1) of the corresponding 32-bit word of `rs2` treated as unsigned,
+extracts bits [47:16] of each 48-bit product, and accumulates the result into
+the corresponding 32-bit element of `rd`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29419,17 +29430,6 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Mnemonic
-
-pmhaccsu.w.h1 _rd_, _rs1_, _rs2_
-
-===== Description
-
-The PMHACCSU.W.H1 instruction multiplies each signed 32-bit word of `rs1` by the
-high halfword (H1) of the corresponding 32-bit word of `rs2` treated as unsigned,
-extracts bits [47:16] of each 48-bit product, and accumulates the result into
-the corresponding 32-bit element of `rd`.
-
 ===== Notes
 
 * This instruction reads and writes `rd`.
@@ -29439,6 +29439,10 @@ the corresponding 32-bit element of `rd`.
 === Widening Multiply
 
 ==== PWMUL.B (RV32)
+
+===== Mnemonic
+
+pwmul.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29460,6 +29464,12 @@ elements (RV32 only).
 ]}
 ....
 
+===== Description
+
+PWMUL.B (RV32 only) performs packed widening signed multiplication of four 8-bit
+byte element pairs from `rs1` and `rs2`. Each pair of signed bytes produces a
+signed 16-bit halfword product. The four halfword results are written as a
+64-bit register pair `rd_p`. If `rd_p` is 0, the result is discarded.
 ===== Operation
 
 [source,pseudocode]
@@ -29479,19 +29489,13 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwmul.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWMUL.B (RV32 only) performs packed widening signed multiplication of four 8-bit
-byte element pairs from `rs1` and `rs2`. Each pair of signed bytes produces a
-signed 16-bit halfword product. The four halfword results are written as a
-64-bit register pair `rd_p`. If `rd_p` is 0, the result is discarded.
 
 <<<
 ==== PWMULSU.B (RV32)
+
+===== Mnemonic
+
+pwmulsu.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29513,6 +29517,13 @@ result into the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
 ]}
 ....
 
+===== Description
+
+The PWMULSU.B instruction performs four signed×unsigned byte multiplications
+between corresponding bytes of `rs1` and `rs2`. Each 16-bit product is packed
+into a 64-bit result, which is written to the destination register pair selected
+by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29530,17 +29541,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwmulsu.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The PWMULSU.B instruction performs four signed×unsigned byte multiplications
-between corresponding bytes of `rs1` and `rs2`. Each 16-bit product is packed
-into a 64-bit result, which is written to the destination register pair selected
-by `rd_p`.
-
 ===== Notes
 
 * If `rd_p=0`, the result is not written (no architectural destination).
@@ -29548,6 +29548,10 @@ by `rd_p`.
 
 <<<
 ==== PWMULU.B (RV32)
+
+===== Mnemonic
+
+pwmulu.b _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29569,6 +29573,13 @@ elements and unsigned multiplication (RV32 only).
 ]}
 ....
 
+===== Description
+
+PWMULU.B (RV32 only) performs packed widening unsigned multiplication of four
+8-bit byte element pairs from `rs1` and `rs2`. Each pair of unsigned bytes
+produces an unsigned 16-bit halfword product. The four halfword results are
+written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
+discarded.
 ===== Operation
 
 [source,pseudocode]
@@ -29588,20 +29599,13 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pwmulu.b _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWMULU.B (RV32 only) performs packed widening unsigned multiplication of four
-8-bit byte element pairs from `rs1` and `rs2`. Each pair of unsigned bytes
-produces an unsigned 16-bit halfword product. The four halfword results are
-written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
-discarded.
 
 <<<
 ==== PWMUL.H (RV32)
+
+===== Mnemonic
+
+pwmul.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29623,6 +29627,12 @@ elements (RV32 only).
 ]}
 ....
 
+===== Description
+
+PWMUL.H (RV32 only) performs packed widening signed multiplication of two 16-bit
+halfword element pairs from `rs1` and `rs2`. Each pair of signed halfwords
+produces a signed 32-bit word product. The two word results are written as a
+64-bit register pair `rd_p`. If `rd_p` is 0, the result is discarded.
 ===== Operation
 
 [source,pseudocode]
@@ -29640,19 +29650,13 @@ if (rd_p != 0):
     X[rd_p*2+1] = d_w1[31:0]
 ----
 
-===== Mnemonic
-
-pwmul.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWMUL.H (RV32 only) performs packed widening signed multiplication of two 16-bit
-halfword element pairs from `rs1` and `rs2`. Each pair of signed halfwords
-produces a signed 32-bit word product. The two word results are written as a
-64-bit register pair `rd_p`. If `rd_p` is 0, the result is discarded.
 
 <<<
 ==== PWMULSU.H (RV32)
+
+===== Mnemonic
+
+pwmulsu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29674,6 +29678,13 @@ results into the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
 ]}
 ....
 
+===== Description
+
+The PWMULSU.H instruction multiplies each signed 16-bit halfword of `rs1` by the
+corresponding unsigned 16-bit halfword of `rs2`, producing two 32-bit products.
+The low-halfword product is written to `X[2*rd_p]` and the high-halfword product
+is written to `X[2*rd_p+1]`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29689,17 +29700,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Mnemonic
-
-pwmulsu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The PWMULSU.H instruction multiplies each signed 16-bit halfword of `rs1` by the
-corresponding unsigned 16-bit halfword of `rs2`, producing two 32-bit products.
-The low-halfword product is written to `X[2*rd_p]` and the high-halfword product
-is written to `X[2*rd_p+1]`.
-
 ===== Notes
 
 * If `rd_p=0`, the result is not written.
@@ -29707,6 +29707,10 @@ is written to `X[2*rd_p+1]`.
 
 <<<
 ==== PWMULU.H (RV32)
+
+===== Mnemonic
+
+pwmulu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29728,6 +29732,13 @@ elements and unsigned multiplication (RV32 only).
 ]}
 ....
 
+===== Description
+
+PWMULU.H (RV32 only) performs packed widening unsigned multiplication of two
+16-bit halfword element pairs from `rs1` and `rs2`. Each pair of unsigned
+halfwords produces an unsigned 32-bit word product. The two word results are
+written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
+discarded.
 ===== Operation
 
 [source,pseudocode]
@@ -29745,20 +29756,13 @@ if (rd_p != 0):
     X[rd_p*2+1] = d_w1[31:0]
 ----
 
-===== Mnemonic
-
-pwmulu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PWMULU.H (RV32 only) performs packed widening unsigned multiplication of two
-16-bit halfword element pairs from `rs1` and `rs2`. Each pair of unsigned
-halfwords produces an unsigned 32-bit word product. The two word results are
-written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
-discarded.
 
 <<<
 ==== WMUL (RV32)
+
+===== Mnemonic
+
+wmul _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29779,6 +29783,12 @@ WMUL is encoded in the widening register-pair format (RV32 only).
 ]}
 ....
 
+===== Description
+
+WMUL (RV32 only) performs a widening signed multiplication of the full 32-bit
+values in `rs1` and `rs2`, producing a 64-bit signed product. The result is
+written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
+discarded.
 ===== Operation
 
 [source,pseudocode]
@@ -29792,19 +29802,13 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wmul _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WMUL (RV32 only) performs a widening signed multiplication of the full 32-bit
-values in `rs1` and `rs2`, producing a 64-bit signed product. The result is
-written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
-discarded.
 
 <<<
 ==== WMULSU (RV32)
+
+===== Mnemonic
+
+wmulsu _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29827,6 +29831,12 @@ by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
+===== Description
+
+The WMULSU instruction multiplies `rs1` as a signed 32-bit integer by `rs2` as an
+unsigned 32-bit integer, producing a 64-bit product. The product is written to
+the destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29838,16 +29848,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = p[63:32]
 ----
 
-===== Mnemonic
-
-wmulsu _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The WMULSU instruction multiplies `rs1` as a signed 32-bit integer by `rs2` as an
-unsigned 32-bit integer, producing a 64-bit product. The product is written to
-the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * If `rd_p=0`, the result is not written.
@@ -29856,6 +29856,10 @@ the destination register pair selected by `rd_p`.
 
 <<<
 ==== WMULU (RV32)
+
+===== Mnemonic
+
+wmulu _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29877,6 +29881,12 @@ multiplication (RV32 only).
 ]}
 ....
 
+===== Description
+
+WMULU (RV32 only) performs a widening unsigned multiplication of the full 32-bit
+values in `rs1` and `rs2`, producing a 64-bit unsigned product. The result is
+written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
+discarded.
 ===== Operation
 
 [source,pseudocode]
@@ -29890,21 +29900,15 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wmulu _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WMULU (RV32 only) performs a widening unsigned multiplication of the full 32-bit
-values in `rs1` and `rs2`, producing a 64-bit unsigned product. The result is
-written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
-discarded.
 
 <<<
 === Widening Multiply-Accumulate
 
 ==== PWMACC.H (RV32)
+
+===== Mnemonic
+
+pwmacc.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29926,6 +29930,12 @@ halfword multiply instruction.
 ]}
 ....
 
+===== Description
+
+The PWMACC.H instruction multiplies corresponding signed 16-bit halfwords of
+`rs1` and `rs2` to form two 32-bit products, then accumulates them into the
+32-bit values held in the destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -29944,16 +29954,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Mnemonic
-
-pwmacc.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The PWMACC.H instruction multiplies corresponding signed 16-bit halfwords of
-`rs1` and `rs2` to form two 32-bit products, then accumulates them into the
-32-bit values held in the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * This instruction reads and writes the destination register pair.
@@ -29962,6 +29962,10 @@ The PWMACC.H instruction multiplies corresponding signed 16-bit halfwords of
 
 <<<
 ==== PWMACCSU.H (RV32)
+
+===== Mnemonic
+
+pwmaccsu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -29983,6 +29987,12 @@ signed×unsigned halfword multiply instruction.
 ]}
 ....
 
+===== Description
+
+The PWMACCSU.H instruction performs signed×unsigned halfword multiplications
+between `rs1` and `rs2`, producing two 32-bit products that are accumulated into
+the destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -30001,16 +30011,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Mnemonic
-
-pwmaccsu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The PWMACCSU.H instruction performs signed×unsigned halfword multiplications
-between `rs1` and `rs2`, producing two 32-bit products that are accumulated into
-the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * This instruction reads and writes the destination register pair.
@@ -30019,6 +30019,10 @@ the destination register pair selected by `rd_p`.
 
 <<<
 ==== PWMACCU.H (RV32)
+
+===== Mnemonic
+
+pwmaccu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30040,6 +30044,12 @@ unsigned×unsigned halfword multiply instruction.
 ]}
 ....
 
+===== Description
+
+The PWMACCU.H instruction multiplies corresponding unsigned 16-bit halfwords of
+`rs1` and `rs2` to form two 32-bit products, then accumulates them into the
+destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -30058,16 +30068,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Mnemonic
-
-pwmaccu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The PWMACCU.H instruction multiplies corresponding unsigned 16-bit halfwords of
-`rs1` and `rs2` to form two 32-bit products, then accumulates them into the
-destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * This instruction reads and writes the destination register pair.
@@ -30076,6 +30076,10 @@ destination register pair selected by `rd_p`.
 
 <<<
 ==== WMACC (RV32)
+
+===== Mnemonic
+
+wmacc _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30097,6 +30101,13 @@ WMACC is encoded in the widening register-pair format with multiply-accumulate
 ]}
 ....
 
+===== Description
+
+WMACC (RV32 only) performs a widening signed multiply-accumulate. It multiplies
+the full 32-bit signed values in `rs1` and `rs2`, producing a 64-bit signed
+product, and adds the product to the existing 64-bit value in register pair
+`rd_p`. The result is written back to register pair `rd_p`. If `rd_p` is 0,
+the result is discarded.
 ===== Operation
 
 [source,pseudocode]
@@ -30113,20 +30124,13 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wmacc _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WMACC (RV32 only) performs a widening signed multiply-accumulate. It multiplies
-the full 32-bit signed values in `rs1` and `rs2`, producing a 64-bit signed
-product, and adds the product to the existing 64-bit value in register pair
-`rd_p`. The result is written back to register pair `rd_p`. If `rd_p` is 0,
-the result is discarded.
 
 <<<
 ==== WMACCSU (RV32)
+
+===== Mnemonic
+
+wmaccsu _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30148,6 +30152,12 @@ of WMULSU.
 ]}
 ....
 
+===== Description
+
+The WMACCSU instruction multiplies `rs1` (signed 32-bit) by `rs2` (unsigned
+32-bit) and accumulates the 64-bit product into the 64-bit accumulator stored in
+the destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -30162,16 +30172,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-wmaccsu _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The WMACCSU instruction multiplies `rs1` (signed 32-bit) by `rs2` (unsigned
-32-bit) and accumulates the 64-bit product into the 64-bit accumulator stored in
-the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * This instruction reads and writes the destination register pair.
@@ -30180,6 +30180,10 @@ the destination register pair selected by `rd_p`.
 
 <<<
 ==== WMACCU (RV32)
+
+===== Mnemonic
+
+wmaccu _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30201,6 +30205,13 @@ multiply-accumulate (RV32 only).
 ]}
 ....
 
+===== Description
+
+WMACCU (RV32 only) performs a widening unsigned multiply-accumulate. It
+multiplies the full 32-bit unsigned values in `rs1` and `rs2`, producing a
+64-bit unsigned product, and adds the product to the existing 64-bit value in
+register pair `rd_p`. The result is written back to register pair `rd_p`. If
+`rd_p` is 0, the result is discarded.
 ===== Operation
 
 [source,pseudocode]
@@ -30217,22 +30228,15 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-wmaccu _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-WMACCU (RV32 only) performs a widening unsigned multiply-accumulate. It
-multiplies the full 32-bit unsigned values in `rs1` and `rs2`, producing a
-64-bit unsigned product, and adds the product to the existing 64-bit value in
-register pair `rd_p`. The result is written back to register pair `rd_p`. If
-`rd_p` is 0, the result is discarded.
 
 <<<
 === Widening Q-format Multiply-Accumulate
 
 ==== PMQWACC.H (RV32)
+
+===== Mnemonic
+
+pmqwacc.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30253,6 +30257,14 @@ select the destination register pair `{X[2*rd_p+1], X[2*rd_p]}`.
     { bits: 1, name: 0x0 },
 ]}
 ....
+
+===== Description
+
+The PMQWACC.H instruction multiplies the two signed 16-bit halfwords of `rs1`
+and `rs2`. For each halfword, it extracts bits [46:15] of the signed 47-bit
+product (equivalent to an arithmetic right shift by 15) and accumulates the
+32-bit extracted value into the corresponding 32-bit lane of a 64-bit
+accumulator held in the destination register pair selected by `rd_p`.
 
 ===== Operation
 
@@ -30277,18 +30289,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-pmqwacc.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The PMQWACC.H instruction multiplies the two signed 16-bit halfwords of `rs1`
-and `rs2`. For each halfword, it extracts bits [46:15] of the signed 47-bit
-product (equivalent to an arithmetic right shift by 15) and accumulates the
-32-bit extracted value into the corresponding 32-bit lane of a 64-bit
-accumulator held in the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * If `rd_p=0`, the accumulator is treated as zero and the result is not written
@@ -30297,6 +30297,10 @@ accumulator held in the destination register pair selected by `rd_p`.
 
 <<<
 ==== PMQRWACC.H (RV32)
+
+===== Mnemonic
+
+pmqrwacc.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30317,6 +30321,12 @@ but uses the rounded variant.
     { bits: 1, name: 0x0 },
 ]}
 ....
+
+===== Description
+
+PMQRWACC.H is the rounded form of PMQWACC.H. It adds a rounding bias of 2^14 to
+each halfword product before extracting bits [46:15], then accumulates the
+result into the 64-bit destination register pair selected by `rd_p`.
 
 ===== Operation
 
@@ -30339,16 +30349,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-pmqrwacc.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PMQRWACC.H is the rounded form of PMQWACC.H. It adds a rounding bias of 2^14 to
-each halfword product before extracting bits [46:15], then accumulates the
-result into the 64-bit destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * If `rd_p=0`, the accumulator is treated as zero and the result is not written
@@ -30357,6 +30357,10 @@ result into the 64-bit destination register pair selected by `rd_p`.
 
 <<<
 ==== MQWACC (RV32)
+
+===== Mnemonic
+
+mqwacc _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30378,6 +30382,13 @@ MQWACC is encoded in a register-pair (rd_p) OP-IMM-32 format and accumulates int
 ]}
 ....
 
+===== Description
+
+The MQWACC instruction multiplies `rs1` and `rs2` as signed 32-bit integers,
+takes the product shifted right by 31 (i.e., bits [94:31] of the sign-extended
+wide product), and accumulates the 64-bit term into the destination register
+pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -30396,17 +30407,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-mqwacc _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-The MQWACC instruction multiplies `rs1` and `rs2` as signed 32-bit integers,
-takes the product shifted right by 31 (i.e., bits [94:31] of the sign-extended
-wide product), and accumulates the 64-bit term into the destination register
-pair selected by `rd_p`.
-
 ===== Notes
 
 * If `rd_p=0`, the accumulator is treated as zero and the result is not written
@@ -30415,6 +30415,10 @@ pair selected by `rd_p`.
 
 <<<
 ==== MQRWACC (RV32)
+
+===== Mnemonic
+
+mqrwacc _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30436,6 +30440,12 @@ uses the rounded variant.
 ]}
 ....
 
+===== Description
+
+MQRWACC is the rounded form of MQWACC. It adds a rounding bias of 2^30 before
+taking the product shifted right by 31, then accumulates the 64-bit term into
+the destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -30454,16 +30464,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-mqrwacc _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-MQRWACC is the rounded form of MQWACC. It adds a rounding bias of 2^30 before
-taking the product shifted right by 31, then accumulates the 64-bit term into
-the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * If `rd_p=0`, the accumulator is treated as zero and the result is not written
@@ -30475,6 +30475,10 @@ the destination register pair selected by `rd_p`.
 === Widening PM2 Multiply-Add/Subtract
 
 ==== PM2WADD.H (RV32)
+
+===== Mnemonic
+
+pm2wadd.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30497,6 +30501,12 @@ sum of two halfword products and writes it to the register pair
 ]}
 ....
 
+===== Description
+
+PM2WADD.H multiplies the two signed 16-bit halfwords of `rs1` and `rs2`
+(halfword0×halfword0 and halfword1×halfword1), sums the two 64-bit products, and
+writes the 64-bit result to the destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -30513,16 +30523,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pm2wadd.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WADD.H multiplies the two signed 16-bit halfwords of `rs1` and `rs2`
-(halfword0×halfword0 and halfword1×halfword1), sums the two 64-bit products, and
-writes the 64-bit result to the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * If `rd_p=0`, no result is written.
@@ -30530,6 +30530,10 @@ writes the 64-bit result to the destination register pair selected by `rd_p`.
 
 <<<
 ==== PM2WADDSU.H (RV32)
+
+===== Mnemonic
+
+pm2waddsu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30552,6 +30556,11 @@ pair selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
+===== Description
+
+PM2WADDSU.H multiplies each signed 16-bit halfword of `rs1` by the corresponding
+unsigned 16-bit halfword of `rs2`, sums the two 64-bit products, and writes the
+64-bit result to the destination register pair selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -30568,18 +30577,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pm2waddsu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WADDSU.H multiplies each signed 16-bit halfword of `rs1` by the corresponding
-unsigned 16-bit halfword of `rs2`, sums the two 64-bit products, and writes the
-64-bit result to the destination register pair selected by `rd_p`.
 
 <<<
 ==== PM2WADDASU.H (RV32)
+
+===== Mnemonic
+
+pm2waddasu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30601,6 +30605,12 @@ form of PM2WADDSU.H.
 ]}
 ....
 
+===== Description
+
+PM2WADDASU.H multiplies corresponding halfwords of `rs1` (signed) and `rs2`
+(unsigned), sums the two 64-bit products, and accumulates the sum into the 64-bit
+accumulator held in the destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -30620,16 +30630,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-pm2waddasu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WADDASU.H multiplies corresponding halfwords of `rs1` (signed) and `rs2`
-(unsigned), sums the two 64-bit products, and accumulates the sum into the 64-bit
-accumulator held in the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * This instruction reads and writes the destination register pair.
@@ -30637,6 +30637,10 @@ accumulator held in the destination register pair selected by `rd_p`.
 
 <<<
 ==== PM2WADDU.H (RV32)
+
+===== Mnemonic
+
+pm2waddu.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30659,6 +30663,11 @@ register pair selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
+===== Description
+
+PM2WADDU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and `rs2`,
+sums the two 64-bit products, and writes the 64-bit result to the destination
+register pair selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -30675,18 +30684,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pm2waddu.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WADDU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and `rs2`,
-sums the two 64-bit products, and writes the 64-bit result to the destination
-register pair selected by `rd_p`.
 
 <<<
 ==== PM2WADDAU.H (RV32)
+
+===== Mnemonic
+
+pm2waddau.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30708,6 +30712,12 @@ form of PM2WADDU.H.
 ]}
 ....
 
+===== Description
+
+PM2WADDAU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and
+`rs2`, sums the two 64-bit products, and accumulates the sum into the 64-bit
+accumulator held in the destination register pair selected by `rd_p`.
+
 ===== Operation
 
 [source,pseudocode]
@@ -30727,16 +30737,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-pm2waddau.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WADDAU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and
-`rs2`, sums the two 64-bit products, and accumulates the sum into the 64-bit
-accumulator held in the destination register pair selected by `rd_p`.
-
 ===== Notes
 
 * This instruction reads and writes the destination register pair.
@@ -30744,6 +30744,10 @@ accumulator held in the destination register pair selected by `rd_p`.
 
 <<<
 ==== PM2WADD.HX (RV32)
+
+===== Mnemonic
+
+pm2wadd.hx _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30766,6 +30770,12 @@ selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
+===== Description
+
+PM2WADD.HX multiplies the low halfword of `rs1` by the high halfword of `rs2` and
+the high halfword of `rs1` by the low halfword of `rs2` (both signed), sums the
+two 64-bit products, and writes the 64-bit result to the destination register
+pair selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -30782,19 +30792,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pm2wadd.hx _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WADD.HX multiplies the low halfword of `rs1` by the high halfword of `rs2` and
-the high halfword of `rs1` by the low halfword of `rs2` (both signed), sums the
-two 64-bit products, and writes the 64-bit result to the destination register
-pair selected by `rd_p`.
 
 <<<
 ==== PM2WSUB.H (RV32)
+
+===== Mnemonic
+
+pm2wsub.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30817,6 +30821,11 @@ the register pair selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
+===== Description
+
+PM2WSUB.H multiplies corresponding signed halfwords of `rs1` and `rs2` and
+computes (low×low) minus (high×high), writing the 64-bit result to the register
+pair selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -30833,18 +30842,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pm2wsub.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WSUB.H multiplies corresponding signed halfwords of `rs1` and `rs2` and
-computes (low×low) minus (high×high), writing the 64-bit result to the register
-pair selected by `rd_p`.
 
 <<<
 ==== PM2WSUB.HX (RV32)
+
+===== Mnemonic
+
+pm2wsub.hx _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30867,6 +30871,11 @@ register pair selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
+===== Description
+
+PM2WSUB.HX multiplies cross halfword pairs and computes (h0 of `rs1` × h1 of
+`rs2`) minus (h1 of `rs1` × h0 of `rs2`), writing the 64-bit result to the
+destination register pair selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -30883,19 +30892,14 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Mnemonic
-
-pm2wsub.hx _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WSUB.HX multiplies cross halfword pairs and computes (h0 of `rs1` × h1 of
-`rs2`) minus (h1 of `rs1` × h0 of `rs2`), writing the 64-bit result to the
-destination register pair selected by `rd_p`.
 
 
 <<<
 ==== PM2WADDA.H (RV32)
+
+===== Mnemonic
+
+pm2wadda.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30917,6 +30921,12 @@ accumulating form of PM2WADD.H.
 ]}
 ....
 
+===== Description
+
+PM2WADDA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`
+(halfword0*halfword0 and halfword1*halfword1), sums the two 64-bit products, and
+accumulates the sum into the 64-bit accumulator held in the destination register
+pair selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -30937,19 +30947,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-pm2wadda.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WADDA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`
-(halfword0*halfword0 and halfword1*halfword1), sums the two 64-bit products, and
-accumulates the sum into the 64-bit accumulator held in the destination register
-pair selected by `rd_p`.
 
 <<<
 ==== PM2WADDA.HX (RV32)
+
+===== Mnemonic
+
+pm2wadda.hx _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -30971,6 +30975,12 @@ accumulating cross-halfword form of PM2WADD.HX.
 ]}
 ....
 
+===== Description
+
+PM2WADDA.HX multiplies cross halfword pairs of `rs1` and `rs2` (low halfword of
+`rs1` by high halfword of `rs2`, and high halfword of `rs1` by low halfword of
+`rs2`), both signed, sums the two 64-bit products, and accumulates the sum into
+the 64-bit accumulator held in the destination register pair selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -30991,19 +31001,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-pm2wadda.hx _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WADDA.HX multiplies cross halfword pairs of `rs1` and `rs2` (low halfword of
-`rs1` by high halfword of `rs2`, and high halfword of `rs1` by low halfword of
-`rs2`), both signed, sums the two 64-bit products, and accumulates the sum into
-the 64-bit accumulator held in the destination register pair selected by `rd_p`.
 
 <<<
 ==== PM2WSUBA.H (RV32)
+
+===== Mnemonic
+
+pm2wsuba.h _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -31025,6 +31029,11 @@ accumulating form of PM2WSUB.H.
 ]}
 ....
 
+===== Description
+
+PM2WSUBA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`,
+computes (low*low) minus (high*high), and accumulates the 64-bit difference into
+the accumulator held in the destination register pair selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -31045,18 +31054,13 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-pm2wsuba.h _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WSUBA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`,
-computes (low*low) minus (high*high), and accumulates the 64-bit difference into
-the accumulator held in the destination register pair selected by `rd_p`.
 
 <<<
 ==== PM2WSUBA.HX (RV32)
+
+===== Mnemonic
+
+pm2wsuba.hx _rd_p_, _rs1_, _rs2_
 
 ===== Encoding
 
@@ -31078,6 +31082,13 @@ accumulating cross-halfword form of PM2WSUB.HX.
 ]}
 ....
 
+===== Description
+
+PM2WSUBA.HX multiplies cross halfword pairs of `rs1` and `rs2` (low halfword of
+`rs1` by high halfword of `rs2`, and high halfword of `rs1` by low halfword of
+`rs2`), both signed, computes the difference of the two 64-bit products, and
+accumulates the result into the accumulator held in the destination register pair
+selected by `rd_p`.
 ===== Operation
 
 [source,pseudocode]
@@ -31098,17 +31109,6 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Mnemonic
-
-pm2wsuba.hx _rd_p_, _rs1_, _rs2_
-
-===== Description
-
-PM2WSUBA.HX multiplies cross halfword pairs of `rs1` and `rs2` (low halfword of
-`rs1` by high halfword of `rs2`, and high halfword of `rs1` by low halfword of
-`rs2`), both signed, computes the difference of the two 64-bit products, and
-accumulates the result into the accumulator held in the destination register pair
-selected by `rd_p`.
 
 <<<
 === RV32 Double-Register Equivalences


### PR DESCRIPTION
Original order was:

Encoding → Operation → Mnemonic → Description

New order is:
Mnemonic → Encoding → Description → Operation → Notes

New order would be more intuitive and easier to read, as the mnemonic is the most important part of an instruction for users, and it should be presented first. The encoding can be presented after the mnemonic, as it provides more technical details about how the instruction is represented in machine code. The description can then provide a more detailed explanation of what the instruction does, followed by the operation and any additional notes.