### PR TITLE
[Clean-up] Clean-ing pseudo code description of register value when the register index is x0

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1431,10 +1431,20 @@ addition wraps modulo 2^8. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = s1_lo[(8*i+7):(8*i)]
@@ -1493,10 +1503,20 @@ addition wraps modulo 2^16. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = s1_lo[(16*i+15):(16*i)]
@@ -1555,10 +1575,20 @@ wraps modulo 2^32. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two ADD operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = s1_lo + s2_lo
 d_hi = s1_hi + s2_hi
@@ -1611,8 +1641,14 @@ wraps modulo 2^8. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.BS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
 s2_b0  = X[rs2][7:0]           // least-significant byte of X[rs2]
 
 for i = 0 .. (XLEN/8 - 1):
@@ -1671,8 +1707,14 @@ element addition wraps modulo 2^16. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.HS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
 s2_h0  = X[rs2][15:0]          // least-significant halfword of X[rs2]
 
 for i = 0 .. (XLEN/16 - 1):
@@ -1731,8 +1773,14 @@ wraps modulo 2^32. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.WS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
 s2_w0  = X[rs2][31:0]          // least-significant word of X[rs2]
 
 d_lo = s1_lo + s2_w0
@@ -1927,10 +1975,20 @@ subtraction wraps modulo 2^8. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSUB.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = s1_lo[(8*i+7):(8*i)]
@@ -1989,10 +2047,20 @@ numbers. Each element subtraction wraps modulo 2^16. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSUB.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = s1_lo[(16*i+15):(16*i)]
@@ -2051,10 +2119,20 @@ subtraction wraps modulo 2^32. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SUB operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = s1_lo - s2_lo
 d_hi = s1_hi - s2_hi
@@ -2530,10 +2608,20 @@ specify even register numbers. Each element result is clamped to the range
 [source,pseudocode]
 ----
 // Equivalent to two PSADD.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = signed(s1_lo[(8*i+7):(8*i)])
@@ -2605,10 +2693,20 @@ specify even register numbers. Each element result is clamped to the range
 [source,pseudocode]
 ----
 // Equivalent to two PSADD.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = signed(s1_lo[(16*i+15):(16*i)])
@@ -2680,10 +2778,20 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SADD operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 a = signed(s1_lo)
 b = signed(s2_lo)
@@ -2753,10 +2861,20 @@ specify even register numbers. Each element result is clamped to the range
 [source,pseudocode]
 ----
 // Equivalent to two PSADDU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = unsigned(s1_lo[(8*i+7):(8*i)])
@@ -2823,9 +2941,22 @@ range [0, 2^16-1]. Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+// Even and Odd registers
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
+
 
 for i = 0 .. 1:
     a = unsigned(s1_lo[(16*i+15):(16*i)])
@@ -2835,9 +2966,7 @@ for i = 0 .. 1:
         res = 2^16 - 1
     d_lo[(16*i+15):(16*i)] = res[15:0]
 
-// Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
+
 
 for i = 0 .. 1:
     a = unsigned(s1_hi[(16*i+15):(16*i)])
@@ -3377,10 +3506,22 @@ odd registers of the pair. Each element result is clamped to the range
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
 
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
+
+// Even registers
 for i = 0 .. 3:
     a = signed(s1_lo[(8*i+7):(8*i)])
     b = signed(s2_lo[(8*i+7):(8*i)])
@@ -3392,9 +3533,6 @@ for i = 0 .. 3:
     d_lo[(8*i+7):(8*i)] = res[7:0]
 
 // Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
 for i = 0 .. 3:
     a = signed(s1_hi[(8*i+7):(8*i)])
     b = signed(s2_hi[(8*i+7):(8*i)])
@@ -3452,10 +3590,22 @@ range [-(2^15), 2^15-1]. Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
 
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
+
+// Even registers
 for i = 0 .. 1:
     a = signed(s1_lo[(16*i+15):(16*i)])
     b = signed(s2_lo[(16*i+15):(16*i)])
@@ -3467,9 +3617,6 @@ for i = 0 .. 1:
     d_lo[(16*i+15):(16*i)] = res[15:0]
 
 // Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
 for i = 0 .. 1:
     a = signed(s1_hi[(16*i+15):(16*i)])
     b = signed(s2_hi[(16*i+15):(16*i)])
@@ -3591,10 +3738,22 @@ range [0, 2^8-1]. Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
 
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
+
+// Even registers
 for i = 0 .. 3:
     a = unsigned(s1_lo[(8*i+7):(8*i)])
     b = unsigned(s2_lo[(8*i+7):(8*i)])
