### PR TITLE
Fix the descriptions and pseudocode for p(s)as.(h/w)x, p(s)sa.(h/w)x.

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -5911,9 +5911,10 @@ elements.
 
 PAS.HX (Packed Add-Subtract Cross, Halfword) performs a cross add-subtract on
 packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
-halfword of `rs1` is added to the even halfword of `rs2`, while the odd (upper)
-halfword of `rs1` has the odd halfword of `rs2` subtracted from it. Results
-wrap modulo 2^16. This instruction is useful for complex number arithmetic.
+halfword of `rs1` has the odd (upper) halfword of `rs2` subtracted from it,
+while the odd (upper) halfword of `rs1` is added to the even (lower) halfword of
+`rs2`.  Results wrap modulo 2^16^. This instruction is useful for complex number
+arithmetic.
 
 ===== Operation
 
@@ -5923,15 +5924,15 @@ s1 = X[rs1]
 s2 = X[rs2]
 
 for i = 0 .. (XLEN/32 - 1):
-    // Even halfword: add
+    // Even halfword: subtract
     a_even = s1[(32*i+15):(32*i)]
-    b_even = s2[(32*i+15):(32*i)]
-    d[(32*i+15):(32*i)] = a_even + b_even
-
-    // Odd halfword: subtract
-    a_odd = s1[(32*i+31):(32*i+16)]
     b_odd = s2[(32*i+31):(32*i+16)]
-    d[(32*i+31):(32*i+16)] = a_odd - b_odd
+    d[(32*i+15):(32*i)] = a_even - b_odd
+
+    // Odd halfword: addition
+    a_odd = s1[(32*i+31):(32*i+16)]
+    b_even = s2[(32*i+15):(32*i)]
+    d[(32*i+31):(32*i+16)] = a_odd + b_even
 
 X[rd] = d
 ----
@@ -5965,10 +5966,10 @@ PAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ===== Description
 
 PAS.WX (Packed Add-Subtract Cross, Word) performs a cross add-subtract on
-packed 32-bit word pairs. The even (lower) word of `rs1` is added to the even
-word of `rs2`, while the odd (upper) word of `rs1` has the odd word of `rs2`
-subtracted from it. Results wrap modulo 2^32. This instruction is useful for
-complex number arithmetic. Available only in RV64.
+packed 32-bit word pairs. The even (lower) word of `rs1` has the odd (upper)
+word of `rs2` subtracted from it, while the odd (upper) word of `rs1` is added
+to the even (lower) word of `rs2`. Results wrap modulo 2^32^. This instruction
+is useful for complex number arithmetic. Available only in RV64.
 
 ===== Operation
 
@@ -5977,15 +5978,15 @@ complex number arithmetic. Available only in RV64.
 s1 = X[rs1]
 s2 = X[rs2]
 
-// Even word: add
+// Even word: subtract
 a_even = s1[31:0]
-b_even = s2[31:0]
-d[31:0] = a_even + b_even
-
-// Odd word: subtract
-a_odd = s1[63:32]
 b_odd = s2[63:32]
-d[63:32] = a_odd - b_odd
+d[31:0] = a_even - b_odd
+
+// Odd word: add
+a_odd = s1[63:32]
+b_even = s2[31:0]
+d[63:32] = a_odd + b_even
 
 X[rd] = d
 ----
@@ -6021,9 +6022,10 @@ elements.
 
 PSA.HX (Packed Subtract-Add Cross, Halfword) performs a cross subtract-add on
 packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
-halfword of `rs1` has the even halfword of `rs2` subtracted from it, while the
-odd (upper) halfword of `rs1` is added to the odd halfword of `rs2`. Results
-wrap modulo 2^16. This instruction is useful for complex number arithmetic.
+halfword of `rs1` is added to the odd (upper) halfword of `rs2`, while the odd
+(upper) halfword of `rs1` has the even (lower) halfword of `rs2` subtracted from
+it. Results wrap modulo 2^16^. This instruction is useful for complex number
+arithmetic.
 
 ===== Operation
 
@@ -6033,15 +6035,15 @@ s1 = X[rs1]
 s2 = X[rs2]
 
 for i = 0 .. (XLEN/32 - 1):
-    // Even halfword: subtract
+    // Even halfword: add
     a_even = s1[(32*i+15):(32*i)]
-    b_even = s2[(32*i+15):(32*i)]
-    d[(32*i+15):(32*i)] = a_even - b_even
-
-    // Odd halfword: add
-    a_odd = s1[(32*i+31):(32*i+16)]
     b_odd = s2[(32*i+31):(32*i+16)]
-    d[(32*i+31):(32*i+16)] = a_odd + b_odd
+    d[(32*i+15):(32*i)] = a_even + b_odd
+
+    // Odd halfword: subtract
+    a_odd = s1[(32*i+31):(32*i+16)]
+    b_even = s2[(32*i+15):(32*i)]
+    d[(32*i+31):(32*i+16)] = a_odd - b_even
 
 X[rd] = d
 ----
