### PR TITLE
Reduce pseudocode for GPR pair instructions. Add rs1_p/rs2_p/rd_p==0 checks

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -987,15 +987,12 @@ pair. This instruction is available only on RV32.
 
 [source,pseudocode]
 ----
-for i = 0 .. 3:
-    d_lo[(8*i+7):(8*i)] = imm[7:0]
-
-for i = 0 .. 3:
-    d_hi[(8*i+7):(8*i)] = imm[7:0]
+for i = 0 .. 7:
+    d[(8*i+7):(8*i)] = imm[7:0]
 
 if (rd_p != 0):
-    X[2*rd_p] = d_lo
-    X[2*rd_p+1] = d_hi
+    X[2*rd_p] = d[31:0]
+    X[2*rd_p+1] = d[63:32]
 ----
 
 
@@ -1039,15 +1036,12 @@ available only on RV32.
 ----
 imm_h = sign_extend(16, imm[9:0])
 
-for i = 0 .. 1:
-    d_lo[(16*i+15):(16*i)] = imm_h
-
-for i = 0 .. 1:
-    d_hi[(16*i+15):(16*i)] = imm_h
+for i = 0 .. 3:
+    d[(16*i+15):(16*i)] = imm_h
 
 if (rd_p != 0):
-    X[2*rd_p] = d_lo
-    X[2*rd_p+1] = d_hi
+    X[2*rd_p] = d[31:0]
+    X[2*rd_p+1] = d[63:32]
 ----
 
 
@@ -1093,15 +1087,12 @@ pair. This instruction is available only on RV32.
 ----
 imm_h = sign_extend(16, imm[9:0] << 6)
 
-for i = 0 .. 1:
-    d_lo[(16*i+15):(16*i)] = imm_h
-
-for i = 0 .. 1:
-    d_hi[(16*i+15):(16*i)] = imm_h
+for i = 0 .. 3:
+    d[(16*i+15):(16*i)] = imm_h
 
 if (rd_p != 0):
-    X[2*rd_p] = d_lo
-    X[2*rd_p+1] = d_hi
+    X[2*rd_p] = d[31:0]
+    X[2*rd_p+1] = d[63:32]
 ----
 
 