@@ -3604,9 +3763,6 @@ for i = 0 .. 3:
     d_lo[(8*i+7):(8*i)] = res[7:0]
 
 // Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
 for i = 0 .. 3:
     a = unsigned(s1_hi[(8*i+7):(8*i)])
     b = unsigned(s2_hi[(8*i+7):(8*i)])
@@ -3662,10 +3818,22 @@ the range [0, 2^16-1]. Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
 
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
+
+// Even registers
 for i = 0 .. 1:
     a = unsigned(s1_lo[(16*i+15):(16*i)])
     b = unsigned(s2_lo[(16*i+15):(16*i)])
@@ -3675,9 +3843,6 @@ for i = 0 .. 1:
     d_lo[(16*i+15):(16*i)] = res[15:0]
 
 // Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
 for i = 0 .. 1:
     a = unsigned(s1_hi[(16*i+15):(16*i)])
     b = unsigned(s2_hi[(16*i+15):(16*i)])
@@ -4189,10 +4354,20 @@ source and destination pairs. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of byte elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
 
 for i = 0 .. 3:
     a = signed(s1_lo[(8*i+7):(8*i)])
@@ -4254,10 +4429,20 @@ only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of halfword elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
 
 for i = 0 .. 1:
     a = signed(s1_lo[(16*i+15):(16*i)])
@@ -4318,10 +4503,20 @@ source and destination pairs. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: two 32-bit word elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
 
 sum_lo = signed(s1_lo) + signed(s2_lo)
 d_lo = to_bits(32, sum_lo >> 1)
@@ -4377,10 +4572,20 @@ only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of byte elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
 
 for i = 0 .. 3:
     a = unsigned(s1_lo[(8*i+7):(8*i)])
@@ -4442,10 +4647,20 @@ available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of halfword elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
 
 for i = 0 .. 1:
     a = unsigned(s1_lo[(16*i+15):(16*i)])
@@ -4506,10 +4721,20 @@ of the source and destination pairs. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: two 32-bit word elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[2*rs1_p]
+    s1_hi = X[2*rs1_p+1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[2*rs2_p]
+    s2_hi = X[2*rs2_p+1]
 
 sum_lo = unsigned(s1_lo) + unsigned(s2_lo)
 d_lo = to_bits(32, sum_lo >> 1)
@@ -4964,10 +5189,20 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASUB.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = signed(s1_lo[(8*i+7):(8*i)])
@@ -5028,10 +5263,20 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASUB.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = signed(s1_lo[(16*i+15):(16*i)])
@@ -5092,10 +5337,20 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two ASUB operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 diff_lo = signed(s1_lo) - signed(s2_lo)
 d_lo = to_bits(32, diff_lo >> 1)
@@ -5150,10 +5405,20 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASUBU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = unsigned(s1_lo[(8*i+7):(8*i)])
@@ -5214,10 +5479,20 @@ is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASUBU.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = unsigned(s1_lo[(16*i+15):(16*i)])
@@ -5278,10 +5553,20 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two ASUBU operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 diff_lo = unsigned(s1_lo) - unsigned(s2_lo)
 d_lo = to_bits(32, diff_lo >> 1)
@@ -5633,10 +5918,20 @@ destination pairs. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSH1ADD.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = s1_lo[(16*i+15):(16*i)]
@@ -5697,10 +5992,20 @@ instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SH1ADD operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = (s1_lo << 1) + s2_lo
 d_hi = (s1_hi << 1) + s2_hi
@@ -5756,10 +6061,20 @@ instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSSH1SADD.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = s1_lo[(16*i+15):(16*i)]
@@ -5843,10 +6158,20 @@ instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SSH1SADD operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 // Even register
 ssh1_lo : bits(32) =
@@ -6659,10 +6984,20 @@ other operand, and vice versa with subtraction. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PAS.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 // Even register pair
 d_lo[31:16] = s1_lo[31:16] + s2_lo[15:0]
@@ -6722,10 +7057,20 @@ of `rs2`. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSA.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 // Even register pair
 d_lo[31:16] = s1_lo[31:16] - s2_lo[15:0]
@@ -6784,10 +7129,20 @@ occurs, the overflow flag `vxsat` is set. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSAS.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 // Even register pair: saturating add-subtract cross
 a_hi = signed(s1_lo[31:16])
@@ -6861,10 +7216,20 @@ occurs, the overflow flag `vxsat` is set. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSSA.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 // Even register pair: saturating subtract-add cross
 a_hi = signed(s1_lo[31:16])
@@ -6938,10 +7303,20 @@ negative infinity). Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PAAS.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 // Even register pair: averaging add-subtract cross
 a_hi = signed(s1_lo[31:16])