@@ -6075,10 +6077,10 @@ PSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ===== Description
 
 PSA.WX (Packed Subtract-Add Cross, Word) performs a cross subtract-add on
-packed 32-bit word pairs. The even (lower) word of `rs1` has the even word of
-`rs2` subtracted from it, while the odd (upper) word of `rs1` is added to the
-odd word of `rs2`. Results wrap modulo 2^32. This instruction is useful for
-complex number arithmetic. Available only in RV64.
+packed 32-bit word pairs. The even (lower) word of `rs1` is added to the odd
+word of `rs2`, while the odd (upper) word of `rs1` has the even (lower) word of
+`rs2` subtracted from it. Results wrap modulo 2^32^. This instruction is useful
+for complex number arithmetic. Available only in RV64.
 
 ===== Operation
 
@@ -6087,15 +6089,15 @@ complex number arithmetic. Available only in RV64.
 s1 = X[rs1]
 s2 = X[rs2]
 
-// Even word: subtract
+// Even word: add
 a_even = s1[31:0]
-b_even = s2[31:0]
-d[31:0] = a_even - b_even
-
-// Odd word: add
-a_odd = s1[63:32]
 b_odd = s2[63:32]
-d[63:32] = a_odd + b_odd
+d[31:0] = a_even + b_odd
+
+// Odd word: subtract
+a_odd = s1[63:32]
+b_even = s2[31:0]
+d[63:32] = a_odd - b_even
 
 X[rd] = d
 ----
@@ -6131,9 +6133,11 @@ elements.
 
 PSAS.HX (Packed Saturating Add-Subtract Cross, Halfword) performs a cross
 saturating add-subtract on packed 16-bit halfword pairs. Within each 32-bit
-word, the even (lower) halfword is computed as a signed saturating addition,
-while the odd (upper) halfword is computed as a signed saturating subtraction.
-Results are clamped to the range [-2^15, 2^15-1]. Sets `vxsat` on saturation.
+word, the even (lower) halfword is computed as a signed saturating subtraction
+of the even (lower) halfword of `rs1` and the odd (upper) halfword of `rs2`,
+while the odd (upper) halfword is computed as a signed saturating addition of
+the odd (upper) halfword of `rs2` and the even (lower) halfword of `rs2`.
+Results are clamped to the range [-2^15^, 2^15^-1]. Sets `vxsat` on saturation.
 This instruction is useful for complex number arithmetic.
 
 ===== Operation
@@ -6144,20 +6148,20 @@ s1 = X[rs1]
 s2 = X[rs2]
 
 for i = 0 .. (XLEN/32 - 1):
-    // Even halfword: saturating add
+    // Even halfword: saturating subtract
     a_even = signed(s1[(32*i+15):(32*i)])
-    b_even = signed(s2[(32*i+15):(32*i)])
-    res_even = a_even + b_even
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    res_even = a_even - b_odd
     if res_even > 2^15 - 1:
         res_even = 2^15 - 1; vxsat = 1
     else if res_even < -(2^15):
         res_even = -(2^15); vxsat = 1
     d[(32*i+15):(32*i)] = res_even[15:0]
 
-    // Odd halfword: saturating subtract
+    // Odd halfword: saturating add
     a_odd = signed(s1[(32*i+31):(32*i+16)])
-    b_odd = signed(s2[(32*i+31):(32*i+16)])
-    res_odd = a_odd - b_odd
+    b_even = signed(s2[(32*i+15):(32*i)])
+    res_odd = a_odd + b_even
     if res_odd > 2^15 - 1:
         res_odd = 2^15 - 1; vxsat = 1
     else if res_odd < -(2^15):
@@ -6200,9 +6204,11 @@ PSAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
 
 PSAS.WX (Packed Saturating Add-Subtract Cross, Word) performs a cross saturating
 add-subtract on packed 32-bit word pairs. The even (lower) word is computed as a
-signed saturating addition, while the odd (upper) word is computed as a signed
-saturating subtraction. Results are clamped to the range [-2^31, 2^31-1]. Sets
-`vxsat` on saturation. This instruction is useful for complex number arithmetic.
+signed saturating subtraction of the even (lower) word of `rs1` and the odd
+(upper) word of `rs2`, while the odd (upper) word is computed as a signed
+saturating addition of the odd (upper) word of `rs2` and the even (lower)
+word of `rs2`. Results are clamped to the range [-2^31^, 2^31^-1]. Sets `vxsat`
+on saturation. This instruction is useful for complex number arithmetic.
 Available only in RV64.
 
 ===== Operation
@@ -6212,20 +6218,20 @@ Available only in RV64.
 s1 = X[rs1]
 s2 = X[rs2]
 
-// Even word: saturating add
+// Even word: saturating subtract
 a_even = signed(s1[31:0])