@@ -1431,23 +1422,17 @@ addition wraps modulo 2^8. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_lo[(8*i+7):(8*i)]
-    b = s2_lo[(8*i+7):(8*i)]
-    d_lo[(8*i+7):(8*i)] = a + b
+for i = 0 .. 7:
+    a = s1[(8*i+7):(8*i)]
+    b = s2[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = a + b
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_hi[(8*i+7):(8*i)]
-    b = s2_hi[(8*i+7):(8*i)]
-    d_hi[(8*i+7):(8*i)] = a + b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -1493,23 +1478,17 @@ addition wraps modulo 2^16. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_lo[(16*i+15):(16*i)]
-    b = s2_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = a + b
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = a + b
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_hi[(16*i+15):(16*i)]
-    b = s2_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = a + b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -1555,16 +1534,17 @@ wraps modulo 2^32. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two ADD operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = s1_lo + s2_lo
-d_hi = s1_hi + s2_hi
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = a + b
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -1611,20 +1591,16 @@ wraps modulo 2^8. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.BS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 s2_b0  = X[rs2][7:0]           // least-significant byte of X[rs2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_lo[(8*i+7):(8*i)]
-    d_lo[(8*i+7):(8*i)] = a + s2_b0
+for i = 0 .. 7:
+    a = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = a + s2_b0
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_hi[(8*i+7):(8*i)]
-    d_hi[(8*i+7):(8*i)] = a + s2_b0
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -1671,20 +1647,16 @@ element addition wraps modulo 2^16. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.HS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 s2_h0  = X[rs2][15:0]          // least-significant halfword of X[rs2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = a + s2_h0
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = a + s2_h0
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = a + s2_h0
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -1731,15 +1703,16 @@ wraps modulo 2^32. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PADD.WS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 s2_w0  = X[rs2][31:0]          // least-significant word of X[rs2]
 
-d_lo = s1_lo + s2_w0
-d_hi = s1_hi + s2_w0
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = a + s2_w0
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -1927,23 +1900,17 @@ subtraction wraps modulo 2^8. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSUB.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_lo[(8*i+7):(8*i)]
-    b = s2_lo[(8*i+7):(8*i)]
-    d_lo[(8*i+7):(8*i)] = a - b
+for i = 0 .. 7:
+    a = s1[(8*i+7):(8*i)]
+    b = s2[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = a - b
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_hi[(8*i+7):(8*i)]
-    b = s2_hi[(8*i+7):(8*i)]
-    d_hi[(8*i+7):(8*i)] = a - b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -1989,23 +1956,17 @@ numbers. Each element subtraction wraps modulo 2^16. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSUB.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_lo[(16*i+15):(16*i)]
-    b = s2_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = a - b
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = a - b
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_hi[(16*i+15):(16*i)]
-    b = s2_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = a - b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -2051,16 +2012,17 @@ subtraction wraps modulo 2^32. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SUB operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = s1_lo - s2_lo
-d_hi = s1_hi - s2_hi
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = a - b
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -2530,35 +2492,23 @@ specify even register numbers. Each element result is clamped to the range
 [source,pseudocode]
 ----
 // Equivalent to two PSADD.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    b = signed(s2_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
     result = a + b
     if result > 127:
-        d_lo[(8*i+7):(8*i)] = to_bits(8, 127)
+        d[(8*i+7):(8*i)] = to_bits(8, 127)
     else if result < -128:
-        d_lo[(8*i+7):(8*i)] = to_bits(8, -128)
+        d[(8*i+7):(8*i)] = to_bits(8, -128)
     else:
-        d_lo[(8*i+7):(8*i)] = to_bits(8, result)
+        d[(8*i+7):(8*i)] = to_bits(8, result)
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    b = signed(s2_hi[(8*i+7):(8*i)])
-    result = a + b
-    if result > 127:
-        d_hi[(8*i+7):(8*i)] = to_bits(8, 127)
-    else if result < -128:
-        d_hi[(8*i+7):(8*i)] = to_bits(8, -128)
-    else:
-        d_hi[(8*i+7):(8*i)] = to_bits(8, result)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -2605,35 +2555,23 @@ specify even register numbers. Each element result is clamped to the range
 [source,pseudocode]
 ----
 // Equivalent to two PSADD.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    b = signed(s2_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
     result = a + b
     if result > 32767:
-        d_lo[(16*i+15):(16*i)] = to_bits(16, 32767)
+        d[(16*i+15):(16*i)] = to_bits(16, 32767)
     else if result < -32768:
-        d_lo[(16*i+15):(16*i)] = to_bits(16, -32768)
+        d[(16*i+15):(16*i)] = to_bits(16, -32768)
     else:
-        d_lo[(16*i+15):(16*i)] = to_bits(16, result)
+        d[(16*i+15):(16*i)] = to_bits(16, result)
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    b = signed(s2_hi[(16*i+15):(16*i)])
-    result = a + b
-    if result > 32767:
-        d_hi[(16*i+15):(16*i)] = to_bits(16, 32767)
-    else if result < -32768:
-        d_hi[(16*i+15):(16*i)] = to_bits(16, -32768)
-    else:
-        d_hi[(16*i+15):(16*i)] = to_bits(16, result)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -2680,33 +2618,23 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SADD operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-a = signed(s1_lo)
-b = signed(s2_lo)
-result = a + b
-if result > 2147483647:
-    d_lo = to_bits(32, 2147483647)
-else if result < -2147483648:
-    d_lo = to_bits(32, -2147483648)
-else:
-    d_lo = to_bits(32, result)
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    b = signed(s2[(32*i+31):(32*i)])
+    result = a + b
+    if result > 2147483647:
+        d[(32*i+31):(32*i)] = to_bits(32, 2147483647)
+    else if result < -2147483648:
+        d[(32*i+31):(32*i)] = to_bits(32, -2147483648)
+    else:
+        d[(32*i+31):(32*i)] = to_bits(32, result)
 
-a = signed(s1_hi)
-b = signed(s2_hi)
-result = a + b
-if result > 2147483647:
-    d_hi = to_bits(32, 2147483647)
-else if result < -2147483648:
-    d_hi = to_bits(32, -2147483648)
-else:
-    d_hi = to_bits(32, result)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -2753,31 +2681,21 @@ specify even register numbers. Each element result is clamped to the range
 [source,pseudocode]
 ----
 // Equivalent to two PSADDU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_lo[(8*i+7):(8*i)])
-    b = unsigned(s2_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
     result = a + b
     if result > 255:
-        d_lo[(8*i+7):(8*i)] = to_bits(8, 255)
+        d[(8*i+7):(8*i)] = to_bits(8, 255)
     else:
-        d_lo[(8*i+7):(8*i)] = to_bits(8, result)
+        d[(8*i+7):(8*i)] = to_bits(8, result)
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_hi[(8*i+7):(8*i)])
-    b = unsigned(s2_hi[(8*i+7):(8*i)])
-    result = a + b
-    if result > 255:
-        d_hi[(8*i+7):(8*i)] = to_bits(8, 255)
-    else:
-        d_hi[(8*i+7):(8*i)] = to_bits(8, result)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -2823,32 +2741,20 @@ range [0, 2^16-1]. Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 1:
-    a = unsigned(s1_lo[(16*i+15):(16*i)])
-    b = unsigned(s2_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
     res = a + b
     if res > 2^16 - 1:
         res = 2^16 - 1
-    d_lo[(16*i+15):(16*i)] = res[15:0]
+    d[(16*i+15):(16*i)] = res[15:0]
 
-// Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
-for i = 0 .. 1:
-    a = unsigned(s1_hi[(16*i+15):(16*i)])
-    b = unsigned(s2_hi[(16*i+15):(16*i)])
-    res = a + b
-    if res > 2^16 - 1:
-        res = 2^16 - 1
-    d_hi[(16*i+15):(16*i)] = res[15:0]
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -2894,21 +2800,20 @@ registers of the pair. Each element result is clamped to the range
 
 [source,pseudocode]
 ----
-// Even registers
-a_lo = unsigned(X[2*rs1_p])
-b_lo = unsigned(X[2*rs2_p])
-res_lo = a_lo + b_lo
-if res_lo > 2^32 - 1:
-    res_lo = 2^32 - 1
-X[2*rd_p] = res_lo[31:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Odd registers
-a_hi = unsigned(X[2*rs1_p+1])
-b_hi = unsigned(X[2*rs2_p+1])
-res_hi = a_hi + b_hi
-if res_hi > 2^32 - 1:
-    res_hi = 2^32 - 1
-X[2*rd_p+1] = res_hi[31:0]
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    res = a + b
+    if res > 2^32 - 1:
+        res = 2^32 - 1
+    d[(32*i+31):(32*i)] = res[31:0]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -3377,36 +3282,22 @@ odd registers of the pair. Each element result is clamped to the range
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 3:
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    b = signed(s2_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
     res = a - b
     if res > 2^7 - 1:
         res = 2^7 - 1
     else if res < -(2^7):
         res = -(2^7)
-    d_lo[(8*i+7):(8*i)] = res[7:0]
+    d[(8*i+7):(8*i)] = res[7:0]
 
-// Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
-for i = 0 .. 3:
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    b = signed(s2_hi[(8*i+7):(8*i)])
-    res = a - b
-    if res > 2^7 - 1:
-        res = 2^7 - 1
-    else if res < -(2^7):
-        res = -(2^7)
-    d_hi[(8*i+7):(8*i)] = res[7:0]
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -3452,36 +3343,22 @@ range [-(2^15), 2^15-1]. Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 1:
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    b = signed(s2_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
     res = a - b
     if res > 2^15 - 1:
         res = 2^15 - 1
     else if res < -(2^15):
         res = -(2^15)
-    d_lo[(16*i+15):(16*i)] = res[15:0]
+    d[(16*i+15):(16*i)] = res[15:0]
 
-// Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
-for i = 0 .. 1:
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    b = signed(s2_hi[(16*i+15):(16*i)])
-    res = a - b
-    if res > 2^15 - 1:
-        res = 2^15 - 1
-    else if res < -(2^15):
-        res = -(2^15)
-    d_hi[(16*i+15):(16*i)] = res[15:0]
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -3527,25 +3404,22 @@ Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-a_lo = signed(X[2*rs1_p])
-b_lo = signed(X[2*rs2_p])
-res_lo = a_lo - b_lo
-if res_lo > 2^31 - 1:
-    res_lo = 2^31 - 1
-else if res_lo < -(2^31):
-    res_lo = -(2^31)
-X[2*rd_p] = res_lo[31:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Odd registers
-a_hi = signed(X[2*rs1_p+1])
-b_hi = signed(X[2*rs2_p+1])
-res_hi = a_hi - b_hi
-if res_hi > 2^31 - 1:
-    res_hi = 2^31 - 1
-else if res_hi < -(2^31):
-    res_hi = -(2^31)
-X[2*rd_p+1] = res_hi[31:0]
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    b = signed(s2[(32*i+31):(32*i)])
+    res = a - b
+    if resi > 2^31 - 1:
+        res = 2^31 - 1
+    else if res < -(2^31):
+        res = -(2^31)
+    d[(32*i+31):(32*i)] = res[31:0]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -3591,32 +3465,20 @@ range [0, 2^8-1]. Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 3:
-    a = unsigned(s1_lo[(8*i+7):(8*i)])
-    b = unsigned(s2_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
     res = a - b
     if res < 0:
         res = 0
-    d_lo[(8*i+7):(8*i)] = res[7:0]
+    d[(8*i+7):(8*i)] = res[7:0]
 
-// Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
-for i = 0 .. 3:
-    a = unsigned(s1_hi[(8*i+7):(8*i)])
-    b = unsigned(s2_hi[(8*i+7):(8*i)])
-    res = a - b
-    if res < 0:
-        res = 0
-    d_hi[(8*i+7):(8*i)] = res[7:0]
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -3662,32 +3524,20 @@ the range [0, 2^16-1]. Available only on RV32.
 
 [source,pseudocode]
 ----
-// Even registers
-s1_lo = X[2*rs1_p]
-s2_lo = X[2*rs2_p]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 1:
-    a = unsigned(s1_lo[(16*i+15):(16*i)])
-    b = unsigned(s2_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
     res = a - b
     if res < 0:
         res = 0
-    d_lo[(16*i+15):(16*i)] = res[15:0]
+    d[(16*i+15):(16*i)] = res[15:0]
 
-// Odd registers
-s1_hi = X[2*rs1_p+1]
-s2_hi = X[2*rs2_p+1]
-
-for i = 0 .. 1:
-    a = unsigned(s1_hi[(16*i+15):(16*i)])
-    b = unsigned(s2_hi[(16*i+15):(16*i)])
-    res = a - b
-    if res < 0:
-        res = 0
-    d_hi[(16*i+15):(16*i)] = res[15:0]
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -3733,21 +3583,20 @@ registers of the pair. Each element result is clamped to the range
 
 [source,pseudocode]
 ----
-// Even registers
-a_lo = unsigned(X[2*rs1_p])
-b_lo = unsigned(X[2*rs2_p])
-res_lo = a_lo - b_lo
-if res_lo < 0:
-    res_lo = 0
-X[2*rd_p] = res_lo[31:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Odd registers
-a_hi = unsigned(X[2*rs1_p+1])
-b_hi = unsigned(X[2*rs2_p+1])
-res_hi = a_hi - b_hi
-if res_hi < 0:
-    res_hi = 0
-X[2*rd_p+1] = res_hi[31:0]
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    res = a - b
+    if res < 0
+        res = 0
+    d[(32*i+31):(32*i)] = res[31:0]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -4189,25 +4038,18 @@ source and destination pairs. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of byte elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 3:
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    b = signed(s2_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
     sum = a + b
-    d_lo[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+    d[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
 
-for i = 0 .. 3:
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    b = signed(s2_hi[(8*i+7):(8*i)])
-    sum = a + b
-    d_hi[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -4254,25 +4096,18 @@ only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of halfword elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 1:
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    b = signed(s2_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
     sum = a + b
-    d_lo[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+    d[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
 
-for i = 0 .. 1:
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    b = signed(s2_hi[(16*i+15):(16*i)])
-    sum = a + b
-    d_hi[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -4318,19 +4153,18 @@ source and destination pairs. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: two 32-bit word elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-sum_lo = signed(s1_lo) + signed(s2_lo)
-d_lo = to_bits(32, sum_lo >> 1)
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    b = signed(s2[(32*i+31):(32*i)])
+    sum = a + b
+    d[(32*i+31):(32*i)] = to_bits(32, sum >> 1)
 
-sum_hi = signed(s1_hi) + signed(s2_hi)
-d_hi = to_bits(32, sum_hi >> 1)
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -4377,25 +4211,18 @@ only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of byte elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 3:
-    a = unsigned(s1_lo[(8*i+7):(8*i)])
-    b = unsigned(s2_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
     sum = a + b
-    d_lo[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+    d[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
 
-for i = 0 .. 3:
-    a = unsigned(s1_hi[(8*i+7):(8*i)])
-    b = unsigned(s2_hi[(8*i+7):(8*i)])
-    sum = a + b
-    d_hi[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -4442,25 +4269,18 @@ available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of halfword elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 1:
-    a = unsigned(s1_lo[(16*i+15):(16*i)])
-    b = unsigned(s2_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
     sum = a + b
-    d_lo[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+    d[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
 
-for i = 0 .. 1:
-    a = unsigned(s1_hi[(16*i+15):(16*i)])
-    b = unsigned(s2_hi[(16*i+15):(16*i)])
-    sum = a + b
-    d_hi[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -4506,19 +4326,18 @@ of the source and destination pairs. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: two 32-bit word elements
-s1_lo = X[2*rs1_p]
-s1_hi = X[2*rs1_p+1]
-s2_lo = X[2*rs2_p]
-s2_hi = X[2*rs2_p+1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-sum_lo = unsigned(s1_lo) + unsigned(s2_lo)
-d_lo = to_bits(32, sum_lo >> 1)
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    sum = a + b
+    d[(32*i+31):(32*i)] = to_bits(32, sum >> 1)
 
-sum_hi = unsigned(s1_hi) + unsigned(s2_hi)
-d_hi = to_bits(32, sum_hi >> 1)
-
-X[2*rd_p] = d_lo
-X[2*rd_p+1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -4964,25 +4783,18 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASUB.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    b = signed(s2_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
     diff = a - b
-    d_lo[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+    d[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    b = signed(s2_hi[(8*i+7):(8*i)])
-    diff = a - b
-    d_hi[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -5028,25 +4840,18 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASUB.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    b = signed(s2_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
     diff = a - b
-    d_lo[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+    d[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    b = signed(s2_hi[(16*i+15):(16*i)])
-    diff = a - b
-    d_hi[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -5092,19 +4897,18 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two ASUB operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-diff_lo = signed(s1_lo) - signed(s2_lo)
-d_lo = to_bits(32, diff_lo >> 1)
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    b = signed(s2[(32*i+31):(32*i)])
+    diff = a - b
+    d[(32*i+31):(32*i)] = to_bits(32, diff >> 1)
 
-diff_hi = signed(s1_hi) - signed(s2_hi)
-d_hi = to_bits(32, diff_hi >> 1)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -5150,25 +4954,18 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASUBU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_lo[(8*i+7):(8*i)])
-    b = unsigned(s2_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
     diff = a - b
-    d_lo[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+    d[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_hi[(8*i+7):(8*i)])
-    b = unsigned(s2_hi[(8*i+7):(8*i)])
-    diff = a - b
-    d_hi[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -5214,25 +5011,18 @@ is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASUBU.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1_lo[(16*i+15):(16*i)])
-    b = unsigned(s2_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
     diff = a - b
-    d_lo[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+    d[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
 
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1_hi[(16*i+15):(16*i)])
-    b = unsigned(s2_hi[(16*i+15):(16*i)])
-    diff = a - b
-    d_hi[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -5278,19 +5068,18 @@ only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two ASUBU operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-diff_lo = unsigned(s1_lo) - unsigned(s2_lo)
-d_lo = to_bits(32, diff_lo >> 1)
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    diff = a - b
+    d[(32*i+31):(32*i)] = to_bits(32, diff >> 1)
 
-diff_hi = unsigned(s1_hi) - unsigned(s2_hi)
-d_hi = to_bits(32, diff_hi >> 1)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -5633,23 +5422,17 @@ destination pairs. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSH1ADD.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_lo[(16*i+15):(16*i)]
-    b = s2_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = (a << 1) + b
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (a << 1) + b
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_hi[(16*i+15):(16*i)]
-    b = s2_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = (a << 1) + b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -5697,16 +5480,17 @@ instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SH1ADD operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = (s1_lo << 1) + s2_lo
-d_hi = (s1_hi << 1) + s2_hi
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (a << 1) + b
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -5756,14 +5540,12 @@ instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSSH1SADD.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_lo[(16*i+15):(16*i)]
-    b = s2_lo[(16*i+15):(16*i)]
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
     // Saturating shift left by 1
     ssh1_a : bits(16) =
         if a <_s 0xC000 then { vxsat = 1; 0x8000 }
@@ -5771,26 +5553,14 @@ for i = 0 .. (XLEN/16 - 1):
         else a << 1
     // Saturating add
     xadd = to_bits(20, signed(ssh1_a) + signed(b))
-    d_lo[(16*i+15):(16*i)] =
+    d[(16*i+15):(16*i)] =
         if xadd <_s 0xF8000 then { vxsat = 1; 0x8000 }
         else if xadd >_s 0x07FFF then { vxsat = 1; 0x7FFF }
         else xadd[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_hi[(16*i+15):(16*i)]
-    b = s2_hi[(16*i+15):(16*i)]
-    ssh1_a : bits(16) =
-        if a <_s 0xC000 then { vxsat = 1; 0x8000 }
-        else if a >=_s 0x4000 then { vxsat = 1; 0x7FFF }
-        else a << 1
-    xadd = to_bits(20, signed(ssh1_a) + signed(b))
-    d_hi[(16*i+15):(16*i)] =
-        if xadd <_s 0xF8000 then { vxsat = 1; 0x8000 }
-        else if xadd >_s 0x07FFF then { vxsat = 1; 0x7FFF }
-        else xadd[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -5843,35 +5613,27 @@ instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SSH1SADD operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Even register
-ssh1_lo : bits(32) =
-    if s1_lo <_s 0xC0000000 then { vxsat = 1; 0x80000000 }
-    else if s1_lo >=_s 0x40000000 then { vxsat = 1; 0x7FFFFFFF }
-    else s1_lo << 1
-xadd_lo = to_bits(36, signed(ssh1_lo) + signed(s2_lo))
-d_lo =
-    if xadd_lo <_s 0xF80000000 then { vxsat = 1; 0x80000000 }
-    else if xadd_lo >_s 0x07FFFFFFF then { vxsat = 1; 0x7FFFFFFF }
-    else xadd_lo[31:0]
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    // Saturating shift left by 1
+    ssh1_a : bits(32) =
+        if a <_s 0xC0000000 then { vxsat = 1; 0x80000000 }
+        else if a >=_s 0x40000000 then { vxsat = 1; 0x7FFFFFFF }
+        else a << 1
+    // Saturating add
+    xadd = to_bits(36, signed(ssh1_a) + signed(b))
+    d[(32*i+31):(32*i)] =
+        if xadd <_s 0xF80000000 then { vxsat = 1; 0x80000000 }
+        else if xadd >_s 0x07FFFFFFF then { vxsat = 1; 0x7FFFFFFF }
+        else xadd[31:0]
 
-// Odd register
-ssh1_hi : bits(32) =
-    if s1_hi <_s 0xC0000000 then { vxsat = 1; 0x80000000 }
-    else if s1_hi >=_s 0x40000000 then { vxsat = 1; 0x7FFFFFFF }
-    else s1_hi << 1
-xadd_hi = to_bits(36, signed(ssh1_hi) + signed(s2_hi))
-d_hi =
-    if xadd_hi <_s 0xF80000000 then { vxsat = 1; 0x80000000 }
-    else if xadd_hi >_s 0x07FFFFFFF then { vxsat = 1; 0x7FFFFFFF }
-    else xadd_hi[31:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -6659,21 +6421,23 @@ other operand, and vice versa with subtraction. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PAS.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Even register pair
-d_lo[31:16] = s1_lo[31:16] + s2_lo[15:0]
-d_lo[15:0]  = s1_lo[15:0]  - s2_lo[31:16]
+for i = 0 .. 1:
+    // Even halfword: subtract
+    a_even = s1[(32*i+15):(32*i)]
+    b_odd = s2[(32*i+31):(32*i+16)]
+    d[(32*i+15):(32*i)] = a_even - b_odd
 
-// Odd register pair
-d_hi[31:16] = s1_hi[31:16] + s2_hi[15:0]
-d_hi[15:0]  = s1_hi[15:0]  - s2_hi[31:16]
+    // Odd halfword: add
+    a_odd = s1[(32*i+31):(32*i+16)]
+    b_even = s2[(32*i+15):(32*i)]
+    d[(32*i+31):(32*i+16)] = a_odd + b_even
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -6722,21 +6486,23 @@ of `rs2`. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSA.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Even register pair
-d_lo[31:16] = s1_lo[31:16] - s2_lo[15:0]
-d_lo[15:0]  = s1_lo[15:0]  + s2_lo[31:16]
+for i = 0 .. 1:
+    // Even halfword: add
+    a_even = s1[(32*i+15):(32*i)]
+    b_odd = s2[(32*i+31):(32*i+16)]
+    d[(32*i+15):(32*i)] = a_even + b_odd
 
-// Odd register pair
-d_hi[31:16] = s1_hi[31:16] - s2_hi[15:0]
-d_hi[15:0]  = s1_hi[15:0]  + s2_hi[31:16]
+    // Odd halfword: subtract
+    a_odd = s1[(32*i+31):(32*i+16)]
+    b_even = s2[(32*i+15):(32*i)]
+    d[(32*i+31):(32*i+16)] = a_odd - b_even
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -6784,33 +6550,25 @@ occurs, the overflow flag `vxsat` is set. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSAS.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Even register pair: saturating add-subtract cross
-a_hi = signed(s1_lo[31:16])
-b_lo = signed(s2_lo[15:0])
-sum = a_hi + b_lo
-d_lo[31:16] = SAT16(sum)
-a_lo = signed(s1_lo[15:0])
-b_hi = signed(s2_lo[31:16])
-diff = a_lo - b_hi
-d_lo[15:0] = SAT16(diff)
+for i = 0 .. 1:
+    // Even halfword: saturating subtract
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    diff = a_even - b_odd
+    d[(32*i+15):(32*i)] = SAT16(diff)
 
-// Odd register pair
-a_hi = signed(s1_hi[31:16])
-b_lo = signed(s2_hi[15:0])
-sum = a_hi + b_lo
-d_hi[31:16] = SAT16(sum)
-a_lo = signed(s1_hi[15:0])
-b_hi = signed(s2_hi[31:16])
-diff = a_lo - b_hi
-d_hi[15:0] = SAT16(diff)
+    // Odd halfword: saturating add
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    sum = a_odd + b_even
+    d[(32*i+31):(32*i+16)] = SAT16(sum)
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -6861,33 +6619,25 @@ occurs, the overflow flag `vxsat` is set. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSSA.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Even register pair: saturating subtract-add cross
-a_hi = signed(s1_lo[31:16])
-b_lo = signed(s2_lo[15:0])
-diff = a_hi - b_lo
-d_lo[31:16] = SAT16(diff)
-a_lo = signed(s1_lo[15:0])
-b_hi = signed(s2_lo[31:16])
-sum = a_lo + b_hi
-d_lo[15:0] = SAT16(sum)
+for i = 0 .. 1:
+    // Even halfword: saturating add
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    sum = a_even + b_odd
+    d[(32*i+15):(32*i)] = SAT16(sum)
 
-// Odd register pair
-a_hi = signed(s1_hi[31:16])
-b_lo = signed(s2_hi[15:0])
-diff = a_hi - b_lo
-d_hi[31:16] = SAT16(diff)
-a_lo = signed(s1_hi[15:0])
-b_hi = signed(s2_hi[31:16])
-sum = a_lo + b_hi
-d_hi[15:0] = SAT16(sum)
+    // Odd halfword: saturating subtract
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    diff = a_odd - b_even
+    d[(32*i+31):(32*i+16)] = SAT16(diff)
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -6938,33 +6688,25 @@ negative infinity). Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PAAS.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Even register pair: averaging add-subtract cross
-a_hi = signed(s1_lo[31:16])
-b_lo = signed(s2_lo[15:0])
-sum = a_hi + b_lo
-d_lo[31:16] = to_bits(16, sum >> 1)
-a_lo = signed(s1_lo[15:0])
-b_hi = signed(s2_lo[31:16])
-diff = a_lo - b_hi
-d_lo[15:0] = to_bits(16, diff >> 1)
+for i = 0 .. 1:
+    // Even halfword: averaging subtract
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    diff = a_even - b_odd
+    d[(32*i+15):(32*i)] = to_bits(16, diff >> 1)
 
-// Odd register pair
-a_hi = signed(s1_hi[31:16])
-b_lo = signed(s2_hi[15:0])
-sum = a_hi + b_lo
-d_hi[31:16] = to_bits(16, sum >> 1)
-a_lo = signed(s1_hi[15:0])
-b_hi = signed(s2_hi[31:16])
-diff = a_lo - b_hi
-d_hi[15:0] = to_bits(16, diff >> 1)
+    // Odd halfword: averaging add
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    sum = a_odd + b_even
+    d[(32*i+31):(32*i+16)] = to_bits(16, sum >> 1)
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -7012,33 +6754,25 @@ negative infinity). Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PASA.HX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-// Even register pair: averaging subtract-add cross
-a_hi = signed(s1_lo[31:16])
-b_lo = signed(s2_lo[15:0])
-diff = a_hi - b_lo
-d_lo[31:16] = to_bits(16, diff >> 1)
-a_lo = signed(s1_lo[15:0])
-b_hi = signed(s2_lo[31:16])
-sum = a_lo + b_hi
-d_lo[15:0] = to_bits(16, sum >> 1)
+for i = 0 .. 1:
+    // Even halfword: averaging add
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    sum = a_even + b_odd
+    d[(32*i+15):(32*i)] = to_bits(16, sum >> 1)
 
-// Odd register pair
-a_hi = signed(s1_hi[31:16])
-b_lo = signed(s2_hi[15:0])
-diff = a_hi - b_lo
-d_hi[31:16] = to_bits(16, diff >> 1)
-a_lo = signed(s1_hi[15:0])
-b_hi = signed(s2_hi[31:16])
-sum = a_lo + b_hi
-d_hi[15:0] = to_bits(16, sum >> 1)
+    // Odd halfword: averaging subtract
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    diff = a_odd - b_even
+    d[(32*i+31):(32*i+16)] = to_bits(16, diff >> 1)
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -7388,23 +7122,17 @@ on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of byte elements
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 3:
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    b = signed(s2_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
 
-for i = 0 .. 3:
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    b = signed(s2_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -7452,23 +7180,17 @@ available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of halfword elements
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 1:
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    b = signed(s2_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
 
-for i = 0 .. 1:
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    b = signed(s2_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -7516,23 +7238,17 @@ available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of byte elements
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 3:
-    a = unsigned(s1_lo[(8*i+7):(8*i)])
-    b = unsigned(s2_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
+for i = 0 .. 7:
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
 
-for i = 0 .. 3:
-    a = unsigned(s1_hi[(8*i+7):(8*i)])
-    b = unsigned(s2_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a >= b) ? (a - b) : (b - a)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -7580,23 +7296,17 @@ instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Register-pair sources: double the number of halfword elements
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. 1:
-    a = unsigned(s1_lo[(16*i+15):(16*i)])
-    b = unsigned(s2_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
+for i = 0 .. 3:
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
 
-for i = 0 .. 1:
-    a = unsigned(s1_hi[(16*i+15):(16*i)])
-    b = unsigned(s2_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a >= b) ? (a - b) : (b - a)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -7757,31 +7467,21 @@ is set. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSABS.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 
-for i = 0 .. 3:
-    val = signed(s1_lo[(8*i+7):(8*i)])
+for i = 0 .. 7:
+    val = signed(s1[(8*i+7):(8*i)])
     if val == -128:
-        d_lo[(8*i+7):(8*i)] = 0x7F
+        d[(8*i+7):(8*i)] = 0x7F
         vxsat = 1
     else if val < 0:
-        d_lo[(8*i+7):(8*i)] = to_bits(8, -val)
+        d[(8*i+7):(8*i)] = to_bits(8, -val)
     else:
-        d_lo[(8*i+7):(8*i)] = to_bits(8, val)
+        d[(8*i+7):(8*i)] = to_bits(8, val)
 
-for i = 0 .. 3:
-    val = signed(s1_hi[(8*i+7):(8*i)])
-    if val == -128:
-        d_hi[(8*i+7):(8*i)] = 0x7F
-        vxsat = 1
-    else if val < 0:
-        d_hi[(8*i+7):(8*i)] = to_bits(8, -val)
-    else:
-        d_hi[(8*i+7):(8*i)] = to_bits(8, val)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -7830,31 +7530,21 @@ flag `vxsat` is set. This instruction is available only on RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSABS.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 
-for i = 0 .. 1:
-    val = signed(s1_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    val = signed(s1[(16*i+15):(16*i)])
     if val == -32768:
-        d_lo[(16*i+15):(16*i)] = 0x7FFF
+        d[(16*i+15):(16*i)] = 0x7FFF
         vxsat = 1
     else if val < 0:
-        d_lo[(16*i+15):(16*i)] = to_bits(16, -val)
+        d[(16*i+15):(16*i)] = to_bits(16, -val)
     else:
-        d_lo[(16*i+15):(16*i)] = to_bits(16, val)
+        d[(16*i+15):(16*i)] = to_bits(16, val)
 
-for i = 0 .. 1:
-    val = signed(s1_hi[(16*i+15):(16*i)])
-    if val == -32768:
-        d_hi[(16*i+15):(16*i)] = 0x7FFF
-        vxsat = 1
-    else if val < 0:
-        d_hi[(16*i+15):(16*i)] = to_bits(16, -val)
-    else:
-        d_hi[(16*i+15):(16*i)] = to_bits(16, val)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -8729,23 +8419,17 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMIN.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    b = signed(s2_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a < b) ? a : b
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? a : b
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    b = signed(s2_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a < b) ? a : b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -8791,23 +8475,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMIN.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    b = signed(s2_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a < b) ? a : b
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? a : b
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    b = signed(s2_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a < b) ? a : b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -8853,16 +8531,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two signed MIN operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = (signed(s1_lo) < signed(s2_lo)) ? s1_lo : s2_lo
-d_hi = (signed(s1_hi) < signed(s2_hi)) ? s1_hi : s2_hi
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    b = signed(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a < b) ? s1[(32*i+31):(32*i)] : s2[(32*i+31):(32*i)]
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -8908,23 +8587,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMINU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_lo[(8*i+7):(8*i)])
-    b = unsigned(s2_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a < b) ? a : b
+for i = 0 .. 7:
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? a : b
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_hi[(8*i+7):(8*i)])
-    b = unsigned(s2_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a < b) ? a : b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -8970,23 +8643,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMINU.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1_lo[(16*i+15):(16*i)])
-    b = unsigned(s2_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a < b) ? a : b
+for i = 0 .. 3:
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? a : b
 
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1_hi[(16*i+15):(16*i)])
-    b = unsigned(s2_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a < b) ? a : b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -9032,16 +8699,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two unsigned MIN operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = (unsigned(s1_lo) < unsigned(s2_lo)) ? s1_lo : s2_lo
-d_hi = (unsigned(s1_hi) < unsigned(s2_hi)) ? s1_hi : s2_hi
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a < b) ? a : b
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -9087,23 +8755,17 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMAX.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    b = signed(s2_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a > b) ? a : b
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a > b) ? a : b
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    b = signed(s2_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a > b) ? a : b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -9149,23 +8811,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMAX.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    b = signed(s2_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a > b) ? a : b
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a > b) ? a : b
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    b = signed(s2_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a > b) ? a : b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -9211,16 +8867,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two signed MAX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = (signed(s1_lo) > signed(s2_lo)) ? s1_lo : s2_lo
-d_hi = (signed(s1_hi) > signed(s2_hi)) ? s1_hi : s2_hi
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    b = signed(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a > b) ? a : b
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -9266,23 +8923,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMAXU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_lo[(8*i+7):(8*i)])
-    b = unsigned(s2_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a > b) ? a : b
+for i = 0 .. 7:
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a > b) ? a : b
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_hi[(8*i+7):(8*i)])
-    b = unsigned(s2_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a > b) ? a : b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -9328,23 +8979,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMAXU.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1_lo[(16*i+15):(16*i)])
-    b = unsigned(s2_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a > b) ? a : b
+for i = 0 .. 3:
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a > b) ? a : b
 
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1_hi[(16*i+15):(16*i)])
-    b = unsigned(s2_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a > b) ? a : b
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -9390,16 +9035,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two unsigned MAX operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = (unsigned(s1_lo) > unsigned(s2_lo)) ? s1_lo : s2_lo
-d_hi = (unsigned(s1_hi) > unsigned(s2_hi)) ? s1_hi : s2_hi
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a > b) ? a : b
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -9977,23 +9623,17 @@ equal, or all-zeros (0x00) otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMSEQ.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_lo[(8*i+7):(8*i)]
-    b = s2_lo[(8*i+7):(8*i)]
-    d_lo[(8*i+7):(8*i)] = (a == b) ? 0xFF : 0x00
+for i = 0 .. 7:
+    a = s1[(8*i+7):(8*i)]
+    b = s2[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (a == b) ? 0xFF : 0x00
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_hi[(8*i+7):(8*i)]
-    b = s2_hi[(8*i+7):(8*i)]
-    d_hi[(8*i+7):(8*i)] = (a == b) ? 0xFF : 0x00
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10040,23 +9680,17 @@ equal, or all-zeros (0x0000) otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMSEQ.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_lo[(16*i+15):(16*i)]
-    b = s2_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = (a == b) ? 0xFFFF : 0x0000
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (a == b) ? 0xFFFF : 0x0000
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_hi[(16*i+15):(16*i)]
-    b = s2_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = (a == b) ? 0xFFFF : 0x0000
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10103,16 +9737,17 @@ are equal, or all-zeros (0x00000000) otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two MSEQ operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = (s1_lo == s2_lo) ? 0xFFFFFFFF : 0x00000000
-d_hi = (s1_hi == s2_hi) ? 0xFFFFFFFF : 0x00000000
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (a == b) ? 0xFFFFFFFF : 0x00000000
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10160,23 +9795,17 @@ otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMSLT.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    b = signed(s2_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    b = signed(s2_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10224,23 +9853,17 @@ otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PMSLT.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    b = signed(s2_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    b = signed(s2_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10288,16 +9911,17 @@ otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two MSLT operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = (signed(s1_lo) < signed(s2_lo)) ? 0xFFFFFFFF : 0x00000000
-d_hi = (signed(s1_hi) < signed(s2_hi)) ? 0xFFFFFFFF : 0x00000000
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    b = signed(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a < b) ? 0xFFFFFFFF : 0x00000000
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10345,23 +9969,17 @@ unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
 [source,pseudocode]
 ----
 // Equivalent to two PMSLTU.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_lo[(8*i+7):(8*i)])
-    b = unsigned(s2_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+for i = 0 .. 7:
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
 
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1_hi[(8*i+7):(8*i)])
-    b = unsigned(s2_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10409,23 +10027,17 @@ unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
 [source,pseudocode]
 ----
 // Equivalent to two PMSLTU.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1_lo[(16*i+15):(16*i)])
-    b = unsigned(s2_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+for i = 0 .. 3:
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
 
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1_hi[(16*i+15):(16*i)])
-    b = unsigned(s2_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10473,16 +10085,17 @@ otherwise. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two MSLTU operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-d_lo = (unsigned(s1_lo) < unsigned(s2_lo)) ? 0xFFFFFFFF : 0x00000000
-d_hi = (unsigned(s1_hi) < unsigned(s2_hi)) ? 0xFFFFFFFF : 0x00000000
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a < b) ? 0xFFFFFFFF : 0x00000000
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10653,19 +10266,15 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSEXT.H.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    b = s1_lo[(16*i+7):(16*i)]
-    d_lo[(16*i+15):(16*i)] = sign_extend(16, b)
+for i = 0 .. 3:
+    b = s1[(16*i+7):(16*i)]
+    d[(16*i+15):(16*i)] = sign_extend(16, b)
 
-for i = 0 .. (XLEN/16 - 1):
-    b = s1_hi[(16*i+7):(16*i)]
-    d_hi[(16*i+15):(16*i)] = sign_extend(16, b)
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10710,14 +10319,14 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SEXT.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 
-d_lo = sign_extend(XLEN, s1_lo[7:0])
-d_hi = sign_extend(XLEN, s1_hi[7:0])
+for i = 0 .. 1:
+    d[(32*i+31):(32*i)] = sign_extend(32, s1[(32*i+7):(32*i)])
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -10762,14 +10371,14 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SEXT.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 
-d_lo = sign_extend(XLEN, s1_lo[15:0])
-d_hi = sign_extend(XLEN, s1_hi[15:0])
+for i = 0 .. 1:
+    d[(32*i+31):(32*i)] = sign_extend(32, s1[(32*i+15):(32*i)])
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -11263,36 +10872,25 @@ flag is set. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSATI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 n = uimm4[3:0]
 minval_h = sign_extend(16, 0xFFFF << n)
 maxval_h = ~minval_h
 
-for i = 0 .. (XLEN/16 - 1):
-    e = signed(s1_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    e = signed(s1[(16*i+15):(16*i)])
     if e < signed(minval_h):
-        d_lo[(16*i+15):(16*i)] = minval_h
+        d[(16*i+15):(16*i)] = minval_h
         vxsat = 1
     else if e > signed(maxval_h):
-        d_lo[(16*i+15):(16*i)] = maxval_h
+        d[(16*i+15):(16*i)] = maxval_h
         vxsat = 1
     else:
-        d_lo[(16*i+15):(16*i)] = s1_lo[(16*i+15):(16*i)]
+        d[(16*i+15):(16*i)] = s1[(16*i+15):(16*i)]
 
-for i = 0 .. (XLEN/16 - 1):
-    e = signed(s1_hi[(16*i+15):(16*i)])
-    if e < signed(minval_h):
-        d_hi[(16*i+15):(16*i)] = minval_h
-        vxsat = 1
-    else if e > signed(maxval_h):
-        d_hi[(16*i+15):(16*i)] = maxval_h
-        vxsat = 1
-    else:
-        d_hi[(16*i+15):(16*i)] = s1_hi[(16*i+15):(16*i)]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -11343,29 +10941,24 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SATI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-n     = uimm5[4:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+n  = uimm5[4:0]
 
 minval = sign_extend(32, 1 << n)       // -(2^n)
 maxval = (1 << n) - 1                  // 2^n - 1
 
-if (s1_lo <s minval):
-    d_lo = minval; vxsat = 1
-else if (s1_lo >s maxval):
-    d_lo = maxval; vxsat = 1
-else:
-    d_lo = s1_lo
+for i = 0 .. 1:
+    e = signed(s1[(32*i+31):(32*i)])
+    if (e <s minval):
+        d[(32*i+31):(32*i)] = minval; vxsat = 1
+    else if (e >s maxval):
+        d[(32*i+31):(32*i)] = maxval; vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = s1[(32*i+31):(32*i)]
 
-if (s1_hi <s minval):
-    d_hi = minval; vxsat = 1
-else if (s1_hi >s maxval):
-    d_hi = maxval; vxsat = 1
-else:
-    d_hi = s1_hi
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -11416,32 +11009,23 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PUSATI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-n     = uimm4[3:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+n  = uimm4[3:0]
 
 maxval = (1 << n) - 1                  // 2^n - 1
 
-for i = 0 .. (XLEN/16 - 1):
-    h = s1_lo[(16*i+15):(16*i)]
+for i = 0 .. 3:
+    h = s1[(16*i+15):(16*i)]
     if (h <s 0):
-        d_lo[(16*i+15):(16*i)] = 0; vxsat = 1
+        d[(16*i+15):(16*i)] = 0; vxsat = 1
     else if (h >s maxval):
-        d_lo[(16*i+15):(16*i)] = maxval; vxsat = 1
+        d[(16*i+15):(16*i)] = maxval; vxsat = 1
     else:
-        d_lo[(16*i+15):(16*i)] = h
+        d[(16*i+15):(16*i)] = h
 
-for i = 0 .. (XLEN/16 - 1):
-    h = s1_hi[(16*i+15):(16*i)]
-    if (h <s 0):
-        d_hi[(16*i+15):(16*i)] = 0; vxsat = 1
-    else if (h >s maxval):
-        d_hi[(16*i+15):(16*i)] = maxval; vxsat = 1
-    else:
-        d_hi[(16*i+15):(16*i)] = h
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -11492,28 +11076,23 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two USATI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-n     = uimm5[4:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+n  = uimm5[4:0]
 
 maxval = (1 << n) - 1                  // 2^n - 1
 
-if (s1_lo <s 0):
-    d_lo = 0; vxsat = 1
-else if (s1_lo >s maxval):
-    d_lo = maxval; vxsat = 1
-else:
-    d_lo = s1_lo
+for i = 0 .. 1:
+    e = signed(s1[(32*i+31):(32*i)])
+    if (e <s 0):
+        d[(32*i+31):(32*i)] = 0; vxsat = 1
+    else if (e >s maxval):
+        d[(32*i+31):(32*i)] = maxval; vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = s1[(32*i+31):(32*i)]
 
-if (s1_hi <s 0):
-    d_hi = 0; vxsat = 1
-else if (s1_hi >s maxval):
-    d_hi = maxval; vxsat = 1
-else:
-    d_hi = s1_hi
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -12514,20 +12093,16 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSLL.BS operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = X[rs2][4:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    b = s1_lo[(8*i+7):(8*i)]
-    d_lo[(8*i+7):(8*i)] = (zero_extend(32, b) << shamt)[7:0]
+for i = 0 .. 7:
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (zero_extend(32, b) << shamt)[7:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    b = s1_hi[(8*i+7):(8*i)]
-    d_hi[(8*i+7):(8*i)] = (zero_extend(32, b) << shamt)[7:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -12575,20 +12150,16 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSLL.HS operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = X[rs2][4:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    h = s1_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
+for i = 0 .. 3:
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    h = s1_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -12636,15 +12207,15 @@ RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SLL operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = X[rs2][4:0]
 
-d_lo = (zero_extend(64, s1_lo) << shamt)[31:0]
-d_hi = (zero_extend(64, s1_hi) << shamt)[31:0]
+for i = 0 .. 1:
+    d[(32*i+31):(32*i)] = (zero_extend(64, s1[(32*i+31):(32*i)]) << shamt)[31:0]
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -12692,20 +12263,16 @@ with zeros. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRL.BS operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = X[rs2][4:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    b = s1_lo[(8*i+7):(8*i)]
-    d_lo[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
+for i = 0 .. 7:
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    b = s1_hi[(8*i+7):(8*i)]
-    d_hi[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -12753,20 +12320,16 @@ with zeros. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRL.HS operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = X[rs2][4:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    h = s1_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
+for i = 0 .. 3:
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    h = s1_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -12814,15 +12377,15 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRL operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
-shamt  = X[rs2][4:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+shamt = X[rs2][4:0]
 
-d_lo = s1_lo >> shamt
-d_hi = s1_hi >> shamt
+for i = 0 .. 1:
+    d[(32*i+31):(32*i)] = s1[(32*i+31):(32*i)] >> shamt
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -12871,20 +12434,16 @@ RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRA.BS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
-shamt  = X[rs2][4:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+shamt = X[rs2][4:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a >> shamt)[7:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a >> shamt)[7:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -12933,20 +12492,16 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRA.HS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
-shamt  = X[rs2][4:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+shamt = X[rs2][4:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a >> shamt)[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a >> shamt)[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -12994,15 +12549,16 @@ Each element is sign-extended before shifting. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRA operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
-shamt  = X[rs2][4:0]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+shamt = X[rs2][4:0]
 
-d_lo = signed(s1_lo) >> shamt
-d_hi = signed(s1_hi) >> shamt
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a >> shamt)[31:0]
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13049,20 +12605,16 @@ numbers. Vacated bits are filled with zeros. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSLLI.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm3[2:0]          // 3-bit shift amount for bytes
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_lo[(8*i+7):(8*i)]
-    d_lo[(8*i+7):(8*i)] = (a << shamt)[7:0]
+for i = 0 .. 7:
+    a = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (a << shamt)[7:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_hi[(8*i+7):(8*i)]
-    d_hi[(8*i+7):(8*i)] = (a << shamt)[7:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13110,20 +12662,16 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSLLI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = (a << shamt)[15:0]
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (a << shamt)[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = (a << shamt)[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13170,15 +12718,16 @@ numbers. Vacated bits are filled with zeros. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SLLI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm5[4:0]          // 5-bit shift amount for words
 
-d_lo = s1_lo << shamt
-d_hi = s1_hi << shamt
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (a << shamt)[31:0]
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13226,20 +12775,16 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRLI.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm3[2:0]          // 3-bit shift amount for bytes
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_lo[(8*i+7):(8*i)]
-    d_lo[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+for i = 0 .. 7:
+    a = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (a >> shamt)[7:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = s1_hi[(8*i+7):(8*i)]
-    d_hi[(8*i+7):(8*i)] = (a >> shamt)[7:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13287,20 +12832,16 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRLI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (a >> shamt)[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = (a >> shamt)[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13348,15 +12889,16 @@ RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRLI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm5[4:0]          // 5-bit shift amount for words
 
-d_lo = s1_lo >> shamt
-d_hi = s1_hi >> shamt
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (a >> shamt)[31:0]
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13404,20 +12946,16 @@ shifting. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRAI.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm3[2:0]          // 3-bit shift amount for bytes
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_lo[(8*i+7):(8*i)])
-    d_lo[(8*i+7):(8*i)] = (a >> shamt)[7:0]
+for i = 0 .. 7:
+    a = signed(s1[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a >> shamt)[7:0]
 
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1_hi[(8*i+7):(8*i)])
-    d_hi[(8*i+7):(8*i)] = (a >> shamt)[7:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13465,20 +13003,16 @@ sign-extended before shifting. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRAI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
-    d_lo[(16*i+15):(16*i)] = (a >> shamt)[15:0]
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a >> shamt)[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    d_hi[(16*i+15):(16*i)] = (a >> shamt)[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13526,15 +13060,16 @@ shifting. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRAI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm5[4:0]          // 5-bit shift amount for words
 
-d_lo = signed(s1_lo) >> shamt
-d_hi = signed(s1_hi) >> shamt
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a >> shamt)[31:0]
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13583,28 +13118,20 @@ added for rounding. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSRARI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
     if shamt == 0:
-        d_lo[(16*i+15):(16*i)] = a[15:0]
+        d[(16*i+15):(16*i)] = a[15:0]
     else:
         round = a[shamt-1]
-        d_lo[(16*i+15):(16*i)] = ((a >> shamt) + round)[15:0]
+        d[(16*i+15):(16*i)] = ((a >> shamt) + round)[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    if shamt == 0:
-        d_hi[(16*i+15):(16*i)] = a[15:0]
-    else:
-        round = a[shamt-1]
-        d_hi[(16*i+15):(16*i)] = ((a >> shamt) + round)[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -13655,21 +13182,20 @@ for rounding. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SRARI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt = uimm5[4:0]          // 5-bit shift amount for words
 
-if shamt == 0:
-    d_lo = s1_lo
-    d_hi = s1_hi
-else:
-    round_lo = s1_lo[shamt-1]
-    d_lo = (signed(s1_lo) >> shamt) + round_lo
-    round_hi = s1_hi[shamt-1]
-    d_hi = (signed(s1_hi) >> shamt) + round_hi
+for i = 0 .. 1:
+    w = s1[(32*i+31):(32*i)]
+    if shamt == 0:
+        d[(32*i+31):(32*i)] = w
+    else:
+        round = w[shamt-1]
+        d[(32*i+31):(32*i)] = (signed(w) >> shamt) + round
 
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -15016,41 +14542,28 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSSHA.HS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+s1     = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt  = X[rs2][7:0]
 sshamt = signed(shamt)
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
     if sshamt < 0:
         // Right shift
-        d_lo[(16*i+15):(16*i)] = (a >> (-sshamt))[15:0]
+        do[(16*i+15):(16*i)] = (a >> (-sshamt))[15:0]
     else:
         // Left shift with saturation
         result = a << sshamt
         if result < -2^15:
-            d_lo[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+             d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
         else if result > 2^15 - 1:
-            d_lo[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+            d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
         else:
-            d_lo[(16*i+15):(16*i)] = result[15:0]
+            d[(16*i+15):(16*i)] = result[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    if sshamt < 0:
-        d_hi[(16*i+15):(16*i)] = (a >> (-sshamt))[15:0]
-    else:
-        result = a << sshamt
-        if result < -2^15:
-            d_hi[(16*i+15):(16*i)] = 0x8000; vxsat = 1
-        else if result > 2^15 - 1:
-            d_hi[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
-        else:
-            d_hi[(16*i+15):(16*i)] = result[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15104,35 +14617,28 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SSHA operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+s1     = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt  = X[rs2][7:0]
 sshamt = signed(shamt)
 
-if sshamt < 0:
-    // Right shift
-    d_lo = (signed(s1_lo) >> (-sshamt))[31:0]
-    d_hi = (signed(s1_hi) >> (-sshamt))[31:0]
-else:
-    // Left shift with saturation
-    result_lo = signed(s1_lo) << sshamt
-    if result_lo < -2^31:
-        d_lo = 0x80000000; vxsat = 1
-    else if result_lo > 2^31 - 1:
-        d_lo = 0x7FFFFFFF; vxsat = 1
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    if sshamt < 0:
+        // Right shift
+        d[(32*i+31):(32*i)] = (a >> (-sshamt))[31:0]
     else:
-        d_lo = result_lo[31:0]
+        // Left shift with saturation
+        result = a << sshamt
+        if result < -2^31:
+            d[(32*i+31):(32*i)] = 0x80000000; vxsat = 1
+        else if result > 2^31 - 1:
+            d[(32*i+31):(32*i)] = 0x7FFFFFFF; vxsat = 1
+        else:
+            d[(32*i+31):(16*i)] = result[31:0]
 
-    result_hi = signed(s1_hi) << sshamt
-    if result_hi < -2^31:
-        d_hi = 0x80000000; vxsat = 1
-    else if result_hi > 2^31 - 1:
-        d_hi = 0x7FFFFFFF; vxsat = 1
-    else:
-        d_hi = result_hi[31:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15187,45 +14693,30 @@ Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PSSHAR.HS operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+s1     = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt  = X[rs2][7:0]
 sshamt = signed(shamt)
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = signed(s1[(16*i+15):(16*i)])
     if sshamt < 0:
         // Right shift with rounding
         xa = a << 1
         shifted = xa >> (-sshamt)
-        d_lo[(16*i+15):(16*i)] = ((shifted + 1) >> 1)[15:0]
+        d[(16*i+15):(16*i)] = ((shifted + 1) >> 1)[15:0]
     else:
         // Left shift with saturation
         result = a << sshamt
         if result < -2^15:
-            d_lo[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+            d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
         else if result > 2^15 - 1:
-            d_lo[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+            d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
         else:
-            d_lo[(16*i+15):(16*i)] = result[15:0]
+            d[(16*i+15):(16*i)] = result[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1_hi[(16*i+15):(16*i)])
-    if sshamt < 0:
-        xa = a << 1
-        shifted = xa >> (-sshamt)
-        d_hi[(16*i+15):(16*i)] = ((shifted + 1) >> 1)[15:0]
-    else:
-        result = a << sshamt
-        if result < -2^15:
-            d_hi[(16*i+15):(16*i)] = 0x8000; vxsat = 1
-        else if result > 2^15 - 1:
-            d_hi[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
-        else:
-            d_hi[(16*i+15):(16*i)] = result[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15280,40 +14771,30 @@ only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two SSHAR operations on even/odd register pairs
-s1_lo  = X[rs1_p * 2]
-s1_hi  = X[rs1_p * 2 + 1]
+s1     = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 shamt  = X[rs2][7:0]
 sshamt = signed(shamt)
 
-if sshamt < 0:
-    // Right shift with rounding
-    xa_lo = signed(s1_lo) << 1
-    shifted_lo = xa_lo >> (-sshamt)
-    d_lo = ((shifted_lo + 1) >> 1)[31:0]
-
-    xa_hi = signed(s1_hi) << 1
-    shifted_hi = xa_hi >> (-sshamt)
-    d_hi = ((shifted_hi + 1) >> 1)[31:0]
-else:
-    // Left shift with saturation
-    result_lo = signed(s1_lo) << sshamt
-    if result_lo < -2^31:
-        d_lo = 0x80000000; vxsat = 1
-    else if result_lo > 2^31 - 1:
-        d_lo = 0x7FFFFFFF; vxsat = 1
+for i = 0 .. 1:
+    a = signed(s1[(32*i+31):(32*i)])
+    if sshamt < 0:
+        // Right shift with rounding
+        xa = a << 1
+        shifted = xa >> (-sshamt)
+        d[(32*i+31):(32*i)] = ((shifted + 1) >> 1)[31:0]
     else:
-        d_lo = result_lo[31:0]
+        // Left shift with saturation
+        result = a << sshamt
+        if result < -2^31:
+            d[(32*i+31):(32*i)] = 0x80000000; vxsat = 1
+        else if result > 2^31 - 1:
+            d[(32*i+31):(32*i)] = 0x7FFFFFFF; vxsat = 1
+        else:
+            d[(32*i+31):(32*i)] = result[31:0]
 
-    result_hi = signed(s1_hi) << sshamt
-    if result_hi < -2^31:
-        d_hi = 0x80000000; vxsat = 1
-    else if result_hi > 2^31 - 1:
-        d_hi = 0x7FFFFFFF; vxsat = 1
-    else:
-        d_hi = result_hi[31:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15384,8 +14865,8 @@ for i = 0 .. 3:
             d[(16*i+15):(16*i)] = result[15:0]
 
 if (rd_p != 0):
-  X[rd_p*2]   = d[31:0]
-  X[rd_p*2+1] = d[63:32]
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15456,8 +14937,8 @@ for i = 0 .. 1:
             d[(32*i+31):(16*i)] = result[31:0]
 
 if (rd_p != 0):
-  X[rd_p*2]   = d[31:0]
-  X[rd_p*2+1] = d[63:32]
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15531,8 +15012,8 @@ for i = 0 .. 3:
             d[(16*i+15):(16*i)] = result[15:0]
 
 if (rd_p != 0):
-  X[rd_p*2]   = d[31:0]
-  X[rd_p*2+1] = d[63:32]
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15606,8 +15087,8 @@ for i = 0 .. 1:
             d[(32*i+31):(32*i)] = result[31:0]
 
 if (rd_p != 0):
-  X[rd_p*2]   = d[31:0]
-  X[rd_p*2+1] = d[63:32]
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15659,32 +15140,22 @@ numbers. If any result overflows the signed 16-bit range, it is saturated and th
 [source,pseudocode]
 ----
 // Equivalent to two PSSLAI.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 imm = uimm4[3:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = sign_extend(32, s1_lo[(16*i+15):(16*i)])
+for i = 0 .. 3:
+    a = sign_extend(32, s1[(16*i+15):(16*i)])
     shx = a << imm
     if shx < -2^15:
-        d_lo[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
     else if shx > 2^15 - 1:
-        d_lo[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
     else:
-        d_lo[(16*i+15):(16*i)] = shx[15:0]
+        d[(16*i+15):(16*i)] = shx[15:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = sign_extend(32, s1_hi[(16*i+15):(16*i)])
-    shx = a << imm
-    if shx < -2^15:
-        d_hi[(16*i+15):(16*i)] = 0x8000; vxsat = 1
-    else if shx > 2^15 - 1:
-        d_hi[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
-    else:
-        d_hi[(16*i+15):(16*i)] = shx[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -15736,30 +15207,22 @@ numbers. If any result overflows the signed 32-bit range, it is saturated and th
 [source,pseudocode]
 ----
 // Equivalent to two SSLAI operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 imm = uimm5[4:0]
 
-a_lo = sign_extend(64, s1_lo)
-shx_lo = a_lo << imm
-if shx_lo < -2^31:
-    d_lo = 0x80000000; vxsat = 1
-else if shx_lo > 2^31 - 1:
-    d_lo = 0x7FFFFFFF; vxsat = 1
-else:
-    d_lo = shx_lo[31:0]
+for i = 0 .. 1:
+    a = sign_extend(64, s1[(32*i+31):(32*i)])
+    shx = a << imm
+    if shx < -2^31:
+        d[(32*i+31):(32*i)] = 0x80000000; vxsat = 1
+    else if shx > 2^31 - 1:
+        d[(32*i+31):(32*i)] = 0x7FFFFFFF; vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = shx[31:0]
 
-a_hi = sign_extend(64, s1_hi)
-shx_hi = a_hi << imm
-if shx_hi < -2^31:
-    d_hi = 0x80000000; vxsat = 1
-else if shx_hi > 2^31 - 1:
-    d_hi = 0x7FFFFFFF; vxsat = 1
-else:
-    d_hi = shx_hi[31:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 ===== Notes
@@ -16338,23 +15801,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIRE.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    s1_h = s1_lo[(16*i+15):(16*i)]
-    s2_h = s2_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[7:0]
+for i = 0 .. 3:
+    s1_h = s1[(16*i+15):(16*i)]
+    s2_h = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[7:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    s1_h = s1_hi[(16*i+15):(16*i)]
-    s2_h = s2_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[7:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -16400,23 +15857,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIRE.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/32 - 1):
-    s1_w = s1_lo[(32*i+31):(32*i)]
-    s2_w = s2_lo[(32*i+31):(32*i)]
-    d_lo[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[15:0]
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[15:0]
 
-for i = 0 .. (XLEN/32 - 1):
-    s1_w = s1_hi[(32*i+31):(32*i)]
-    s2_w = s2_hi[(32*i+31):(32*i)]
-    d_hi[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -16462,23 +15913,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIREO.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    s1_h = s1_lo[(16*i+15):(16*i)]
-    s2_h = s2_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[7:0]
+for i = 0 .. 3:
+    s1_h = s1[(16*i+15):(16*i)]
+    s2_h = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[7:0]
 
-for i = 0 .. (XLEN/16 - 1):
-    s1_h = s1_hi[(16*i+15):(16*i)]
-    s2_h = s2_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[7:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -16524,23 +15969,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIREO.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/32 - 1):
-    s1_w = s1_lo[(32*i+31):(32*i)]
-    s2_w = s2_lo[(32*i+31):(32*i)]
-    d_lo[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[15:0]
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[15:0]
 
-for i = 0 .. (XLEN/32 - 1):
-    s1_w = s1_hi[(32*i+31):(32*i)]
-    s2_w = s2_hi[(32*i+31):(32*i)]
-    d_hi[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[15:0]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -16586,23 +16025,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIROE.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    s1_h = s1_lo[(16*i+15):(16*i)]
-    s2_h = s2_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[15:8]
+for i = 0 .. 3:
+    s1_h = s1[(16*i+15):(16*i)]
+    s2_h = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[15:8]
 
-for i = 0 .. (XLEN/16 - 1):
-    s1_h = s1_hi[(16*i+15):(16*i)]
-    s2_h = s2_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[15:8]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -16648,23 +16081,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIROE.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/32 - 1):
-    s1_w = s1_lo[(32*i+31):(32*i)]
-    s2_w = s2_lo[(32*i+31):(32*i)]
-    d_lo[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[31:16]
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[31:16]
 
-for i = 0 .. (XLEN/32 - 1):
-    s1_w = s1_hi[(32*i+31):(32*i)]
-    s2_w = s2_hi[(32*i+31):(32*i)]
-    d_hi[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[31:16]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -16710,23 +16137,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIRO.B operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/16 - 1):
-    s1_h = s1_lo[(16*i+15):(16*i)]
-    s2_h = s2_lo[(16*i+15):(16*i)]
-    d_lo[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[15:8]
+for i = 0 .. 3:
+    s1_h = s1[(16*i+15):(16*i)]
+    s2_h = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[15:8]
 
-for i = 0 .. (XLEN/16 - 1):
-    s1_h = s1_hi[(16*i+15):(16*i)]
-    s2_h = s2_hi[(16*i+15):(16*i)]
-    d_hi[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[15:8]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -16772,23 +16193,17 @@ numbers. Available only in RV32.
 [source,pseudocode]
 ----
 // Equivalent to two PPAIRO.H operations on even/odd register pairs
-s1_lo = X[rs1_p * 2]
-s1_hi = X[rs1_p * 2 + 1]
-s2_lo = X[rs2_p * 2]
-s2_hi = X[rs2_p * 2 + 1]
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
-for i = 0 .. (XLEN/32 - 1):
-    s1_w = s1_lo[(32*i+31):(32*i)]
-    s2_w = s2_lo[(32*i+31):(32*i)]
-    d_lo[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[31:16]
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[31:16]
 
-for i = 0 .. (XLEN/32 - 1):
-    s1_w = s1_hi[(32*i+31):(32*i)]
-    s2_w = s2_hi[(32*i+31):(32*i)]
-    d_hi[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[31:16]
-
-X[rd_p * 2]     = d_lo
-X[rd_p * 2 + 1] = d_hi
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 


### PR DESCRIPTION
Many of the GPR pair instructions had their pseudocode written as to separate blocks of code for the even register and the odd register.

Rewrite them to concatenate their sources, loop over the elements in both registers, and then write out their results to two registers. Add the rs1_p/rs2_p checks for the source data and a rd_p check for the writes.

This is an alternative to #239.

Rewrite was done with AI. I did a review myself and fixed some issues, but I might have missed some.