@@ -7012,10 +7387,20 @@ negative infinity). Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASA.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 // Even register pair: averaging subtract-add cross
 a_hi = signed(s1_lo[31:16])
@@ -7388,10 +7773,20 @@ on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of byte elements
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. 3:
     a = signed(s1_lo[(8*i+7):(8*i)])
@@ -7452,10 +7847,20 @@ available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of halfword elements
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. 1:
     a = signed(s1_lo[(16*i+15):(16*i)])
@@ -7516,10 +7921,20 @@ available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of byte elements
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. 3:
     a = unsigned(s1_lo[(8*i+7):(8*i)])
@@ -7580,10 +7995,20 @@ instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of halfword elements
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. 1:
     a = unsigned(s1_lo[(16*i+15):(16*i)])
@@ -7757,8 +8182,13 @@ is set. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSABS.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 
 for i = 0 .. 3:
     val = signed(s1_lo[(8*i+7):(8*i)])
@@ -7830,8 +8260,13 @@ flag `vxsat` is set. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSABS.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 
 for i = 0 .. 1:
     val = signed(s1_lo[(16*i+15):(16*i)])
@@ -8729,10 +9164,20 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMIN.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = signed(s1_lo[(8*i+7):(8*i)])
@@ -8791,10 +9236,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMIN.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = signed(s1_lo[(16*i+15):(16*i)])
@@ -8853,10 +9308,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two signed MIN operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = (signed(s1_lo) < signed(s2_lo)) ? s1_lo : s2_lo
 d_hi = (signed(s1_hi) < signed(s2_hi)) ? s1_hi : s2_hi
@@ -8908,10 +9373,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMINU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = unsigned(s1_lo[(8*i+7):(8*i)])
@@ -8970,10 +9445,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMINU.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = unsigned(s1_lo[(16*i+15):(16*i)])
@@ -9032,10 +9517,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two unsigned MIN operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = (unsigned(s1_lo) < unsigned(s2_lo)) ? s1_lo : s2_lo
 d_hi = (unsigned(s1_hi) < unsigned(s2_hi)) ? s1_hi : s2_hi
@@ -9087,10 +9582,20 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMAX.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = signed(s1_lo[(8*i+7):(8*i)])
@@ -9149,10 +9654,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMAX.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = signed(s1_lo[(16*i+15):(16*i)])
@@ -9211,10 +9726,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two signed MAX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = (signed(s1_lo) > signed(s2_lo)) ? s1_lo : s2_lo
 d_hi = (signed(s1_hi) > signed(s2_hi)) ? s1_hi : s2_hi
@@ -9266,10 +9791,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMAXU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = unsigned(s1_lo[(8*i+7):(8*i)])
@@ -9328,10 +9863,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMAXU.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = unsigned(s1_lo[(16*i+15):(16*i)])
@@ -9390,10 +9935,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two unsigned MAX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = (unsigned(s1_lo) > unsigned(s2_lo)) ? s1_lo : s2_lo
 d_hi = (unsigned(s1_hi) > unsigned(s2_hi)) ? s1_hi : s2_hi
@@ -9977,10 +10532,20 @@ equal, or all-zeros (0x00) otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMSEQ.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = s1_lo[(8*i+7):(8*i)]
@@ -10040,10 +10605,20 @@ equal, or all-zeros (0x0000) otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMSEQ.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = s1_lo[(16*i+15):(16*i)]
@@ -10103,10 +10678,20 @@ are equal, or all-zeros (0x00000000) otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two MSEQ operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = (s1_lo == s2_lo) ? 0xFFFFFFFF : 0x00000000
 d_hi = (s1_hi == s2_hi) ? 0xFFFFFFFF : 0x00000000
@@ -10160,10 +10745,20 @@ otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMSLT.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = signed(s1_lo[(8*i+7):(8*i)])
@@ -10224,10 +10819,20 @@ otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMSLT.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = signed(s1_lo[(16*i+15):(16*i)])
@@ -10288,10 +10893,20 @@ otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two MSLT operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = (signed(s1_lo) < signed(s2_lo)) ? 0xFFFFFFFF : 0x00000000
 d_hi = (signed(s1_hi) < signed(s2_hi)) ? 0xFFFFFFFF : 0x00000000