-b_even = signed(s2[31:0])
-res_even = a_even + b_even
+b_odd = signed(s2[63:32])
+res_even = a_even - b_odd
 if res_even > 2^31 - 1:
     res_even = 2^31 - 1; vxsat = 1
 else if res_even < -(2^31):
     res_even = -(2^31); vxsat = 1
 d[31:0] = res_even[31:0]
 
-// Odd word: saturating subtract
+// Odd word: saturating add
 a_odd = signed(s1[63:32])
-b_odd = signed(s2[63:32])
-res_odd = a_odd - b_odd
+b_even = signed(s2[31:0])
+res_odd = a_odd + b_even
 if res_odd > 2^31 - 1:
     res_odd = 2^31 - 1; vxsat = 1
 else if res_odd < -(2^31):
@@ -6269,9 +6275,11 @@ elements.
 
 PSSA.HX (Packed Saturating Subtract-Add Cross, Halfword) performs a cross
 saturating subtract-add on packed 16-bit halfword pairs. Within each 32-bit
-word, the even (lower) halfword is computed as a signed saturating subtraction,
-while the odd (upper) halfword is computed as a signed saturating addition.
-Results are clamped to the range [-2^15, 2^15-1]. Sets `vxsat` on saturation.
+word, the even (lower) halfword is computed as a signed saturating addition of
+the even (lower) halfword of `rs1` and the odd (upper) halfword of `rs2`,
+while the odd (upper) halfword is computed as a signed saturating subtraction
+of the odd (upper) halfword of `rs1` and the even (lower) halfword of `rs2`.
+Results are clamped to the range [-2^15^, 2^15^-1]. Sets `vxsat` on saturation.
 This instruction is useful for complex number arithmetic.
 
 ===== Operation
@@ -6282,20 +6290,20 @@ s1 = X[rs1]
 s2 = X[rs2]
 
 for i = 0 .. (XLEN/32 - 1):
-    // Even halfword: saturating subtract
+    // Even halfword: saturating add
     a_even = signed(s1[(32*i+15):(32*i)])
-    b_even = signed(s2[(32*i+15):(32*i)])
-    res_even = a_even - b_even
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    res_even = a_even + b_odd
     if res_even > 2^15 - 1:
         res_even = 2^15 - 1; vxsat = 1
     else if res_even < -(2^15):
         res_even = -(2^15); vxsat = 1
     d[(32*i+15):(32*i)] = res_even[15:0]
 
-    // Odd halfword: saturating add
+    // Odd halfword: saturating subtract
     a_odd = signed(s1[(32*i+31):(32*i+16)])
-    b_odd = signed(s2[(32*i+31):(32*i+16)])
-    res_odd = a_odd + b_odd
+    b_even = signed(s2[(32*i+15):(32*i)])
+    res_odd = a_odd - b_even
     if res_odd > 2^15 - 1:
         res_odd = 2^15 - 1; vxsat = 1
     else if res_odd < -(2^15):
@@ -6338,10 +6346,12 @@ PSSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
 
 PSSA.WX (Packed Saturating Subtract-Add Cross, Word) performs a cross saturating
 subtract-add on packed 32-bit word pairs. The even (lower) word is computed as a
-signed saturating subtraction, while the odd (upper) word is computed as a
-signed saturating addition. Results are clamped to the range [-2^31, 2^31-1].
-Sets `vxsat` on saturation. This instruction is useful for complex number
-arithmetic. Available only in RV64.
+signed saturating addition of the even (lower) word of `rs1` and the odd
+(upper) word of `rs2`, while the odd (upper) word is computed as a signed
+saturating subtraction of the odd (upper) word of `rs1` and the even (lower)
+word of `rs2`. Results are clamped to the range [-2^31^, 2^31^-1]. Sets `vxsat` on
+saturation. This instruction is useful for complex number arithmetic. Available
+only in RV64.
 
 ===== Operation
 
@@ -6350,20 +6360,20 @@ arithmetic. Available only in RV64.
 s1 = X[rs1]
 s2 = X[rs2]
 
-// Even word: saturating subtract
+// Even word: saturating add
 a_even = signed(s1[31:0])
-b_even = signed(s2[31:0])
-res_even = a_even - b_even
+b_odd = signed(s2[63:32])
+res_even = a_even + b_odd
 if res_even > 2^31 - 1:
     res_even = 2^31 - 1; vxsat = 1
 else if res_even < -(2^31):
     res_even = -(2^31); vxsat = 1
 d[31:0] = res_even[31:0]
 
-// Odd word: saturating add
+// Odd word: saturating subtract
 a_odd = signed(s1[63:32])
-b_odd = signed(s2[63:32])
-res_odd = a_odd + b_odd
+b_even = signed(s2[31:0])
+res_odd = a_odd - b_even
 if res_odd > 2^31 - 1:
     res_odd = 2^31 - 1; vxsat = 1
 else if res_odd < -(2^31):


### PR DESCRIPTION
The addition and subtraction were reversed and the cross was missing.

I think the averaging versions are correct. The register pair versions are also correct.