@@ -10345,10 +10960,20 @@ unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
 [source,pseudocode]
 ----
 // Equivalent to two PMSLTU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/8 - 1):
     a = unsigned(s1_lo[(8*i+7):(8*i)])
@@ -10409,10 +11034,20 @@ unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
 [source,pseudocode]
 ----
 // Equivalent to two PMSLTU.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     a = unsigned(s1_lo[(16*i+15):(16*i)])
@@ -10473,10 +11108,20 @@ otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two MSLTU operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 d_lo = (unsigned(s1_lo) < unsigned(s2_lo)) ? 0xFFFFFFFF : 0x00000000
 d_hi = (unsigned(s1_hi) < unsigned(s2_hi)) ? 0xFFFFFFFF : 0x00000000
@@ -10653,8 +11298,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSEXT.H.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     b = s1_lo[(16*i+7):(16*i)]
@@ -10710,8 +11360,13 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SEXT.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 
 d_lo = sign_extend(XLEN, s1_lo[7:0])
 d_hi = sign_extend(XLEN, s1_hi[7:0])
@@ -10762,8 +11417,13 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SEXT.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 
 d_lo = sign_extend(XLEN, s1_lo[15:0])
 d_hi = sign_extend(XLEN, s1_hi[15:0])
@@ -11263,8 +11923,13 @@ flag is set. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSATI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 n = uimm4[3:0]
 minval_h = sign_extend(16, 0xFFFF << n)
 maxval_h = ~minval_h
@@ -11343,8 +12008,13 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SATI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 n     = uimm5[4:0]
 
 minval = sign_extend(32, 1 << n)       // -(2^n)
@@ -11416,8 +12086,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PUSATI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 n     = uimm4[3:0]
 
 maxval = (1 << n) - 1                  // 2^n - 1
@@ -11492,8 +12167,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two USATI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 n     = uimm5[4:0]
 
 maxval = (1 << n) - 1                  // 2^n - 1
@@ -12514,8 +13194,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSLL.BS operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = X[rs2][4:0]
 
 for i = 0 .. (XLEN/8 - 1):
@@ -12575,8 +13260,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSLL.HS operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = X[rs2][4:0]
 
 for i = 0 .. (XLEN/16 - 1):
@@ -12636,8 +13326,13 @@ RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SLL operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = X[rs2][4:0]
 
 d_lo = (zero_extend(64, s1_lo) << shamt)[31:0]
@@ -12692,8 +13387,13 @@ with zeros. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRL.BS operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = X[rs2][4:0]
 
 for i = 0 .. (XLEN/8 - 1):
@@ -12753,8 +13453,13 @@ with zeros. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRL.HS operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = X[rs2][4:0]
 
 for i = 0 .. (XLEN/16 - 1):
@@ -12814,8 +13519,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRL operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt  = X[rs2][4:0]
 
 d_lo = s1_lo >> shamt
@@ -12871,8 +13581,13 @@ RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRA.BS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt  = X[rs2][4:0]
 
 for i = 0 .. (XLEN/8 - 1):
@@ -12933,8 +13648,13 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRA.HS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt  = X[rs2][4:0]
 
 for i = 0 .. (XLEN/16 - 1):
@@ -12994,8 +13714,13 @@ Each element is sign-extended before shifting. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRA operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt  = X[rs2][4:0]
 
 d_lo = signed(s1_lo) >> shamt
@@ -13049,8 +13774,13 @@ numbers. Vacated bits are filled with zeros. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSLLI.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm3[2:0]          // 3-bit shift amount for bytes
 
 for i = 0 .. (XLEN/8 - 1):
@@ -13110,8 +13840,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSLLI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
 
 for i = 0 .. (XLEN/16 - 1):
@@ -13170,8 +13905,13 @@ numbers. Vacated bits are filled with zeros. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SLLI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm5[4:0]          // 5-bit shift amount for words
 
 d_lo = s1_lo << shamt
@@ -13226,8 +13966,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRLI.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm3[2:0]          // 3-bit shift amount for bytes
 
 for i = 0 .. (XLEN/8 - 1):
@@ -13287,8 +14032,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRLI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
 
 for i = 0 .. (XLEN/16 - 1):
@@ -13348,8 +14098,13 @@ RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRLI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm5[4:0]          // 5-bit shift amount for words
 
 d_lo = s1_lo >> shamt
@@ -13404,8 +14159,13 @@ shifting. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRAI.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm3[2:0]          // 3-bit shift amount for bytes
 
 for i = 0 .. (XLEN/8 - 1):
@@ -13465,8 +14225,13 @@ sign-extended before shifting. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRAI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
 
 for i = 0 .. (XLEN/16 - 1):
@@ -13526,8 +14291,13 @@ shifting. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRAI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm5[4:0]          // 5-bit shift amount for words
 
 d_lo = signed(s1_lo) >> shamt
@@ -13583,8 +14353,13 @@ added for rounding. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRARI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
 
 for i = 0 .. (XLEN/16 - 1):
@@ -13655,8 +14430,13 @@ for rounding. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRARI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt = uimm5[4:0]          // 5-bit shift amount for words
 
 if shamt == 0:
@@ -15016,8 +15796,13 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSSHA.HS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt  = X[rs2][7:0]
 sshamt = signed(shamt)
 
@@ -15104,8 +15889,13 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SSHA operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt  = X[rs2][7:0]
 sshamt = signed(shamt)
 
@@ -15187,8 +15977,13 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSSHAR.HS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt  = X[rs2][7:0]
 sshamt = signed(shamt)
 
@@ -15280,8 +16075,13 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SSHAR operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 shamt  = X[rs2][7:0]
 sshamt = signed(shamt)
 
@@ -15659,8 +16459,13 @@ numbers. If any result overflows the signed 16-bit range, it is saturated and th
 [source,pseudocode]
 ----
 // Equivalent to two PSSLAI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 imm = uimm4[3:0]
 
 for i = 0 .. (XLEN/16 - 1):
@@ -15736,8 +16541,13 @@ numbers. If any result overflows the signed 32-bit range, it is saturated and th
 [source,pseudocode]
 ----
 // Equivalent to two SSLAI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+// When rs1_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
 imm = uimm5[4:0]
 
 a_lo = sign_extend(64, s1_lo)
@@ -16338,10 +17148,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIRE.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     s1_h = s1_lo[(16*i+15):(16*i)]
@@ -16400,10 +17220,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIRE.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/32 - 1):
     s1_w = s1_lo[(32*i+31):(32*i)]
@@ -16462,10 +17292,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIREO.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     s1_h = s1_lo[(16*i+15):(16*i)]
@@ -16524,10 +17364,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIREO.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/32 - 1):
     s1_w = s1_lo[(32*i+31):(32*i)]
@@ -16586,10 +17436,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIROE.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     s1_h = s1_lo[(16*i+15):(16*i)]
@@ -16648,10 +17508,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIROE.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/32 - 1):
     s1_w = s1_lo[(32*i+31):(32*i)]
@@ -16710,10 +17580,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIRO.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/16 - 1):
     s1_h = s1_lo[(16*i+15):(16*i)]
@@ -16772,10 +17652,20 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIRO.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+// When rs1_p or rs2_p is 0, the full 64-bit value must be zero
+if (rs1_p == 0):
+    s1_lo = 0
+    s1_hi = 0
+else:
+    s1_lo = X[rs1_p * 2]
+    s1_hi = X[rs1_p * 2 + 1]
+
+if (rs2_p == 0):
+    s2_lo = 0
+    s2_hi = 0
+else:
+    s2_lo = X[rs2_p * 2]
+    s2_hi = X[rs2_p * 2 + 1]
 
 for i = 0 .. (XLEN/32 - 1):
     s1_w = s1_lo[(32*i+31):(32*i)]


### PR DESCRIPTION
Work done following a discussion on a previous PR: https://github.com/riscv/riscv-p-spec/pull/237#discussion_r2972370616.

When x0 is used to index a pair of registers, the specification specifies that both the low and the high XLEN-bit should be interpreted as zero-values.

This patch is an attempts at cleaning this in the P extension specification. It introduces a very verbose prolog for a lot of instructions, there should be a cleaner / less verbose way.

cc @topperc 


One way to summarize the behavior would be

```
s1_lo = X[rs1_p * 2]
s1_hi = X[rs1_p * 2 + (rs1_p == 0 ? 0 : 1)]
```
(which would rely on X[0] "read" to materialize a zero-value register pair rather than explicitly having `s1_lo = 0` and `s1_hi = 0`).