### PR TITLE
Use 'description lists' instead of 'section headers' for information about instructions.

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -735,11 +735,11 @@ corresponding `rd+`, `rs1+`, or `rs2+` also denotes `x0`.
 
 ==== PLI.B
 
-===== Mnemonic
+Mnemonic::
 
 pli.b _rd_, _imm8_
 
-===== Encoding
+Encoding::
 
 PLI.B is encoded in the OP-IMM-32 major opcode with an 8-bit immediate
 and packed byte elements.
@@ -758,12 +758,12 @@ and packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PLI.B (Packed Load Immediate, Byte) loads an 8-bit immediate into every
 byte element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -777,11 +777,11 @@ X[rd] = d
 <<<
 ==== PLI.H
 
-===== Mnemonic
+Mnemonic::
 
 pli.h _rd_, _simm10_
 
-===== Encoding
+Encoding::
 
 PLI.H is encoded in the OP-IMM-32 major opcode with a 10-bit signed immediate
 and packed halfword elements.
@@ -798,12 +798,12 @@ and packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PLI.H (Packed Load Immediate, Halfword) sign-extends a 10-bit signed immediate
 to 16 bits and replicates it into every halfword element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -819,11 +819,11 @@ X[rd] = d
 <<<
 ==== PLI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pli.w _rd_, _simm10_
 
-===== Encoding
+Encoding::
 
 PLI.W is encoded in the OP-IMM-32 major opcode with a 10-bit signed immediate
 and packed word elements. This instruction exists only for RV64.
@@ -840,13 +840,13 @@ and packed word elements. This instruction exists only for RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PLI.W (Packed Load Immediate, Word) sign-extends a 10-bit signed immediate
 to 32 bits and replicates it into every word element of `rd`. This instruction
 is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -862,11 +862,11 @@ X[rd] = d
 <<<
 ==== PLUI.H
 
-===== Mnemonic
+Mnemonic::
 
 plui.h _rd_, _simm10_
 
-===== Encoding
+Encoding::
 
 PLUI.H is encoded in the OP-IMM-32 major opcode with a 10-bit immediate
 loaded into the upper bits of each halfword element.
@@ -883,14 +883,14 @@ loaded into the upper bits of each halfword element.
 ]}
 ....
 
-===== Description
+Description::
 
 PLUI.H (Packed Load Upper Immediate, Halfword) loads a 10-bit signed immediate
 into the most-significant 10 bits of each 16-bit halfword element, with the
 lower 6 bits set to zero, and replicates the result into every halfword
 element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -906,11 +906,11 @@ X[rd] = d
 <<<
 ==== PLUI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 plui.w _rd_, _simm10_
 
-===== Encoding
+Encoding::
 
 PLUI.W is encoded in the OP-IMM-32 major opcode with a 10-bit immediate
 loaded into the upper bits of each word element. This instruction exists
@@ -928,14 +928,14 @@ only for RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PLUI.W (Packed Load Upper Immediate, Word) loads a 10-bit signed immediate
 into the most-significant 10 bits of each 32-bit word element, with the
 lower 22 bits set to zero, and replicates the result into every word element
 of `rd`. This instruction is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -951,11 +951,11 @@ X[rd] = d
 <<<
 ==== PLI.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pli.db _rd_p_, _imm8_
 
-===== Encoding
+Encoding::
 
 PLI.DB is encoded in the OP-IMM-32 major opcode (register-pair variant)
 with an 8-bit immediate and packed byte elements. This instruction exists
@@ -976,14 +976,14 @@ only for RV32 and uses a register-pair destination `rd_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PLI.DB (Packed Load Immediate, Double-wide Byte) loads an 8-bit immediate
 into every byte element of the register pair designated by `rd_p`. This is
 equivalent to performing PLI.B on both the even and odd registers of the
 pair. This instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -999,11 +999,11 @@ if (rd_p != 0):
 <<<
 ==== PLI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pli.dh _rd_p_, _simm10_
 
-===== Encoding
+Encoding::
 
 PLI.DH is encoded in the OP-IMM-32 major opcode (register-pair variant)
 with a 10-bit signed immediate and packed halfword elements. This instruction
@@ -1022,7 +1022,7 @@ exists only for RV32 and uses a register-pair destination `rd_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PLI.DH (Packed Load Immediate, Double-wide Halfword) sign-extends a 10-bit
 signed immediate to 16 bits and replicates it into every halfword element of
@@ -1030,7 +1030,7 @@ the register pair designated by `rd_p`. This is equivalent to performing
 PLI.H on both the even and odd registers of the pair. This instruction is
 available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1048,11 +1048,11 @@ if (rd_p != 0):
 <<<
 ==== PLUI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 plui.dh _rd_p_, _simm10_
 
-===== Encoding
+Encoding::
 
 PLUI.DH is encoded in the OP-IMM-32 major opcode (register-pair variant)
 with a 10-bit immediate loaded into the upper bits of each halfword element.
@@ -1072,7 +1072,7 @@ This instruction exists only for RV32 and uses a register-pair destination
 ]}
 ....
 
-===== Description
+Description::
 
 PLUI.DH (Packed Load Upper Immediate, Double-wide Halfword) loads a 10-bit
 signed immediate into the most-significant 10 bits of each 16-bit halfword
@@ -1081,7 +1081,7 @@ every halfword element of the register pair designated by `rd_p`. This is
 equivalent to performing PLUI.H on both the even and odd registers of the
 pair. This instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1101,11 +1101,11 @@ if (rd_p != 0):
 
 ==== PADD.B
 
-===== Mnemonic
+Mnemonic::
 
 padd.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -1123,12 +1123,12 @@ PADD.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.B adds corresponding packed 8-bit elements of `rs1` and `rs2` and writes
 the packed byte results to `rd`. Each element addition wraps modulo 2^8.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1147,11 +1147,11 @@ X[rd] = d
 <<<
 ==== PADD.H
 
-===== Mnemonic
+Mnemonic::
 
 padd.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -1169,13 +1169,13 @@ PADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.H adds corresponding packed 16-bit halfword elements of `rs1` and `rs2`
 and writes the packed halfword results to `rd`. Each element addition wraps
 modulo 2^16.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1194,11 +1194,11 @@ X[rd] = d
 <<<
 ==== PADD.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 padd.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -1216,13 +1216,13 @@ PADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.W adds corresponding packed 32-bit word elements of `rs1` and `rs2` and
 writes the packed word results to `rd`. Each element addition wraps modulo 2^32.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1239,11 +1239,11 @@ X[rd] = d
 <<<
 ==== PADD.BS
 
-===== Mnemonic
+Mnemonic::
 
 padd.bs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.BS is encoded using the OP-IMM-32 major opcode with a scalar second source
 operand and packed byte elements.
@@ -1263,12 +1263,12 @@ operand and packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PADD.BS instruction adds the least-significant byte of `rs2` to each packed
 8-bit element of `rs1`, producing a packed byte result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1282,7 +1282,7 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * Each 8-bit element addition wraps modulo 2^8.
 * The scalar operand is taken only from bits [7:0] of `rs2`; higher bits are ignored.
@@ -1290,11 +1290,11 @@ X[rd] = d
 <<<
 ==== PADD.HS
 
-===== Mnemonic
+Mnemonic::
 
 padd.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.HS is encoded in the OP-IMM-32 major opcode with a scalar second source
 operand and packed halfword elements.
@@ -1314,12 +1314,12 @@ operand and packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PADD.HS instruction adds the least-significant halfword of `rs2` to each
 packed 16-bit element of `rs1`, producing a packed halfword result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1337,11 +1337,11 @@ X[rd] = d
 <<<
 ==== PADD.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 padd.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.WS is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 
@@ -1360,12 +1360,12 @@ PADD.WS is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PADD.WS instruction adds the least-significant word of `rs2` to each packed
 32-bit element of `rs1`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1383,11 +1383,11 @@ X[rd] = d
 <<<
 ==== PADD.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 padd.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PADD.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -1409,7 +1409,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.DB performs packed 8-bit byte addition on double-wide (register-pair)
 operands. It is equivalent to two PADD.B operations: one on the even registers
@@ -1417,7 +1417,7 @@ and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
 `rs2_p`) are register pairs and must specify even register numbers. Each element
 addition wraps modulo 2^8. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1439,11 +1439,11 @@ if (rd_p != 0):
 <<<
 ==== PADD.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 padd.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PADD.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -1465,7 +1465,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.DH performs packed 16-bit halfword addition on double-wide (register-pair)
 operands. It is equivalent to two PADD.H operations: one on the even registers
@@ -1473,7 +1473,7 @@ and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
 `rs2_p`) are register pairs and must specify even register numbers. Each element
 addition wraps modulo 2^16. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1495,11 +1495,11 @@ if (rd_p != 0):
 <<<
 ==== PADD.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 padd.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -1521,7 +1521,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.DW performs 32-bit word addition on double-wide (register-pair) operands.
 It is equivalent to two ADD operations: one on the even registers and one on
@@ -1529,7 +1529,7 @@ the odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`)
 are register pairs and must specify even register numbers. Each element addition
 wraps modulo 2^32. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1551,11 +1551,11 @@ if (rd_p != 0):
 <<<
 ==== PADD.DBS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 padd.dbs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.DBS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed byte elements. Available only in RV32.
@@ -1577,7 +1577,7 @@ scalar format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.DBS adds the least-significant byte of `rs2` to each packed 8-bit element
 across a double-wide (register-pair) source. It is equivalent to two PADD.BS
@@ -1586,7 +1586,7 @@ The destination (`rd_p`) and first source (`rs1_p`) are register pairs and must
 specify even register numbers; `rs2` is a single register. Each element addition
 wraps modulo 2^8. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1607,11 +1607,11 @@ if (rd_p != 0):
 <<<
 ==== PADD.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 padd.dhs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed halfword elements. Available only in RV32.
@@ -1633,7 +1633,7 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.DHS adds the least-significant halfword of `rs2` to each packed 16-bit
 element across a double-wide (register-pair) source. It is equivalent to two
@@ -1642,7 +1642,7 @@ each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
 pairs and must specify even register numbers; `rs2` is a single register. Each
 element addition wraps modulo 2^16. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1663,11 +1663,11 @@ if (rd_p != 0):
 <<<
 ==== PADD.DWS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 padd.dws _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PADD.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with word elements. Available only in RV32.
@@ -1689,7 +1689,7 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PADD.DWS adds the least-significant word of `rs2` to each 32-bit element across
 a double-wide (register-pair) source. It is equivalent to two PADD.WS
@@ -1698,7 +1698,7 @@ The destination (`rd_p`) and first source (`rs1_p`) are register pairs and must
 specify even register numbers; `rs2` is a single register. Each element addition
 wraps modulo 2^32. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1722,11 +1722,11 @@ if (rd_p != 0):
 
 ==== PSUB.B
 
-===== Mnemonic
+Mnemonic::
 
 psub.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSUB.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -1744,13 +1744,13 @@ PSUB.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSUB.B subtracts corresponding packed 8-bit elements of `rs2` from `rs1` and
 writes the packed byte results to `rd`. Each element subtraction wraps modulo
 2^8.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1769,11 +1769,11 @@ X[rd] = d
 <<<
 ==== PSUB.H
 
-===== Mnemonic
+Mnemonic::
 
 psub.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -1791,13 +1791,13 @@ PSUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSUB.H subtracts corresponding packed 16-bit halfword elements of `rs2` from
 `rs1` and writes the packed halfword results to `rd`. Each element subtraction
 wraps modulo 2^16.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1816,11 +1816,11 @@ X[rd] = d
 <<<
 ==== PSUB.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psub.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -1838,13 +1838,13 @@ PSUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSUB.W subtracts corresponding packed 32-bit word elements of `rs2` from `rs1`
 and writes the packed word results to `rd`. Each element subtraction wraps
 modulo 2^32. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1861,11 +1861,11 @@ X[rd] = d
 <<<
 ==== PSUB.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psub.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSUB.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -1887,7 +1887,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSUB.DB performs packed 8-bit byte subtraction on double-wide (register-pair)
 operands. It is equivalent to two PSUB.B operations: one on the even registers
@@ -1895,7 +1895,7 @@ and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
 `rs2_p`) are register pairs and must specify even register numbers. Each element
 subtraction wraps modulo 2^8. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1917,11 +1917,11 @@ if (rd_p != 0):
 <<<
 ==== PSUB.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psub.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSUB.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -1943,7 +1943,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSUB.DH performs packed 16-bit halfword subtraction on double-wide
 (register-pair) operands. It is equivalent to two PSUB.H operations: one on the
@@ -1951,7 +1951,7 @@ even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Each element subtraction wraps modulo 2^16. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -1973,11 +1973,11 @@ if (rd_p != 0):
 <<<
 ==== PSUB.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psub.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSUB.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -1999,7 +1999,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSUB.DW performs 32-bit word subtraction on double-wide (register-pair)
 operands. It is equivalent to two SUB operations: one on the even registers and
@@ -2007,7 +2007,7 @@ one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
 `rs2_p`) are register pairs and must specify even register numbers. Each element
 subtraction wraps modulo 2^32. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2032,11 +2032,11 @@ if (rd_p != 0):
 
 ==== PSADD.B
 
-===== Mnemonic
+Mnemonic::
 
 psadd.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSADD.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -2054,13 +2054,13 @@ PSADD.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADD.B performs signed saturating addition on packed 8-bit byte elements of
 `rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
 the range [-128, 127]. Corresponds to KADD8 in the earlier P extension draft.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2085,11 +2085,11 @@ X[rd] = d
 <<<
 ==== PSADD.H
 
-===== Mnemonic
+Mnemonic::
 
 psadd.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -2107,14 +2107,14 @@ PSADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADD.H performs signed saturating addition on packed 16-bit halfword elements
 of `rs1` and `rs2`, writing the results to `rd`. Each element result is clamped
 to the range [-32768, 32767]. Corresponds to KADD16 in the earlier P extension
 draft.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2139,11 +2139,11 @@ X[rd] = d
 <<<
 ==== PSADD.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psadd.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSADD.W is encoded in the OP-32 major opcode with packed word elements.
 Available only in RV64.
@@ -2162,14 +2162,14 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADD.W performs signed saturating addition on packed 32-bit word elements of
 `rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
 the range [-(2^31), 2^31-1]. Corresponds to KADD32 in the earlier P extension
 draft. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2195,11 +2195,11 @@ X[rd] = d
 <<<
 ==== PSADDU.B
 
-===== Mnemonic
+Mnemonic::
 
 psaddu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSADDU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -2217,13 +2217,13 @@ PSADDU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADDU.B performs unsigned saturating addition on packed 8-bit byte elements of
 `rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
 the range [0, 255]. Corresponds to UKADD8 in the earlier P extension draft.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2246,11 +2246,11 @@ X[rd] = d
 <<<
 ==== PSADDU.H
 
-===== Mnemonic
+Mnemonic::
 
 psaddu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -2268,14 +2268,14 @@ PSADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADDU.H performs unsigned saturating addition on packed 16-bit halfword
 elements of `rs1` and `rs2`, writing the results to `rd`. Each element result is
 clamped to the range [0, 65535]. Corresponds to UKADD16 in the earlier P
 extension draft.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2298,11 +2298,11 @@ X[rd] = d
 <<<
 ==== PSADDU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psaddu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSADDU.W is encoded in the OP-32 major opcode with packed word elements.
 Available only in RV64.
@@ -2321,14 +2321,14 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADDU.W performs unsigned saturating addition on packed 32-bit word elements of
 `rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
 the range [0, 2^32-1]. Corresponds to UKADD32 in the earlier P extension draft.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2352,11 +2352,11 @@ X[rd] = d
 <<<
 ==== SADD (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 sadd _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SADD is encoded in the OP-32 major opcode as a scalar XLEN-wide signed
 saturating addition. This instruction is available only in RV32.
@@ -2375,14 +2375,14 @@ saturating addition. This instruction is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 SADD performs signed saturating addition of the full XLEN-wide values in `rs1`
 and `rs2`, writing the result to `rd`. The result is clamped to the range
 [-(2^(XLEN-1)), 2^(XLEN-1)-1]. Corresponds to KADDW in the earlier P extension
 draft.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2404,11 +2404,11 @@ X[rd] = d
 <<<
 ==== SADDU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 saddu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SADDU is encoded in the OP-32 major opcode and is available only in RV32.
 
@@ -2426,13 +2426,13 @@ SADDU is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 SADDU performs unsigned saturating addition of the full XLEN-wide values in
 `rs1` and `rs2`, writing the result to `rd`. The result is clamped to the range
 [0, 2^XLEN-1]. Corresponds to UKADDW in the earlier P extension draft.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2452,11 +2452,11 @@ X[rd] = d
 <<<
 ==== PSADD.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psadd.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSADD.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -2478,7 +2478,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADD.DB performs signed saturating addition on packed 8-bit byte elements using
 double-wide (register-pair) operands. It is equivalent to two PSADD.B
@@ -2487,7 +2487,7 @@ All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
 specify even register numbers. Each element result is clamped to the range
 [-128, 127]. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2515,11 +2515,11 @@ if (rd_p != 0):
 <<<
 ==== PSADD.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psadd.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSADD.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -2541,7 +2541,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADD.DH performs signed saturating addition on packed 16-bit halfword elements
 using double-wide (register-pair) operands. It is equivalent to two PSADD.H
@@ -2550,7 +2550,7 @@ All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
 specify even register numbers. Each element result is clamped to the range
 [-32768, 32767]. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2578,11 +2578,11 @@ if (rd_p != 0):
 <<<
 ==== PSADD.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psadd.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -2604,7 +2604,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADD.DW performs signed saturating 32-bit word addition on double-wide
 (register-pair) operands. It is equivalent to two SADD operations: one on the
@@ -2613,7 +2613,7 @@ even registers and one on the odd registers of each pair. All three operands
 numbers. Each element result is clamped to the range [-(2^31), 2^31-1].
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2641,11 +2641,11 @@ if (rd_p != 0):
 <<<
 ==== PSADDU.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psaddu.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSADDU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -2667,7 +2667,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADDU.DB performs unsigned saturating addition on packed 8-bit byte elements
 using double-wide (register-pair) operands. It is equivalent to two PSADDU.B
@@ -2676,7 +2676,7 @@ All three operands (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must
 specify even register numbers. Each element result is clamped to the range
 [0, 255]. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2702,11 +2702,11 @@ if (rd_p != 0):
 <<<
 ==== PSADDU.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psaddu.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSADDU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed halfword elements. This instruction exists
@@ -2729,7 +2729,7 @@ only for RV32 and uses register pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADDU.DH (Packed Saturating Add Unsigned, Double-wide Halfword) performs
 unsigned saturating addition on corresponding packed 16-bit halfword elements
@@ -2737,7 +2737,7 @@ across a register pair. This is equivalent to performing PSADDU.H on both the
 even and odd registers of the pair. Each element result is clamped to the
 range [0, 2^16-1]. Available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2761,11 +2761,11 @@ if (rd_p != 0):
 <<<
 ==== PSADDU.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psaddu.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSADDU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. This instruction exists only for RV32 and uses register
@@ -2788,7 +2788,7 @@ pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PSADDU.DW (Packed Saturating Add Unsigned, Double-wide Word) performs unsigned
 saturating addition on corresponding 32-bit word values across a register
@@ -2796,7 +2796,7 @@ pair. This is equivalent to performing SADDU on both the even and odd
 registers of the pair. Each element result is clamped to the range
 [0, 2^32-1]. Available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2823,11 +2823,11 @@ if (rd_p != 0):
 
 ==== PSSUB.B
 
-===== Mnemonic
+Mnemonic::
 
 pssub.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSUB.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -2845,13 +2845,13 @@ PSSUB.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUB.B performs signed saturating subtraction on corresponding packed 8-bit
 byte elements of `rs1` and `rs2`, writing the results to `rd`. Each element
 result is clamped to the range [-(2^7), 2^7-1].
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2875,11 +2875,11 @@ X[rd] = d
 <<<
 ==== PSSUB.H
 
-===== Mnemonic
+Mnemonic::
 
 pssub.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -2897,13 +2897,13 @@ PSSUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUB.H performs signed saturating subtraction on corresponding packed 16-bit
 halfword elements of `rs1` and `rs2`, writing the results to `rd`. Each
 element result is clamped to the range [-(2^15), 2^15-1].
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2927,11 +2927,11 @@ X[rd] = d
 <<<
 ==== PSSUB.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pssub.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -2949,13 +2949,13 @@ PSSUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUB.W performs signed saturating subtraction on corresponding packed 32-bit
 word elements of `rs1` and `rs2`, writing the results to `rd`. Each element
 result is clamped to the range [-(2^31), 2^31-1]. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -2989,11 +2989,11 @@ X[rd] = d
 <<<
 ==== PSSUBU.B
 
-===== Mnemonic
+Mnemonic::
 
 pssubu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSUBU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -3011,13 +3011,13 @@ PSSUBU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUBU.B performs unsigned saturating subtraction on corresponding packed
 8-bit byte elements of `rs1` and `rs2`, writing the results to `rd`. Each
 element result is clamped to the range [0, 2^8-1].
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3039,11 +3039,11 @@ X[rd] = d
 <<<
 ==== PSSUBU.H
 
-===== Mnemonic
+Mnemonic::
 
 pssubu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -3061,13 +3061,13 @@ PSSUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUBU.H performs unsigned saturating subtraction on corresponding packed
 16-bit halfword elements of `rs1` and `rs2`, writing the results to `rd`.
 Each element result is clamped to the range [0, 2^16-1].
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3089,11 +3089,11 @@ X[rd] = d
 <<<
 ==== PSSUBU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pssubu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -3111,13 +3111,13 @@ PSSUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUBU.W performs unsigned saturating subtraction on corresponding packed
 32-bit word elements of `rs1` and `rs2`, writing the results to `rd`. Each
 element result is clamped to the range [0, 2^32-1]. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3147,11 +3147,11 @@ X[rd] = d
 <<<
 ==== SSUB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ssub _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SSUB is encoded in the OP-32 major opcode. On RV32 it operates on a single
 XLEN-wide (32-bit) value; on RV64 it is the PSSUB.W instruction.
@@ -3170,14 +3170,14 @@ XLEN-wide (32-bit) value; on RV64 it is the PSSUB.W instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 SSUB performs signed saturating subtraction of `rs2` from `rs1`, writing the
 result to `rd`. The result is clamped to the range [-(2^(XLEN-1)),
 2^(XLEN-1)-1]. On RV32 this is the XLEN-wide scalar form; on RV64 this
 encoding is used by PSSUB.W.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3197,11 +3197,11 @@ X[rd] = res[XLEN-1:0]
 <<<
 ==== SSUBU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ssubu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SSUBU is encoded in the OP-32 major opcode and is available only in RV32.
 
@@ -3219,13 +3219,13 @@ SSUBU is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 SSUBU performs unsigned saturating subtraction of `rs2` from `rs1`, writing
 the result to `rd`. The result is clamped to the range [0, 2^XLEN-1]. This
 instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3243,11 +3243,11 @@ X[rd] = res[XLEN-1:0]
 <<<
 ==== PSSUB.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssub.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSUB.DB is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format with
 packed byte elements. This instruction exists only for RV32 and uses register
@@ -3270,7 +3270,7 @@ pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUB.DB (Packed Signed Saturating Subtract, Double-wide Byte) performs signed
 saturating subtraction on corresponding packed 8-bit byte elements across a
@@ -3278,7 +3278,7 @@ register pair. This is equivalent to performing PSSUB.B on both the even and
 odd registers of the pair. Each element result is clamped to the range
 [-(2^7), 2^7-1]. Available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3304,11 +3304,11 @@ if (rd_p != 0):
 <<<
 ==== PSSUB.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssub.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSUB.DH is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format with
 packed halfword elements. This instruction exists only for RV32 and uses
@@ -3331,7 +3331,7 @@ register pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUB.DH (Packed Signed Saturating Subtract, Double-wide Halfword) performs
 signed saturating subtraction on corresponding packed 16-bit halfword elements
@@ -3339,7 +3339,7 @@ across a register pair. This is equivalent to performing PSSUB.H on both the
 even and odd registers of the pair. Each element result is clamped to the
 range [-(2^15), 2^15-1]. Available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3365,11 +3365,11 @@ if (rd_p != 0):
 <<<
 ==== PSSUB.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssub.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSUB.DW is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format. This
 instruction exists only for RV32 and uses register pairs `rd_p`, `rs1_p`, and
@@ -3392,7 +3392,7 @@ instruction exists only for RV32 and uses register pairs `rd_p`, `rs1_p`, and
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUB.DW (Packed Signed Saturating Subtract, Double-wide Word) performs signed
 saturating subtraction on corresponding 32-bit word values across a register
@@ -3400,7 +3400,7 @@ pair. This is equivalent to performing SSUB on both the even and odd registers
 of the pair. Each element result is clamped to the range [-(2^31), 2^31-1].
 Available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3426,11 +3426,11 @@ if (rd_p != 0):
 <<<
 ==== PSSUBU.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssubu.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSUBU.DB is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format with
 packed byte elements. This instruction exists only for RV32 and uses register
@@ -3453,7 +3453,7 @@ pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUBU.DB (Packed Unsigned Saturating Subtract, Double-wide Byte) performs
 unsigned saturating subtraction on corresponding packed 8-bit byte elements
@@ -3461,7 +3461,7 @@ across a register pair. This is equivalent to performing PSSUBU.B on both the
 even and odd registers of the pair. Each element result is clamped to the
 range [0, 2^8-1]. Available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3485,11 +3485,11 @@ if (rd_p != 0):
 <<<
 ==== PSSUBU.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssubu.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSUBU.DH is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format with
 packed halfword elements. This instruction exists only for RV32 and uses
@@ -3512,7 +3512,7 @@ register pairs `rd_p`, `rs1_p`, and `rs2_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUBU.DH (Packed Unsigned Saturating Subtract, Double-wide Halfword) performs
 unsigned saturating subtraction on corresponding packed 16-bit halfword
@@ -3520,7 +3520,7 @@ elements across a register pair. This is equivalent to performing PSSUBU.H on
 both the even and odd registers of the pair. Each element result is clamped to
 the range [0, 2^16-1]. Available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3544,11 +3544,11 @@ if (rd_p != 0):
 <<<
 ==== PSSUBU.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssubu.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSUBU.DW is encoded in the OP-IMM-32 major opcode using the double-wide register-pair format. This
 instruction exists only for RV32 and uses register pairs `rd_p`, `rs1_p`, and
@@ -3571,7 +3571,7 @@ instruction exists only for RV32 and uses register pairs `rd_p`, `rs1_p`, and
 ]}
 ....
 
-===== Description
+Description::
 
 PSSUBU.DW (Packed Unsigned Saturating Subtract, Double-wide Word) performs
 unsigned saturating subtraction on corresponding 32-bit word values across a
@@ -3579,7 +3579,7 @@ register pair. This is equivalent to performing SSUBU on both the even and odd
 registers of the pair. Each element result is clamped to the range
 [0, 2^32-1]. Available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3606,11 +3606,11 @@ if (rd_p != 0):
 
 ==== PAADD.B
 
-===== Mnemonic
+Mnemonic::
 
 paadd.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAADD.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -3628,14 +3628,14 @@ PAADD.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADD.B performs a signed averaging addition on packed 8-bit elements. For each
 byte lane, it adds the signed elements from `rs1` and `rs2` at full precision
 (9 bits), then shifts the result right by 1 (toward negative infinity), and
 writes the lower 8 bits to the corresponding byte of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3655,11 +3655,11 @@ X[rd] = d
 <<<
 ==== PAADD.H
 
-===== Mnemonic
+Mnemonic::
 
 paadd.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -3677,14 +3677,14 @@ PAADD.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADD.H performs a signed averaging addition on packed 16-bit halfword elements.
 For each halfword lane, it adds the signed elements from `rs1` and `rs2` at full
 precision (17 bits), then shifts the result right by 1 (toward negative
 infinity), and writes the lower 16 bits to the corresponding halfword of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3704,11 +3704,11 @@ X[rd] = d
 <<<
 ==== PAADD.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 paadd.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -3726,7 +3726,7 @@ PAADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADD.W performs a signed averaging addition on packed 32-bit word elements.
 For each word lane, it adds the signed elements from `rs1` and `rs2` at full
@@ -3734,7 +3734,7 @@ precision (33 bits), then shifts the result right by 1 (toward negative
 infinity), and writes the lower 32 bits to the corresponding word of `rd`.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3759,11 +3759,11 @@ X[rd] = d
 <<<
 ==== PAADDU.B
 
-===== Mnemonic
+Mnemonic::
 
 paaddu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAADDU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -3781,14 +3781,14 @@ PAADDU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADDU.B performs an unsigned averaging addition on packed 8-bit elements. For
 each byte lane, it adds the unsigned elements from `rs1` and `rs2` at full
 precision (9 bits), then shifts the result right by 1, and writes the lower
 8 bits to the corresponding byte of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3808,11 +3808,11 @@ X[rd] = d
 <<<
 ==== PAADDU.H
 
-===== Mnemonic
+Mnemonic::
 
 paaddu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -3830,14 +3830,14 @@ PAADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADDU.H performs an unsigned averaging addition on packed 16-bit halfword
 elements. For each halfword lane, it adds the unsigned elements from `rs1` and
 `rs2` at full precision (17 bits), then shifts the result right by 1, and writes
 the lower 16 bits to the corresponding halfword of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3857,11 +3857,11 @@ X[rd] = d
 <<<
 ==== PAADDU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 paaddu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAADDU.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -3879,14 +3879,14 @@ PAADDU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADDU.W performs an unsigned averaging addition on packed 32-bit word elements.
 For each word lane, it adds the unsigned elements from `rs1` and `rs2` at full
 precision (33 bits), then shifts the result right by 1, and writes the lower
 32 bits to the corresponding word of `rd`. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3911,11 +3911,11 @@ X[rd] = d
 <<<
 ==== AADD (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 aadd _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 AADD is encoded in the OP-32 major opcode and is available only in RV32.
 
@@ -3933,14 +3933,14 @@ AADD is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 AADD performs a signed averaging addition on a single XLEN-wide value. It adds
 the signed values in `rs1` and `rs2` at full precision (33 bits), then shifts
 the result right by 1 (toward negative infinity), and writes the lower 32 bits
 to `rd`. Available only in RV32; the RV64 counterpart is PAADD.W.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3955,11 +3955,11 @@ X[rd] = to_bits(32, sum >> 1)
 <<<
 ==== AADDU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 aaddu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 AADDU is encoded in the OP-32 major opcode and is available only in RV32.
 
@@ -3977,14 +3977,14 @@ AADDU is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 AADDU performs an unsigned averaging addition on a single XLEN-wide value. It
 adds the unsigned values in `rs1` and `rs2` at full precision (33 bits), then
 shifts the result right by 1, and writes the lower 32 bits to `rd`. Available
 only in RV32; the RV64 counterpart is PAADDU.W.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -3999,11 +3999,11 @@ X[rd] = to_bits(32, sum >> 1)
 <<<
 ==== PAADD.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 paadd.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PAADD.DB is the register-pair (double-wide) variant of PAADD.B and is available
 only in RV32. It is encoded in the OP-IMM-32 major opcode using the double-wide
@@ -4026,14 +4026,14 @@ register-pair format with register-pair operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADD.DB (Packed Averaging Add, Double-wide Byte) performs a signed averaging
 addition on packed 8-bit elements across register pairs. It is equivalent to
 performing PAADD.B independently on both the even and odd registers of the
 source and destination pairs. This instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4056,11 +4056,11 @@ if (rd_p != 0):
 <<<
 ==== PAADD.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 paadd.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PAADD.DH is the register-pair (double-wide) variant of PAADD.H and is available
 only in RV32. It is encoded in the OP-IMM-32 major opcode using the double-wide
@@ -4083,7 +4083,7 @@ register-pair format with register-pair operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADD.DH (Packed Averaging Add, Double-wide Halfword) performs a signed
 averaging addition on packed 16-bit halfword elements across register pairs. It
@@ -4091,7 +4091,7 @@ is equivalent to performing PAADD.H independently on both the even and odd
 registers of the source and destination pairs. This instruction is available
 only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4114,11 +4114,11 @@ if (rd_p != 0):
 <<<
 ==== PAADD.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 paadd.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PAADD.DW is the register-pair (double-wide) variant of PAADD.W and is available
 only in RV32. It is encoded in the OP-IMM-32 major opcode using the double-wide
@@ -4141,14 +4141,14 @@ register-pair format with register-pair operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADD.DW (Packed Averaging Add, Double-wide Word) performs a signed averaging
 addition on packed 32-bit word elements across register pairs. It is equivalent
 to performing AADD independently on both the even and odd registers of the
 source and destination pairs. This instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4171,11 +4171,11 @@ if (rd_p != 0):
 <<<
 ==== PAADDU.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 paaddu.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PAADDU.DB is the register-pair (double-wide) variant of PAADDU.B and is
 available only in RV32. It shares the same encoding as PAADDU.B with
@@ -4198,7 +4198,7 @@ register-pair operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADDU.DB (Packed Averaging Add Unsigned, Double-wide Byte) performs an unsigned
 averaging addition on packed 8-bit elements across register pairs. It is
@@ -4206,7 +4206,7 @@ equivalent to performing PAADDU.B independently on both the even and odd
 registers of the source and destination pairs. This instruction is available
 only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4229,11 +4229,11 @@ if (rd_p != 0):
 <<<
 ==== PAADDU.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 paaddu.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PAADDU.DH is the register-pair (double-wide) variant of PAADDU.H and is
 available only in RV32. It is encoded in the OP-IMM-32 major opcode using the
@@ -4256,7 +4256,7 @@ double-wide register-pair format with register-pair operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADDU.DH (Packed Averaging Add Unsigned, Double-wide Halfword) performs an
 unsigned averaging addition on packed 16-bit halfword elements across register
@@ -4264,7 +4264,7 @@ pairs. It is equivalent to performing PAADDU.H independently on both the even
 and odd registers of the source and destination pairs. This instruction is
 available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4287,11 +4287,11 @@ if (rd_p != 0):
 <<<
 ==== PAADDU.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 paaddu.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PAADDU.DW is the register-pair (double-wide) variant of PAADDU.W and is
 available only in RV32. It is encoded in the OP-IMM-32 major opcode using the
@@ -4314,14 +4314,14 @@ double-wide register-pair format with register-pair operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PAADDU.DW (Packed Averaging Add Unsigned, Double-wide Word) performs an unsigned
 averaging addition on packed 32-bit word elements across register pairs. It is
 equivalent to performing AADDU independently on both the even and odd registers
 of the source and destination pairs. This instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4347,11 +4347,11 @@ if (rd_p != 0):
 
 ==== PASUB.B
 
-===== Mnemonic
+Mnemonic::
 
 pasub.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PASUB.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -4369,7 +4369,7 @@ PASUB.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUB.B performs a signed averaging subtraction on packed 8-bit elements. For
 each byte lane, it subtracts the signed element in `rs2` from the signed element
@@ -4377,7 +4377,7 @@ in `rs1` at full precision (9 bits), then shifts the result right by 1 (toward
 negative infinity), and writes the lower 8 bits to the corresponding byte of
 `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4397,11 +4397,11 @@ X[rd] = d
 <<<
 ==== PASUB.H
 
-===== Mnemonic
+Mnemonic::
 
 pasub.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PASUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -4419,7 +4419,7 @@ PASUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUB.H performs a signed averaging subtraction on packed 16-bit halfword
 elements. For each halfword lane, it subtracts the signed element in `rs2` from
@@ -4427,7 +4427,7 @@ the signed element in `rs1` at full precision (17 bits), then shifts the result
 right by 1 (toward negative infinity), and writes the lower 16 bits to the
 corresponding halfword of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4447,11 +4447,11 @@ X[rd] = d
 <<<
 ==== PASUB.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pasub.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PASUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -4469,7 +4469,7 @@ PASUB.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUB.W performs a signed averaging subtraction on packed 32-bit word elements.
 For each word lane, it subtracts the signed element in `rs2` from the signed
@@ -4477,7 +4477,7 @@ element in `rs1` at full precision (33 bits), then shifts the result right by 1
 (toward negative infinity), and writes the lower 32 bits to the corresponding
 word of `rd`. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4502,11 +4502,11 @@ X[rd] = d
 <<<
 ==== PASUBU.B
 
-===== Mnemonic
+Mnemonic::
 
 pasubu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PASUBU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -4524,14 +4524,14 @@ PASUBU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUBU.B performs an unsigned averaging subtraction on packed 8-bit elements.
 For each byte lane, it subtracts the unsigned element in `rs2` from the unsigned
 element in `rs1` at full precision (9 bits), then shifts the result right by 1,
 and writes the lower 8 bits to the corresponding byte of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4551,11 +4551,11 @@ X[rd] = d
 <<<
 ==== PASUBU.H
 
-===== Mnemonic
+Mnemonic::
 
 pasubu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PASUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -4573,7 +4573,7 @@ PASUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUBU.H performs an unsigned averaging subtraction on packed 16-bit halfword
 elements. For each halfword lane, it subtracts the unsigned element in `rs2`
@@ -4581,7 +4581,7 @@ from the unsigned element in `rs1` at full precision (17 bits), then shifts the
 result right by 1, and writes the lower 16 bits to the corresponding halfword
 of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4601,11 +4601,11 @@ X[rd] = d
 <<<
 ==== PASUBU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pasubu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PASUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -4623,7 +4623,7 @@ PASUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUBU.W performs an unsigned averaging subtraction on packed 32-bit word
 elements. For each word lane, it subtracts the unsigned element in `rs2` from
@@ -4631,7 +4631,7 @@ the unsigned element in `rs1` at full precision (33 bits), then shifts the
 result right by 1, and writes the lower 32 bits to the corresponding word of
 `rd`. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4656,11 +4656,11 @@ X[rd] = d
 <<<
 ==== ASUB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 asub _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 ASUB is encoded in the OP-32 major opcode and is available only in RV32.
 
@@ -4678,14 +4678,14 @@ ASUB is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 ASUB performs a signed averaging subtraction on a single XLEN-wide value. It
 subtracts the signed value in `rs2` from `rs1` at full precision (33 bits), then
 shifts the result right by 1 (toward negative infinity), and writes the lower
 32 bits to `rd`. Available only in RV32; the RV64 counterpart is PASUB.W.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4700,11 +4700,11 @@ X[rd] = to_bits(32, diff >> 1)
 <<<
 ==== ASUBU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 asubu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 ASUBU is encoded in the OP-32 major opcode and is available only in RV32.
 
@@ -4722,14 +4722,14 @@ ASUBU is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 ASUBU performs an unsigned averaging subtraction on a single XLEN-wide value. It
 subtracts the unsigned value in `rs2` from `rs1` at full precision (33 bits),
 then shifts the result right by 1, and writes the lower 32 bits to `rd`.
 Available only in RV32; the RV64 counterpart is PASUBU.W.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4744,11 +4744,11 @@ X[rd] = to_bits(32, diff >> 1)
 <<<
 ==== PASUB.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pasub.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PASUB.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -4770,7 +4770,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUB.DB (Packed Averaging Subtract, Double-wide Byte) performs a signed
 averaging subtraction on packed 8-bit elements across register pairs. It is
@@ -4778,7 +4778,7 @@ equivalent to performing PASUB.B independently on both the even and odd
 registers of the source and destination pairs. This instruction is available
 only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4801,11 +4801,11 @@ if (rd_p != 0):
 <<<
 ==== PASUB.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pasub.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PASUB.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -4827,7 +4827,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUB.DH (Packed Averaging Subtract, Double-wide Halfword) performs a signed
 averaging subtraction on packed 16-bit halfword elements across register pairs.
@@ -4835,7 +4835,7 @@ It is equivalent to performing PASUB.H independently on both the even and odd
 registers of the source and destination pairs. This instruction is available
 only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4858,11 +4858,11 @@ if (rd_p != 0):
 <<<
 ==== PASUB.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pasub.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PASUB.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -4884,7 +4884,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUB.DW (Packed Averaging Subtract, Double-wide Word) performs a signed
 averaging subtraction on packed 32-bit word elements across register pairs. It
@@ -4892,7 +4892,7 @@ is equivalent to performing ASUB independently on both the even and odd
 registers of the source and destination pairs. This instruction is available
 only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4915,11 +4915,11 @@ if (rd_p != 0):
 <<<
 ==== PASUBU.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pasubu.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PASUBU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -4941,7 +4941,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUBU.DB (Packed Averaging Subtract Unsigned, Double-wide Byte) performs an
 unsigned averaging subtraction on packed 8-bit elements across register pairs.
@@ -4949,7 +4949,7 @@ It is equivalent to performing PASUBU.B independently on both the even and odd
 registers of the source and destination pairs. This instruction is available
 only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -4972,11 +4972,11 @@ if (rd_p != 0):
 <<<
 ==== PASUBU.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pasubu.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PASUBU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -4998,7 +4998,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUBU.DH (Packed Averaging Subtract Unsigned, Double-wide Halfword) performs
 an unsigned averaging subtraction on packed 16-bit halfword elements across
@@ -5006,7 +5006,7 @@ register pairs. It is equivalent to performing PASUBU.H independently on both
 the even and odd registers of the source and destination pairs. This instruction
 is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5029,11 +5029,11 @@ if (rd_p != 0):
 <<<
 ==== PASUBU.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pasubu.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PASUBU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -5055,7 +5055,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PASUBU.DW (Packed Averaging Subtract Unsigned, Double-wide Word) performs an
 unsigned averaging subtraction on packed 32-bit word elements across register
@@ -5063,7 +5063,7 @@ pairs. It is equivalent to performing ASUBU independently on both the even and
 odd registers of the source and destination pairs. This instruction is available
 only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5088,11 +5088,11 @@ if (rd_p != 0):
 
 ==== PSH1ADD.H
 
-===== Mnemonic
+Mnemonic::
 
 psh1add.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSH1ADD.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
 
@@ -5111,12 +5111,12 @@ PSH1ADD.H is encoded in the OP-32 major opcode. It uses packed halfword elements
 ]}
 ....
 
-===== Description
+Description::
 
 The PSH1ADD.H instruction computes, for each packed 16-bit element,
 `(rs1_h << 1) + rs2_h`, and writes the packed halfword result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5135,11 +5135,11 @@ X[rd] = d
 <<<
 ==== PSH1ADD.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psh1add.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSH1ADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -5158,12 +5158,12 @@ PSH1ADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSH1ADD.W instruction computes, for each packed 32-bit element,
 `(rs1_w << 1) + rs2_w`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5180,11 +5180,11 @@ X[rd] = d
 <<<
 ==== PSSH1SADD.H
 
-===== Mnemonic
+Mnemonic::
 
 pssh1sadd.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSH1SADD.H is encoded in the OP-32 major opcode. It uses packed halfword
 elements and performs signed saturating arithmetic.
@@ -5204,14 +5204,14 @@ elements and performs signed saturating arithmetic.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSH1SADD.H instruction performs a signed saturating left shift by 1 on each
 packed 16-bit element of `rs1`, then performs a signed saturating add with the
 corresponding packed 16-bit element of `rs2`. The packed halfword result is
 written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5244,7 +5244,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element, either during the
   shift-left-by-1 step or during the subsequent add.
@@ -5252,11 +5252,11 @@ X[rd] = d
 <<<
 ==== PSSH1SADD.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pssh1sadd.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSH1SADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -5275,13 +5275,13 @@ PSSH1SADD.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSH1SADD.W instruction performs a signed saturating left shift by 1 on each
 packed 32-bit element of `rs1`, followed by a signed saturating add with the
 corresponding element of `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5314,18 +5314,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== SSH1SADD (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ssh1sadd _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SSH1SADD is encoded in the OP-32 major opcode and is available only in RV32.
 
@@ -5344,12 +5344,12 @@ SSH1SADD is encoded in the OP-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 The SSH1SADD instruction performs a signed saturating left shift by 1 on `rs1`,
 followed by a signed saturating add with `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5374,18 +5374,18 @@ else
     X[rd] = to_bits(32, s)
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSH1ADD.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psh1add.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSH1ADD.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -5408,7 +5408,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSH1ADD.DH (Packed Shift-left-by-1 and Add, Double-wide Halfword) performs a
 packed halfword shift-left-by-1-and-add across register pairs. For each 16-bit
@@ -5417,7 +5417,7 @@ element from `rs2`, wrapping modulo 2^16. It is equivalent to performing
 PSH1ADD.H independently on both the even and odd registers of the source and
 destination pairs. This instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5439,11 +5439,11 @@ if (rd_p != 0):
 <<<
 ==== PSH1ADD.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psh1add.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSH1ADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -5466,7 +5466,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSH1ADD.DW (Packed Shift-left-by-1 and Add, Double-wide Word) performs a 32-bit
 word shift-left-by-1-and-add across register pairs. For each 32-bit element, it
@@ -5475,7 +5475,7 @@ shifts the element from `rs1` left by 1 and adds the corresponding element from
 on both the even and odd registers of the source and destination pairs. This
 instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5497,11 +5497,11 @@ if (rd_p != 0):
 <<<
 ==== PSSH1SADD.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssh1sadd.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSH1SADD.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -5524,7 +5524,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSH1SADD.DH (Packed Saturating Shift-left-by-1 Saturating Add, Double-wide
 Halfword) performs a packed halfword saturating shift-left-by-1 followed by a
@@ -5535,7 +5535,7 @@ equivalent to performing PSSH1SADD.H independently on both the even and odd
 registers of the source and destination pairs. Sets `vxsat` on saturation. This
 instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5563,18 +5563,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSH1SADD.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssh1sadd.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSH1SADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -5597,7 +5597,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSH1SADD.DW (Packed Saturating Shift-left-by-1 Saturating Add, Double-wide
 Word) performs a 32-bit word saturating shift-left-by-1 followed by a saturating
@@ -5608,7 +5608,7 @@ equivalent to performing SSH1SADD independently on both the even and odd
 registers of the source and destination pairs. Sets `vxsat` on saturation. This
 instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5636,7 +5636,7 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
@@ -5646,11 +5646,11 @@ if (rd_p != 0):
 
 ==== PAS.HX
 
-===== Mnemonic
+Mnemonic::
 
 pas.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAS.HX is encoded in the OP-32 major opcode with packed halfword cross
 elements.
@@ -5669,7 +5669,7 @@ elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PAS.HX (Packed Add-Subtract Cross, Halfword) performs a cross add-subtract on
 packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
@@ -5678,7 +5678,7 @@ while the odd (upper) halfword of `rs1` is added to the even (lower) halfword of
 `rs2`.  Results wrap modulo 2^16^. This instruction is useful for complex number
 arithmetic.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5703,11 +5703,11 @@ X[rd] = d
 <<<
 ==== PAS.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pas.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -5725,7 +5725,7 @@ PAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PAS.WX (Packed Add-Subtract Cross, Word) performs a cross add-subtract on
 packed 32-bit word pairs. The even (lower) word of `rs1` has the odd (upper)
@@ -5733,7 +5733,7 @@ word of `rs2` subtracted from it, while the odd (upper) word of `rs1` is added
 to the even (lower) word of `rs2`. Results wrap modulo 2^32^. This instruction
 is useful for complex number arithmetic. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5757,11 +5757,11 @@ X[rd] = d
 <<<
 ==== PSA.HX
 
-===== Mnemonic
+Mnemonic::
 
 psa.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSA.HX is encoded in the OP-32 major opcode with packed halfword cross
 elements.
@@ -5780,7 +5780,7 @@ elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSA.HX (Packed Subtract-Add Cross, Halfword) performs a cross subtract-add on
 packed 16-bit halfword pairs. Within each 32-bit word, the even (lower)
@@ -5789,7 +5789,7 @@ halfword of `rs1` is added to the odd (upper) halfword of `rs2`, while the odd
 it. Results wrap modulo 2^16^. This instruction is useful for complex number
 arithmetic.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5814,11 +5814,11 @@ X[rd] = d
 <<<
 ==== PSA.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psa.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -5836,7 +5836,7 @@ PSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSA.WX (Packed Subtract-Add Cross, Word) performs a cross subtract-add on
 packed 32-bit word pairs. The even (lower) word of `rs1` is added to the odd
@@ -5844,7 +5844,7 @@ word of `rs2`, while the odd (upper) word of `rs1` has the even (lower) word of
 `rs2` subtracted from it. Results wrap modulo 2^32^. This instruction is useful
 for complex number arithmetic. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5868,11 +5868,11 @@ X[rd] = d
 <<<
 ==== PSAS.HX
 
-===== Mnemonic
+Mnemonic::
 
 psas.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSAS.HX is encoded in the OP-32 major opcode with packed halfword cross
 elements.
@@ -5891,7 +5891,7 @@ elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSAS.HX (Packed Saturating Add-Subtract Cross, Halfword) performs a cross
 saturating add-subtract on packed 16-bit halfword pairs. Within each 32-bit
@@ -5902,7 +5902,7 @@ the odd (upper) halfword of `rs2` and the even (lower) halfword of `rs2`.
 Results are clamped to the range [-2^15^, 2^15^-1]. Sets `vxsat` on saturation.
 This instruction is useful for complex number arithmetic.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -5933,18 +5933,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSAS.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psas.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -5962,7 +5962,7 @@ PSAS.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSAS.WX (Packed Saturating Add-Subtract Cross, Word) performs a cross saturating
 add-subtract on packed 32-bit word pairs. The even (lower) word is computed as a
@@ -5973,7 +5973,7 @@ word of `rs2`. Results are clamped to the range [-2^31^, 2^31^-1]. Sets `vxsat`
 on saturation. This instruction is useful for complex number arithmetic.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6003,18 +6003,18 @@ d[63:32] = res_odd[31:0]
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSA.HX
 
-===== Mnemonic
+Mnemonic::
 
 pssa.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSA.HX is encoded in the OP-32 major opcode with packed halfword cross
 elements.
@@ -6033,7 +6033,7 @@ elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSA.HX (Packed Saturating Subtract-Add Cross, Halfword) performs a cross
 saturating subtract-add on packed 16-bit halfword pairs. Within each 32-bit
@@ -6044,7 +6044,7 @@ of the odd (upper) halfword of `rs1` and the even (lower) halfword of `rs2`.
 Results are clamped to the range [-2^15^, 2^15^-1]. Sets `vxsat` on saturation.
 This instruction is useful for complex number arithmetic.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6075,18 +6075,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSA.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pssa.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -6104,7 +6104,7 @@ PSSA.WX is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSA.WX (Packed Saturating Subtract-Add Cross, Word) performs a cross saturating
 subtract-add on packed 32-bit word pairs. The even (lower) word is computed as a
@@ -6115,7 +6115,7 @@ word of `rs2`. Results are clamped to the range [-2^31^, 2^31^-1]. Sets `vxsat` 
 saturation. This instruction is useful for complex number arithmetic. Available
 only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6145,18 +6145,18 @@ d[63:32] = res_odd[31:0]
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PAAS.HX
 
-===== Mnemonic
+Mnemonic::
 
 paas.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAAS.HX is encoded in the OP-32 major opcode with packed halfword cross
 operations.
@@ -6175,7 +6175,7 @@ operations.
 ]}
 ....
 
-===== Description
+Description::
 
 PAAS.HX (Packed Averaging Add-Subtract, Cross Halfword) performs a signed
 averaging cross add-subtract on packed 16-bit halfword elements. For each pair
@@ -6185,7 +6185,7 @@ the even (lower) halfword of `rs1` has the odd (upper) halfword of `rs2`
 subtracted at full precision and the result is shifted right by 1. The truncated
 results are written to the corresponding halfwords of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6211,11 +6211,11 @@ X[rd] = d
 <<<
 ==== PAAS.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 paas.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PAAS.WX is encoded in the OP-32 major opcode with packed word cross operations.
 Available only in RV64.
@@ -6234,7 +6234,7 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PAAS.WX (Packed Averaging Add-Subtract, Cross Word) performs a signed averaging
 cross add-subtract on packed 32-bit word elements within a 64-bit register. The
@@ -6244,7 +6244,7 @@ word of `rs2` subtracted at full precision and the result is shifted right by 1.
 The truncated results are written to the corresponding words of `rd`. Available
 only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6271,11 +6271,11 @@ X[rd] = d
 <<<
 ==== PASA.HX
 
-===== Mnemonic
+Mnemonic::
 
 pasa.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PASA.HX is encoded in the OP-32 major opcode with packed halfword cross
 operations.
@@ -6294,7 +6294,7 @@ operations.
 ]}
 ....
 
-===== Description
+Description::
 
 PASA.HX (Packed Averaging Subtract-Add, Cross Halfword) performs a signed
 averaging cross subtract-add on packed 16-bit halfword elements. For each pair
@@ -6304,7 +6304,7 @@ the even (lower) halfword of `rs1` is added to the odd (upper) halfword of
 `rs2` at full precision and the result is shifted right by 1. The truncated
 results are written to the corresponding halfwords of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6330,11 +6330,11 @@ X[rd] = d
 <<<
 ==== PASA.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pasa.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PASA.WX is encoded in the OP-32 major opcode with packed word cross operations.
 Available only in RV64.
@@ -6353,7 +6353,7 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PASA.WX (Packed Averaging Subtract-Add, Cross Word) performs a signed averaging
 cross subtract-add on packed 32-bit word elements within a 64-bit register. The
@@ -6363,7 +6363,7 @@ upper word of `rs2` at full precision and the result is shifted right by 1. The
 truncated results are written to the corresponding words of `rd`. Available only
 in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6390,11 +6390,11 @@ X[rd] = d
 <<<
 ==== PAS.DHX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pas.dhx _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -6416,7 +6416,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PAS.DHX (Packed Add-Subtract, Double-wide Cross Halfword) performs packed
 16-bit cross add-subtract on double-wide (register-pair) operands. It is
@@ -6426,7 +6426,7 @@ register pairs and must specify even register numbers. For each pair of
 halfwords, the upper halfword is added cross with the lower halfword of the
 other operand, and vice versa with subtraction. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6454,11 +6454,11 @@ if (rd_p != 0):
 <<<
 ==== PSA.DHX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -6480,7 +6480,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSA.DHX (Packed Subtract-Add, Double-wide Cross Halfword) performs packed
 16-bit cross subtract-add on double-wide (register-pair) operands. It is
@@ -6491,7 +6491,7 @@ halfwords, the upper halfword of `rs1` has the lower halfword of `rs2`
 subtracted, and the lower halfword of `rs1` is added with the upper halfword
 of `rs2`. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6519,11 +6519,11 @@ if (rd_p != 0):
 <<<
 ==== PSAS.DHX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psas.dhx _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -6545,7 +6545,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSAS.DHX (Packed Saturating Add-Subtract, Double-wide Cross Halfword) performs
 signed saturating cross add-subtract on packed 16-bit halfword elements across
@@ -6555,7 +6555,7 @@ registers and one on the odd registers of each pair. All three operands (`rd_p`,
 Results are saturated to the signed 16-bit range [-2^15, 2^15-1]. If saturation
 occurs, the overflow flag `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6581,18 +6581,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSA.DHX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PSSA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -6614,7 +6614,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSA.DHX (Packed Saturating Subtract-Add, Double-wide Cross Halfword) performs
 signed saturating cross subtract-add on packed 16-bit halfword elements across
@@ -6624,7 +6624,7 @@ registers and one on the odd registers of each pair. All three operands (`rd_p`,
 Results are saturated to the signed 16-bit range [-2^15, 2^15-1]. If saturation
 occurs, the overflow flag `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6650,18 +6650,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PAAS.DHX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 paas.dhx _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PAAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -6683,7 +6683,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PAAS.DHX (Packed Averaging Add-Subtract, Double-wide Cross Halfword) performs
 signed averaging cross add-subtract on packed 16-bit halfword elements across
@@ -6693,7 +6693,7 @@ registers and one on the odd registers of each pair. All three operands (`rd_p`,
 Each result is computed at full precision and then shifted right by 1 (toward
 negative infinity). Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6723,11 +6723,11 @@ if (rd_p != 0):
 <<<
 ==== PASA.DHX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pasa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PASA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -6749,7 +6749,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PASA.DHX (Packed Averaging Subtract-Add, Double-wide Cross Halfword) performs
 signed averaging cross subtract-add on packed 16-bit halfword elements across
@@ -6759,7 +6759,7 @@ registers and one on the odd registers of each pair. All three operands (`rd_p`,
 Each result is computed at full precision and then shifted right by 1 (toward
 negative infinity). Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6791,11 +6791,11 @@ if (rd_p != 0):
 
 ==== PABD.B
 
-===== Mnemonic
+Mnemonic::
 
 pabd.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PABD.B is encoded in the OP-32 major opcode. It uses packed byte elements.
 
@@ -6813,13 +6813,13 @@ PABD.B is encoded in the OP-32 major opcode. It uses packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PABD.B instruction computes the absolute difference of corresponding packed
 8-bit elements of `rs1` and `rs2`, using signed comparison, and writes the result
 to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6834,18 +6834,18 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * Signed ordering is used to determine the magnitude of each element difference.
 
 <<<
 ==== PABD.H
 
-===== Mnemonic
+Mnemonic::
 
 pabd.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PABD.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
 
@@ -6863,13 +6863,13 @@ PABD.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PABD.H instruction computes the absolute difference of corresponding packed
 16-bit elements of `rs1` and `rs2`, using signed comparison, and writes the
 result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6888,11 +6888,11 @@ X[rd] = d
 <<<
 ==== PABDU.B
 
-===== Mnemonic
+Mnemonic::
 
 pabdu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PABDU.B is encoded in the OP-32 major opcode. It uses packed byte elements.
 
@@ -6910,13 +6910,13 @@ PABDU.B is encoded in the OP-32 major opcode. It uses packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PABDU.B instruction computes the absolute difference of corresponding packed
 8-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
 result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6931,18 +6931,18 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * Unsigned ordering is used to determine the magnitude of each element difference.
 
 <<<
 ==== PABDU.H
 
-===== Mnemonic
+Mnemonic::
 
 pabdu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PABDU.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
 
@@ -6960,13 +6960,13 @@ PABDU.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PABDU.H instruction computes the absolute difference of corresponding packed
 16-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
 result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -6986,11 +6986,11 @@ X[rd] = d
 <<<
 ==== PABDSUMU.B
 
-===== Mnemonic
+Mnemonic::
 
 pabdsumu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PABDSUMU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -7008,7 +7008,7 @@ PABDSUMU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PABDSUMU.B (Packed Absolute Difference Sum, Unsigned Byte) computes the sum of
 absolute differences of packed unsigned 8-bit byte elements from `rs1` and
@@ -7017,7 +7017,7 @@ differences are summed into a single scalar result written to `rd`. This
 instruction is commonly used in motion estimation and image processing
 algorithms.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7038,11 +7038,11 @@ X[rd] = to_bits(XLEN, sum)
 <<<
 ==== PABDSUMAU.B
 
-===== Mnemonic
+Mnemonic::
 
 pabdsumau.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PABDSUMAU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -7060,7 +7060,7 @@ PABDSUMAU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PABDSUMAU.B (Packed Absolute Difference Sum Accumulate, Unsigned Byte) computes
 the sum of absolute differences of packed unsigned 8-bit byte elements from
@@ -7070,7 +7070,7 @@ the current value of `rd`. This accumulating form is useful for iteratively
 computing the sum of absolute differences across multiple register-widths of
 data, as commonly needed in motion estimation and image processing algorithms.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7091,11 +7091,11 @@ X[rd] = to_bits(XLEN, sum)
 <<<
 ==== PABD.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pabd.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PABD.DB is the register-pair (double-wide) variant of PABD.B and is available
 only in RV32. It shares the same encoding as PABD.B with register-pair
@@ -7118,7 +7118,7 @@ operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PABD.DB (Packed Absolute Difference, Double-wide Byte) computes the signed
 absolute difference of packed 8-bit elements across register pairs. It is
@@ -7127,7 +7127,7 @@ of the source and destination pairs. For each byte lane, the signed absolute
 difference |rs1[i] - rs2[i]| is computed. This instruction is available only
 on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7149,11 +7149,11 @@ if (rd_p != 0):
 <<<
 ==== PABD.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pabd.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PABD.DH is the register-pair (double-wide) variant of PABD.H and is available
 only in RV32. It shares the same encoding as PABD.H with register-pair
@@ -7176,7 +7176,7 @@ operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PABD.DH (Packed Absolute Difference, Double-wide Halfword) computes the signed
 absolute difference of packed 16-bit halfword elements across register pairs. It
@@ -7185,7 +7185,7 @@ registers of the source and destination pairs. For each halfword lane, the
 signed absolute difference |rs1[i] - rs2[i]| is computed. This instruction is
 available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7207,11 +7207,11 @@ if (rd_p != 0):
 <<<
 ==== PABDU.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pabdu.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PABDU.DB is the register-pair (double-wide) variant of PABDU.B and is available
 only in RV32. It shares the same encoding as PABDU.B with register-pair
@@ -7234,7 +7234,7 @@ operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PABDU.DB (Packed Absolute Difference Unsigned, Double-wide Byte) computes the
 unsigned absolute difference of packed 8-bit elements across register pairs. It
@@ -7243,7 +7243,7 @@ registers of the source and destination pairs. For each byte lane, the unsigned
 absolute difference |rs1[i] - rs2[i]| is computed. This instruction is
 available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7265,11 +7265,11 @@ if (rd_p != 0):
 <<<
 ==== PABDU.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pabdu.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PABDU.DH is the register-pair (double-wide) variant of PABDU.H and is available
 only in RV32. It shares the same encoding as PABDU.H with register-pair
@@ -7292,7 +7292,7 @@ operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PABDU.DH (Packed Absolute Difference Unsigned, Double-wide Halfword) computes
 the unsigned absolute difference of packed 16-bit halfword elements across
@@ -7301,7 +7301,7 @@ even and odd registers of the source and destination pairs. For each halfword
 lane, the unsigned absolute difference |rs1[i] - rs2[i]| is computed. This
 instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7326,11 +7326,11 @@ if (rd_p != 0):
 
 ==== PSABS.B
 
-===== Mnemonic
+Mnemonic::
 
 psabs.b _rd_, _rs1_
 
-===== Encoding
+Encoding::
 
 PSABS.B is encoded as a unary instruction in the OP-IMM-32 major opcode with
 packed byte elements.
@@ -7348,7 +7348,7 @@ packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSABS.B (Packed Saturating Absolute Value, Byte) computes the saturating
 absolute value of each packed signed 8-bit byte element in `rs1` and writes the
@@ -7356,7 +7356,7 @@ results to `rd`. If an element is -128 (the most negative value), the result
 saturates to 127 and the overflow flag `vxsat` is set. For all other values,
 the result is the standard absolute value.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7375,18 +7375,18 @@ for i = 0 .. (XLEN/8 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSABS.H
 
-===== Mnemonic
+Mnemonic::
 
 psabs.h _rd_, _rs1_
 
-===== Encoding
+Encoding::
 
 PSABS.H is encoded as a unary instruction in the OP-IMM-32 major opcode with
 packed halfword elements.
@@ -7404,7 +7404,7 @@ packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PSABS.H (Packed Saturating Absolute Value, Halfword) computes the saturating
 absolute value of each packed signed 16-bit halfword element in `rs1` and writes
@@ -7412,7 +7412,7 @@ the results to `rd`. If an element is -32768 (the most negative value), the
 result saturates to 32767 and the overflow flag `vxsat` is set. For all other
 values, the result is the standard absolute value.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7431,18 +7431,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSABS.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psabs.db _rd_p_, _rs1_p_
 
-===== Encoding
+Encoding::
 
 PSABS.DB is the register-pair (double-wide) variant of PSABS.B and is available
 only in RV32. It is encoded as a unary instruction in the OP-IMM-32 major
@@ -7463,7 +7463,7 @@ opcode using the double-wide register-pair format.
 ]}
 ....
 
-===== Description
+Description::
 
 PSABS.DB (Packed Saturating Absolute Value, Double-wide Byte) computes the
 saturating absolute value of packed signed 8-bit byte elements across register
@@ -7472,7 +7472,7 @@ odd registers of the source and destination pairs. If an element is -128 (the
 most negative value), the result saturates to 127 and the overflow flag `vxsat`
 is set. This instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7494,18 +7494,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSABS.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psabs.dh _rd_p_, _rs1_p_
 
-===== Encoding
+Encoding::
 
 PSABS.DH is the register-pair (double-wide) variant of PSABS.H and is available
 only in RV32. It is encoded as a unary instruction in the OP-IMM-32 major
@@ -7526,7 +7526,7 @@ opcode using the double-wide register-pair format.
 ]}
 ....
 
-===== Description
+Description::
 
 PSABS.DH (Packed Saturating Absolute Value, Double-wide Halfword) computes the
 saturating absolute value of packed signed 16-bit halfword elements across
@@ -7535,7 +7535,7 @@ even and odd registers of the source and destination pairs. If an element is
 -32768 (the most negative value), the result saturates to 32767 and the overflow
 flag `vxsat` is set. This instruction is available only on RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7557,7 +7557,7 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
@@ -7566,11 +7566,11 @@ if (rd_p != 0):
 
 ==== PREDSUM.BS
 
-===== Mnemonic
+Mnemonic::
 
 predsum.bs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUM.BS is encoded in the OP-IMM-32 major opcode. It performs a reduction
 operation using packed byte elements.
@@ -7590,13 +7590,13 @@ operation using packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PREDSUM.BS instruction computes a signed reduction sum of packed 8-bit
 elements in `rs1`. Each element is sign-extended to XLEN and accumulated into
 the initial value in `rs2`. The final sum is written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7614,11 +7614,11 @@ X[rd] = sum
 <<<
 ==== PREDSUM.HS
 
-===== Mnemonic
+Mnemonic::
 
 predsum.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUM.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -7637,12 +7637,12 @@ PREDSUM.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PREDSUM.HS instruction computes a signed reduction sum of packed 16-bit
 elements in `rs1`, accumulating into the initial value in `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7660,11 +7660,11 @@ X[rd] = sum
 <<<
 ==== PREDSUM.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 predsum.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUM.WS is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 
@@ -7683,12 +7683,12 @@ PREDSUM.WS is encoded in the OP-IMM-32 major opcode and is available only in RV6
 ]}
 ....
 
-===== Description
+Description::
 
 The PREDSUM.WS instruction computes a signed reduction sum of the two packed
 32-bit elements in `rs1`, accumulating into `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7702,11 +7702,11 @@ X[rd] = X[rs2]
 <<<
 ==== PREDSUMU.BS
 
-===== Mnemonic
+Mnemonic::
 
 predsumu.bs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUMU.BS is encoded in the OP-IMM-32 major opcode. It performs a reduction
 operation using packed byte elements.
@@ -7726,13 +7726,13 @@ operation using packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PREDSUMU.BS instruction computes an unsigned reduction sum of packed 8-bit
 elements in `rs1`. Each element is zero-extended to XLEN and accumulated into
 the initial value in `rs2`. The final sum is written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7750,11 +7750,11 @@ X[rd] = sum
 <<<
 ==== PREDSUMU.HS
 
-===== Mnemonic
+Mnemonic::
 
 predsumu.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUMU.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -7773,12 +7773,12 @@ PREDSUMU.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PREDSUMU.HS instruction computes an unsigned reduction sum of packed 16-bit
 elements in `rs1`, accumulating into the initial value in `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7796,11 +7796,11 @@ X[rd] = sum
 <<<
 ==== PREDSUMU.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 predsumu.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUMU.WS is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 
@@ -7819,12 +7819,12 @@ PREDSUMU.WS is encoded in the OP-IMM-32 major opcode and is available only in RV
 ]}
 ....
 
-===== Description
+Description::
 
 The PREDSUMU.WS instruction computes an unsigned reduction sum of the two packed
 32-bit elements in `rs1`, accumulating into `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7842,11 +7842,11 @@ X[rd] = X[rs2]
 
 ==== PMIN.B
 
-===== Mnemonic
+Mnemonic::
 
 pmin.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMIN.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -7864,12 +7864,12 @@ PMIN.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMIN.B computes the signed minimum of corresponding packed 8-bit byte elements
 of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7888,11 +7888,11 @@ X[rd] = d
 <<<
 ==== PMIN.H
 
-===== Mnemonic
+Mnemonic::
 
 pmin.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMIN.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -7910,12 +7910,12 @@ PMIN.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMIN.H computes the signed minimum of corresponding packed 16-bit halfword
 elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7934,11 +7934,11 @@ X[rd] = d
 <<<
 ==== PMIN.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmin.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMIN.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -7956,13 +7956,13 @@ PMIN.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PMIN.W computes the signed minimum of corresponding packed 32-bit word elements
 of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
 in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -7979,11 +7979,11 @@ X[rd] = d
 <<<
 ==== PMINU.B
 
-===== Mnemonic
+Mnemonic::
 
 pminu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMINU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -8001,12 +8001,12 @@ PMINU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMINU.B computes the unsigned minimum of corresponding packed 8-bit byte
 elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8025,11 +8025,11 @@ X[rd] = d
 <<<
 ==== PMINU.H
 
-===== Mnemonic
+Mnemonic::
 
 pminu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMINU.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -8047,12 +8047,12 @@ PMINU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMINU.H computes the unsigned minimum of corresponding packed 16-bit halfword
 elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8071,11 +8071,11 @@ X[rd] = d
 <<<
 ==== PMINU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pminu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMINU.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -8093,13 +8093,13 @@ PMINU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PMINU.W computes the unsigned minimum of corresponding packed 32-bit word
 elements of `rs1` and `rs2` and writes the packed word results to `rd`.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8116,11 +8116,11 @@ X[rd] = d
 <<<
 ==== PMAX.B
 
-===== Mnemonic
+Mnemonic::
 
 pmax.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMAX.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -8138,12 +8138,12 @@ PMAX.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAX.B computes the signed maximum of corresponding packed 8-bit byte elements
 of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8162,11 +8162,11 @@ X[rd] = d
 <<<
 ==== PMAX.H
 
-===== Mnemonic
+Mnemonic::
 
 pmax.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMAX.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -8184,12 +8184,12 @@ PMAX.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAX.H computes the signed maximum of corresponding packed 16-bit halfword
 elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8208,11 +8208,11 @@ X[rd] = d
 <<<
 ==== PMAX.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmax.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMAX.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -8230,13 +8230,13 @@ PMAX.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAX.W computes the signed maximum of corresponding packed 32-bit word elements
 of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
 in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8253,11 +8253,11 @@ X[rd] = d
 <<<
 ==== PMAXU.B
 
-===== Mnemonic
+Mnemonic::
 
 pmaxu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMAXU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -8275,12 +8275,12 @@ PMAXU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAXU.B computes the unsigned maximum of corresponding packed 8-bit byte
 elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8299,11 +8299,11 @@ X[rd] = d
 <<<
 ==== PMAXU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmaxu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMAXU.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -8321,12 +8321,12 @@ PMAXU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAXU.H computes the unsigned maximum of corresponding packed 16-bit halfword
 elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8345,11 +8345,11 @@ X[rd] = d
 <<<
 ==== PMAXU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmaxu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMAXU.W is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -8367,13 +8367,13 @@ PMAXU.W is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAXU.W computes the unsigned maximum of corresponding packed 32-bit word
 elements of `rs1` and `rs2` and writes the packed word results to `rd`.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8390,11 +8390,11 @@ X[rd] = d
 <<<
 ==== PMIN.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmin.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMIN.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8416,7 +8416,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMIN.DB performs packed signed 8-bit byte minimum on double-wide (register-pair)
 operands. It is equivalent to two PMIN.B operations: one on the even registers
@@ -8424,7 +8424,7 @@ and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
 `rs2_p`) are register pairs and must specify even register numbers. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8446,11 +8446,11 @@ if (rd_p != 0):
 <<<
 ==== PMIN.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmin.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMIN.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8472,7 +8472,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMIN.DH performs packed signed 16-bit halfword minimum on double-wide
 (register-pair) operands. It is equivalent to two PMIN.H operations: one on the
@@ -8480,7 +8480,7 @@ even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8502,11 +8502,11 @@ if (rd_p != 0):
 <<<
 ==== PMIN.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmin.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMIN.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8528,7 +8528,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMIN.DW performs signed 32-bit word minimum on double-wide (register-pair)
 operands. It is equivalent to two signed MIN operations: one on the even
@@ -8536,7 +8536,7 @@ registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8558,11 +8558,11 @@ if (rd_p != 0):
 <<<
 ==== PMINU.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pminu.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMINU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8584,7 +8584,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMINU.DB performs packed unsigned 8-bit byte minimum on double-wide
 (register-pair) operands. It is equivalent to two PMINU.B operations: one on
@@ -8592,7 +8592,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8614,11 +8614,11 @@ if (rd_p != 0):
 <<<
 ==== PMINU.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pminu.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMINU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8640,7 +8640,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMINU.DH performs packed unsigned 16-bit halfword minimum on double-wide
 (register-pair) operands. It is equivalent to two PMINU.H operations: one on
@@ -8648,7 +8648,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8670,11 +8670,11 @@ if (rd_p != 0):
 <<<
 ==== PMINU.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pminu.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMINU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8696,7 +8696,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMINU.DW performs unsigned 32-bit word minimum on double-wide (register-pair)
 operands. It is equivalent to two unsigned MIN operations: one on the even
@@ -8704,7 +8704,7 @@ registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8726,11 +8726,11 @@ if (rd_p != 0):
 <<<
 ==== PMAX.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmax.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMAX.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8752,7 +8752,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAX.DB performs packed signed 8-bit byte maximum on double-wide (register-pair)
 operands. It is equivalent to two PMAX.B operations: one on the even registers
@@ -8760,7 +8760,7 @@ and one on the odd registers of each pair. All three operands (`rd_p`, `rs1_p`,
 `rs2_p`) are register pairs and must specify even register numbers. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8782,11 +8782,11 @@ if (rd_p != 0):
 <<<
 ==== PMAX.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmax.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMAX.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8808,7 +8808,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAX.DH performs packed signed 16-bit halfword maximum on double-wide
 (register-pair) operands. It is equivalent to two PMAX.H operations: one on the
@@ -8816,7 +8816,7 @@ even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8838,11 +8838,11 @@ if (rd_p != 0):
 <<<
 ==== PMAX.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmax.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMAX.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8864,7 +8864,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAX.DW performs signed 32-bit word maximum on double-wide (register-pair)
 operands. It is equivalent to two signed MAX operations: one on the even
@@ -8872,7 +8872,7 @@ registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8894,11 +8894,11 @@ if (rd_p != 0):
 <<<
 ==== PMAXU.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmaxu.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMAXU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8920,7 +8920,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAXU.DB performs packed unsigned 8-bit byte maximum on double-wide
 (register-pair) operands. It is equivalent to two PMAXU.B operations: one on
@@ -8928,7 +8928,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -8950,11 +8950,11 @@ if (rd_p != 0):
 <<<
 ==== PMAXU.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmaxu.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMAXU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -8976,7 +8976,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAXU.DH performs packed unsigned 16-bit halfword maximum on double-wide
 (register-pair) operands. It is equivalent to two PMAXU.H operations: one on
@@ -8984,7 +8984,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9006,11 +9006,11 @@ if (rd_p != 0):
 <<<
 ==== PMAXU.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmaxu.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMAXU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -9032,7 +9032,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMAXU.DW performs unsigned 32-bit word maximum on double-wide (register-pair)
 operands. It is equivalent to two unsigned MAX operations: one on the even
@@ -9040,7 +9040,7 @@ registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9064,11 +9064,11 @@ if (rd_p != 0):
 
 ==== PMSEQ.B
 
-===== Mnemonic
+Mnemonic::
 
 pmseq.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSEQ.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -9086,14 +9086,14 @@ PMSEQ.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSEQ.B (Packed Mask Set-if-Equal, Byte) compares corresponding packed 8-bit
 byte elements of `rs1` and `rs2`. For each element position, if the elements
 are equal the result byte is set to all ones (0xFF); otherwise it is set to
 all zeros (0x00). The packed results are written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9112,11 +9112,11 @@ X[rd] = d
 <<<
 ==== PMSEQ.H
 
-===== Mnemonic
+Mnemonic::
 
 pmseq.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSEQ.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -9134,14 +9134,14 @@ PMSEQ.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSEQ.H (Packed Mask Set-if-Equal, Halfword) compares corresponding packed
 16-bit halfword elements of `rs1` and `rs2`. For each element position, if the
 elements are equal the result halfword is set to all ones (0xFFFF); otherwise
 it is set to all zeros (0x0000). The packed results are written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9160,11 +9160,11 @@ X[rd] = d
 <<<
 ==== PMSEQ.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmseq.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSEQ.W is available only in RV64.
 
@@ -9182,12 +9182,12 @@ PMSEQ.W is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMSEQ.W instruction compares corresponding packed 32-bit elements for
 equality and produces a packed word mask in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9202,11 +9202,11 @@ X[rd] = d1 @ d0
 <<<
 ==== PMSLT.B
 
-===== Mnemonic
+Mnemonic::
 
 pmslt.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSLT.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -9224,14 +9224,14 @@ PMSLT.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLT.B performs a signed less-than comparison on corresponding packed 8-bit byte
 elements of `rs1` and `rs2`. For each element, if the signed value of `rs1` is
 less than the signed value of `rs2`, the corresponding byte in `rd` is set to
 all-ones (0xFF); otherwise it is set to all-zeros (0x00).
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9250,11 +9250,11 @@ X[rd] = d
 <<<
 ==== PMSLT.H
 
-===== Mnemonic
+Mnemonic::
 
 pmslt.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSLT.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -9272,14 +9272,14 @@ PMSLT.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLT.H performs a signed less-than comparison on corresponding packed 16-bit
 halfword elements of `rs1` and `rs2`. For each element, if the signed value of
 `rs1` is less than the signed value of `rs2`, the corresponding halfword in `rd`
 is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9298,11 +9298,11 @@ X[rd] = d
 <<<
 ==== PMSLT.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmslt.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSLT.W is available only in RV64.
 
@@ -9320,12 +9320,12 @@ PMSLT.W is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMSLT.W instruction performs signed less-than comparisons on corresponding
 packed 32-bit elements and produces a packed word mask in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9340,11 +9340,11 @@ X[rd] = d1 @ d0
 <<<
 ==== PMSLTU.B
 
-===== Mnemonic
+Mnemonic::
 
 pmsltu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSLTU.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -9362,14 +9362,14 @@ PMSLTU.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLTU.B performs an unsigned less-than comparison on corresponding packed 8-bit
 byte elements of `rs1` and `rs2`. For each element, if the unsigned value of
 `rs1` is less than the unsigned value of `rs2`, the corresponding byte in `rd` is
 set to all-ones (0xFF); otherwise it is set to all-zeros (0x00).
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9388,11 +9388,11 @@ X[rd] = d
 <<<
 ==== PMSLTU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmsltu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSLTU.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -9410,14 +9410,14 @@ PMSLTU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLTU.H performs an unsigned less-than comparison on corresponding packed 16-bit
 halfword elements of `rs1` and `rs2`. For each element, if the unsigned value of
 `rs1` is less than the unsigned value of `rs2`, the corresponding halfword in
 `rd` is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9436,11 +9436,11 @@ X[rd] = d
 <<<
 ==== PMSLTU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmsltu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMSLTU.W is available only in RV64.
 
@@ -9458,12 +9458,12 @@ PMSLTU.W is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMSLTU.W instruction performs unsigned less-than comparisons on corresponding
 packed 32-bit elements and produces a packed word mask in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9478,11 +9478,11 @@ X[rd] = d1 @ d0
 <<<
 ==== MSEQ (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mseq _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MSEQ is available only in RV32.
 
@@ -9500,12 +9500,12 @@ MSEQ is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 The MSEQ instruction sets `rd` to all ones if `rs1` equals `rs2`; otherwise it
 sets `rd` to zero.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9516,11 +9516,11 @@ X[rd] = (X[rs1] == X[rs2]) ? 0xFFFFFFFF : 0x00000000
 <<<
 ==== MSLT (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mslt _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MSLT is available only in RV32.
 
@@ -9538,12 +9538,12 @@ MSLT is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 The MSLT instruction sets `rd` to all ones if `rs1` is less than `rs2` using
 signed comparison; otherwise it sets `rd` to zero.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9554,11 +9554,11 @@ X[rd] = (X[rs1] <_s X[rs2]) ? 0xFFFFFFFF : 0x00000000
 <<<
 ==== MSLTU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 msltu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MSLTU is available only in RV32.
 
@@ -9576,12 +9576,12 @@ MSLTU is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 The MSLTU instruction sets `rd` to all ones if `rs1` is less than `rs2` using
 unsigned comparison; otherwise it sets `rd` to zero.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9593,11 +9593,11 @@ X[rd] = (X[rs1] <_u X[rs2]) ? 0xFFFFFFFF : 0x00000000
 <<<
 ==== PMSEQ.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmseq.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSEQ.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -9619,7 +9619,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSEQ.DB performs packed 8-bit byte mask-equality comparison on double-wide
 (register-pair) operands. It is equivalent to two PMSEQ.B operations: one on the
@@ -9628,7 +9628,7 @@ even registers and one on the odd registers of each pair. All three operands
 numbers. For each element, the result is all-ones (0xFF) if the elements are
 equal, or all-zeros (0x00) otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9650,11 +9650,11 @@ if (rd_p != 0):
 <<<
 ==== PMSEQ.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmseq.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSEQ.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -9676,7 +9676,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSEQ.DH performs packed 16-bit halfword mask-equality comparison on double-wide
 (register-pair) operands. It is equivalent to two PMSEQ.H operations: one on the
@@ -9685,7 +9685,7 @@ even registers and one on the odd registers of each pair. All three operands
 numbers. For each element, the result is all-ones (0xFFFF) if the elements are
 equal, or all-zeros (0x0000) otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9707,11 +9707,11 @@ if (rd_p != 0):
 <<<
 ==== PMSEQ.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmseq.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSEQ.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -9733,7 +9733,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSEQ.DW performs 32-bit word mask-equality comparison on double-wide
 (register-pair) operands. It is equivalent to two MSEQ operations: one on the
@@ -9742,7 +9742,7 @@ even registers and one on the odd registers of each pair. All three operands
 numbers. For each element, the result is all-ones (0xFFFFFFFF) if the elements
 are equal, or all-zeros (0x00000000) otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9764,11 +9764,11 @@ if (rd_p != 0):
 <<<
 ==== PMSLT.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmslt.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSLT.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -9790,7 +9790,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLT.DB performs packed 8-bit byte signed less-than mask comparison on
 double-wide (register-pair) operands. It is equivalent to two PMSLT.B operations:
@@ -9800,7 +9800,7 @@ register numbers. For each element, the result is all-ones (0xFF) if the signed
 `rs1` element is less than the signed `rs2` element, or all-zeros (0x00)
 otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9822,11 +9822,11 @@ if (rd_p != 0):
 <<<
 ==== PMSLT.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmslt.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSLT.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -9848,7 +9848,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLT.DH performs packed 16-bit halfword signed less-than mask comparison on
 double-wide (register-pair) operands. It is equivalent to two PMSLT.H operations:
@@ -9858,7 +9858,7 @@ register numbers. For each element, the result is all-ones (0xFFFF) if the signe
 `rs1` element is less than the signed `rs2` element, or all-zeros (0x0000)
 otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9880,11 +9880,11 @@ if (rd_p != 0):
 <<<
 ==== PMSLT.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmslt.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSLT.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -9906,7 +9906,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLT.DW performs 32-bit word signed less-than mask comparison on double-wide
 (register-pair) operands. It is equivalent to two MSLT operations: one on the
@@ -9916,7 +9916,7 @@ numbers. For each element, the result is all-ones (0xFFFFFFFF) if the signed
 `rs1` element is less than the signed `rs2` element, or all-zeros (0x00000000)
 otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9938,11 +9938,11 @@ if (rd_p != 0):
 <<<
 ==== PMSLTU.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmsltu.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSLTU.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -9964,7 +9964,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLTU.DB performs packed 8-bit byte unsigned less-than mask comparison on
 double-wide (register-pair) operands. It is equivalent to two PMSLTU.B
@@ -9974,7 +9974,7 @@ even register numbers. For each element, the result is all-ones (0xFF) if the
 unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
 (0x00) otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -9996,11 +9996,11 @@ if (rd_p != 0):
 <<<
 ==== PMSLTU.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmsltu.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSLTU.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -10022,7 +10022,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLTU.DH performs packed 16-bit halfword unsigned less-than mask comparison on
 double-wide (register-pair) operands. It is equivalent to two PMSLTU.H
@@ -10032,7 +10032,7 @@ even register numbers. For each element, the result is all-ones (0xFFFF) if the
 unsigned `rs1` element is less than the unsigned `rs2` element, or all-zeros
 (0x0000) otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10054,11 +10054,11 @@ if (rd_p != 0):
 <<<
 ==== PMSLTU.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmsltu.dw _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PMSLTU.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -10080,7 +10080,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PMSLTU.DW performs 32-bit word unsigned less-than mask comparison on double-wide
 (register-pair) operands. It is equivalent to two MSLTU operations: one on the
@@ -10090,7 +10090,7 @@ numbers. For each element, the result is all-ones (0xFFFFFFFF) if the unsigned
 `rs1` element is less than the unsigned `rs2` element, or all-zeros (0x00000000)
 otherwise. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10114,11 +10114,11 @@ if (rd_p != 0):
 
 ==== PSEXT.H.B
 
-===== Mnemonic
+Mnemonic::
 
 psext.h.b _rd_, _rs1_
 
-===== Encoding
+Encoding::
 
 PSEXT.H.B is encoded in the OP-IMM-32 major opcode as a unary instruction.
 
@@ -10136,14 +10136,14 @@ PSEXT.H.B is encoded in the OP-IMM-32 major opcode as a unary instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 PSEXT.H.B sign-extends packed 8-bit byte elements from the lower byte of each
 16-bit halfword position in `rs1` into full 16-bit halfword results in `rd`. The
 upper byte of each halfword input is ignored; only the lower byte is
 sign-extended.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10161,11 +10161,11 @@ X[rd] = d
 <<<
 ==== PSEXT.W.B (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psext.w.b _rd_, _rs1_
 
-===== Encoding
+Encoding::
 
 PSEXT.W.B is available only in RV64.
 
@@ -10182,12 +10182,12 @@ PSEXT.W.B is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSEXT.W.B instruction extracts byte elements from `rs1`, sign-extends them
 to 32-bit values, and packs them into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10199,11 +10199,11 @@ X[rd] = sign_extend(32, s1[39:32]) @ sign_extend(32, s1[7:0])
 <<<
 ==== PSEXT.W.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psext.w.h _rd_, _rs1_
 
-===== Encoding
+Encoding::
 
 PSEXT.W.H is available only in RV64.
 
@@ -10220,12 +10220,12 @@ PSEXT.W.H is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSEXT.W.H instruction extracts halfword elements from `rs1`, sign-extends
 them to 32-bit values, and packs them into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10238,11 +10238,11 @@ X[rd] = sign_extend(32, s1[47:32]) @ sign_extend(32, s1[15:0])
 <<<
 ==== PSEXT.DH.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psext.dh.b _rd_p_, _rs1_p_
 
-===== Encoding
+Encoding::
 
 PSEXT.DH.B is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair unary format. Available only in RV32.
@@ -10263,7 +10263,7 @@ register-pair unary format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSEXT.DH.B performs packed sign-extension of bytes to halfwords on double-wide
 (register-pair) operands. It is equivalent to two PSEXT.H.B operations: one on
@@ -10271,7 +10271,7 @@ the even registers and one on the odd registers of each pair. Both operands
 (`rd_p`, `rs1_p`) are register pairs and must specify even register numbers.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10291,11 +10291,11 @@ if (rd_p != 0):
 <<<
 ==== PSEXT.DW.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psext.dw.b _rd_p_, _rs1_p_
 
-===== Encoding
+Encoding::
 
 PSEXT.DW.B is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair unary format. Available only in RV32.
@@ -10316,7 +10316,7 @@ register-pair unary format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSEXT.DW.B performs sign-extension of bytes to words on double-wide
 (register-pair) operands. It is equivalent to two SEXT.B operations: one on the
@@ -10324,7 +10324,7 @@ even registers and one on the odd registers of each pair. Both operands (`rd_p`,
 `rs1_p`) are register pairs and must specify even register numbers. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10343,11 +10343,11 @@ if (rd_p != 0):
 <<<
 ==== PSEXT.DW.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psext.dw.h _rd_p_, _rs1_p_
 
-===== Encoding
+Encoding::
 
 PSEXT.DW.H is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair unary format. Available only in RV32.
@@ -10368,7 +10368,7 @@ register-pair unary format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSEXT.DW.H performs sign-extension of halfwords to words on double-wide
 (register-pair) operands. It is equivalent to two SEXT.H operations: one on the
@@ -10376,7 +10376,7 @@ even registers and one on the odd registers of each pair. Both operands (`rd_p`,
 `rs1_p`) are register pairs and must specify even register numbers. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10397,11 +10397,11 @@ if (rd_p != 0):
 
 ==== PSATI.H
 
-===== Mnemonic
+Mnemonic::
 
 psati.h _rd_, _rs1_, _width_
 
-===== Encoding
+Encoding::
 
 PSATI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format for
 packed halfword elements with a 4-bit unsigned immediate.
@@ -10421,7 +10421,7 @@ packed halfword elements with a 4-bit unsigned immediate.
 ]}
 ....
 
-===== Description
+Description::
 
 PSATI.H saturates each packed 16-bit halfword element of `rs1` to the signed
 range [-(2^width-1^), 2^width-1^-1], where `width` is specified by `uimm4`+1.
@@ -10429,7 +10429,7 @@ If an element exceeds the range, the result is clamped to the nearest bound and
 the `vxsat` overflow flag is set. Elements already within range are passed
 through unchanged.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10452,18 +10452,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSATI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psati.w _rd_, _rs1_, _width_
 
-===== Encoding
+Encoding::
 
 PSATI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format for
 packed word elements with a 5-bit unsigned immediate. Available only in RV64.
@@ -10483,7 +10483,7 @@ packed word elements with a 5-bit unsigned immediate. Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSATI.W saturates each packed 32-bit word element of `rs1` to the signed range
 [-(2^width-1^), 2^width-1^-1], where `width` is specified by `uimm5`+1. If an
@@ -10491,7 +10491,7 @@ element exceeds the range, the result is clamped to the nearest bound and the
 `vxsat` overflow flag is set. Elements already within range are passed through
 unchanged. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10514,18 +10514,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PUSATI.H
 
-===== Mnemonic
+Mnemonic::
 
 pusati.h _rd_, _rs1_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PUSATI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format for
 packed halfword elements with a 4-bit unsigned immediate.
@@ -10545,7 +10545,7 @@ packed halfword elements with a 4-bit unsigned immediate.
 ]}
 ....
 
-===== Description
+Description::
 
 PUSATI.H performs unsigned saturation on each packed 16-bit halfword element of
 `rs1` to the range [0, 2^width^-1], where `width` is specified by `uimm4`.
@@ -10553,7 +10553,7 @@ Negative values are clamped to zero and values exceeding the maximum are clamped
 to 2^width^-1. When clamping occurs, the `vxsat` overflow flag is set.
 Elements already within range are passed through unchanged.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10575,18 +10575,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PUSATI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pusati.w _rd_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PUSATI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format for
 packed word elements with a 5-bit unsigned immediate. Available only in RV64.
@@ -10606,7 +10606,7 @@ packed word elements with a 5-bit unsigned immediate. Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PUSATI.W performs unsigned saturation on each packed 32-bit word element of `rs1`
 to the range [0, 2^width^-1], where `width` is specified by `uimm5`.
@@ -10614,7 +10614,7 @@ Negative values are clamped to zero and values exceeding the maximum are clamped
 to 2^width^-1. When clamping occurs, the `vxsat` overflow flag is set. Elements
 already within range are passed through unchanged. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10636,18 +10636,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== SATI
 
-===== Mnemonic
+Mnemonic::
 
 sati _rd_, _rs1_, _width_
 
-===== Encoding
+Encoding::
 
 SATI is encoded in the OP-IMM-32 major opcode.
 
@@ -10685,7 +10685,7 @@ RV64:
 ]}
 ....
 
-===== Description
+Description::
 
 The SATI instruction saturates `rs1` to the signed range
 [-(2^width-1^), 2^width-1^-1] where `width` is specified by `uimm5`+1(RV32) or
@@ -10693,7 +10693,7 @@ The SATI instruction saturates `rs1` to the signed range
 nearest bound and the `vxsat` overflow flag is set. Values within the range are
 passed through unchanged.
 
-===== Operation
+Operation::
 
 RV32:
 
@@ -10735,19 +10735,19 @@ else:
     X[rd] = s1
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs.
 
 <<<
 ==== USATI
 
-===== Mnemonic
+Mnemonic::
 
 usati _rd_, _rs1_, _uimm5_ (RV32) +
 usati _rd_, _rs1_, _uimm6_ (RV64)
 
-===== Encoding
+Encoding::
 
 USATI is encoded in the OP-IMM-32 major opcode.
 
@@ -10785,7 +10785,7 @@ RV64:
 ]}
 ....
 
-===== Description
+Description::
 
 The USATI instruction saturates `rs1` to the unsigned range [0, 2^width^-1]
 where `width` is specified by `uimm5`(RV32) or `uimm6`(RV64). Negative values
@@ -10793,7 +10793,7 @@ are clamped to zero and values exceeding the maximum are clamped to 2^width^-1.
 When clamping occurs, the `vxsat` overflow flag is set. Values already within
 range are passed through unchanged.
 
-===== Operation
+Operation::
 
 RV32:
 
@@ -10833,7 +10833,7 @@ else:
     X[rd] = s1
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs.
 
@@ -10841,11 +10841,11 @@ else:
 <<<
 ==== PSATI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psati.dh _rd_p_, _rs1_p_, _width_
 
-===== Encoding
+Encoding::
 
 PSATI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair w-uimm format. Available only in RV32.
@@ -10867,7 +10867,7 @@ register-pair w-uimm format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSATI.DH performs packed 16-bit halfword signed saturation on double-wide
 (register-pair) operands. It is equivalent to two PSATI.H operations: one on the
@@ -10877,7 +10877,7 @@ element is saturated to the signed range [-(2^width-1^), 2^width-1^-1], where
 `width` is specified by `uimm4`+1. When clamping occurs, the `vxsat` overflow
 flag is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10903,18 +10903,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSATI.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psati.dw _rd_p_, _rs1_p_, _width_
 
-===== Encoding
+Encoding::
 
 PSATI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 immediate format with word elements. Available only in RV32.
@@ -10936,7 +10936,7 @@ immediate format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSATI.DW performs signed saturation on each 32-bit element across a double-wide
 (register-pair) source. It is equivalent to two SATI operations: one on the even
@@ -10946,7 +10946,7 @@ If saturation occurs, `vxsat` is set. The destination (`rd_p`) and source
 (`rs1_p`) are register pairs and must specify even register numbers. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -10971,18 +10971,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PUSATI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pusati.dh _rd_p_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PUSATI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 immediate format with packed halfword elements. Available only in RV32.
@@ -11004,7 +11004,7 @@ immediate format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PUSATI.DH performs unsigned saturation on each packed 16-bit element across a
 double-wide (register-pair) source. It is equivalent to two PUSATI.H operations:
@@ -11014,7 +11014,7 @@ element is clamped to the range [0, 2^width^-1] where `width` is specified by
 and source (`rs1_p`) are register pairs and must specify even register numbers.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11038,18 +11038,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PUSATI.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pusati.dw _rd_p_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PUSATI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 immediate format with word elements. Available only in RV32.
@@ -11071,7 +11071,7 @@ immediate format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PUSATI.DW performs unsigned saturation on each 32-bit element across a
 double-wide (register-pair) source. It is equivalent to two USATI operations:
@@ -11081,7 +11081,7 @@ element is clamped to the range [0, 2^width^-1] where `n` is specified by
 and source (`rs1_p`) are register pairs and must specify even register numbers.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11105,7 +11105,7 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
@@ -11114,11 +11114,11 @@ if (rd_p != 0):
 
 ==== PSLL.BS
 
-===== Mnemonic
+Mnemonic::
 
 psll.bs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSLL.BS is encoded in the OP-IMM-32 major opcode.
 
@@ -11137,12 +11137,12 @@ PSLL.BS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSLL.BS instruction shifts each packed 8-bit element of `rs1` left by the
 shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11158,11 +11158,11 @@ X[rd] = d
 <<<
 ==== PSLL.HS
 
-===== Mnemonic
+Mnemonic::
 
 psll.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSLL.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -11181,12 +11181,12 @@ PSLL.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSLL.HS instruction shifts each packed 16-bit element of `rs1` left by the
 shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11202,11 +11202,11 @@ X[rd] = d
 <<<
 ==== PSLL.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psll.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSLL.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
 and word elements. Available only in RV64.
@@ -11226,14 +11226,14 @@ and word elements. Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSLL.WS shifts each packed 32-bit element of `rs1` left by the scalar shift
 amount in `rs2[4:0]` and writes the packed word result to `rd`. Bits shifted
 out are discarded and vacated bit positions are filled with zeros. Available
 only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11249,11 +11249,11 @@ X[rd] = d
 <<<
 ==== PSRL.BS
 
-===== Mnemonic
+Mnemonic::
 
 psrl.bs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRL.BS is encoded in the OP-IMM-32 major opcode.
 
@@ -11272,12 +11272,12 @@ PSRL.BS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSRL.BS instruction logically shifts each packed 8-bit element of `rs1`
 right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11293,11 +11293,11 @@ X[rd] = d
 <<<
 ==== PSRL.HS
 
-===== Mnemonic
+Mnemonic::
 
 psrl.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRL.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -11316,12 +11316,12 @@ PSRL.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSRL.HS instruction logically shifts each packed 16-bit element of `rs1`
 right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11337,11 +11337,11 @@ X[rd] = d
 <<<
 ==== PSRL.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psrl.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRL.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
 and word elements. Available only in RV64.
@@ -11361,14 +11361,14 @@ and word elements. Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRL.WS logically shifts each packed 32-bit element of `rs1` right by the
 scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
 Bits shifted out are discarded and vacated bit positions are filled with zeros.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11384,11 +11384,11 @@ X[rd] = d
 <<<
 ==== PSRA.BS
 
-===== Mnemonic
+Mnemonic::
 
 psra.bs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRA.BS is encoded in the OP-IMM-32 major opcode.
 
@@ -11407,12 +11407,12 @@ PSRA.BS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSRA.BS instruction arithmetically shifts each packed 8-bit element of `rs1`
 right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11428,11 +11428,11 @@ X[rd] = d
 <<<
 ==== PSRA.HS
 
-===== Mnemonic
+Mnemonic::
 
 psra.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRA.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -11451,12 +11451,12 @@ PSRA.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSRA.HS instruction arithmetically shifts each packed 16-bit element of `rs1`
 right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11473,11 +11473,11 @@ X[rd] = d
 <<<
 ==== PSRA.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psra.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRA.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
 and word elements. Available only in RV64.
@@ -11497,14 +11497,14 @@ and word elements. Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRA.WS arithmetically shifts each packed 32-bit element of `rs1` right by the
 scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
 Bits shifted out are discarded and vacated bit positions are filled with copies
 of the sign bit. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11520,11 +11520,11 @@ X[rd] = d
 <<<
 ==== PSLLI.B
 
-===== Mnemonic
+Mnemonic::
 
 pslli.b _rd_, _rs1_, _uimm3_
 
-===== Encoding
+Encoding::
 
 PSLLI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
 and an immediate shift amount.
@@ -11546,13 +11546,13 @@ and an immediate shift amount.
 
 The `uimm3` field encodes the 3-bit shift amount for byte elements.
 
-===== Description
+Description::
 
 PSLLI.B shifts each packed 8-bit element of `rs1` left by the immediate shift
 amount encoded in `uimm3` and writes the packed byte result to `rd`. Bits
 shifted out are discarded and vacated bit positions are filled with zeros.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11568,11 +11568,11 @@ X[rd] = d
 <<<
 ==== PSLLI.H
 
-===== Mnemonic
+Mnemonic::
 
 pslli.h _rd_, _rs1_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSLLI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
 and an immediate shift amount.
@@ -11594,13 +11594,13 @@ and an immediate shift amount.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
-===== Description
+Description::
 
 PSLLI.H shifts each packed 16-bit element of `rs1` left by the immediate shift
 amount encoded in `uimm4` and writes the packed halfword result to `rd`.
 Bits shifted out are discarded and vacated bit positions are filled with zeros.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11616,11 +11616,11 @@ X[rd] = d
 <<<
 ==== PSLLI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pslli.w _rd_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSLLI.W is encoded in the OP-IMM-32 major opcode with packed word elements
 and an immediate shift amount. Available only in RV64.
@@ -11642,14 +11642,14 @@ and an immediate shift amount. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
-===== Description
+Description::
 
 PSLLI.W shifts each packed 32-bit element of `rs1` left by the immediate shift
 amount encoded in `uimm5` and writes the packed word result to `rd`. Bits
 shifted out are discarded and vacated bit positions are filled with zeros.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11665,11 +11665,11 @@ X[rd] = d
 <<<
 ==== PSRLI.B
 
-===== Mnemonic
+Mnemonic::
 
 psrli.b _rd_, _rs1_, _uimm3_
 
-===== Encoding
+Encoding::
 
 PSRLI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
 and an immediate shift amount.
@@ -11691,14 +11691,14 @@ and an immediate shift amount.
 
 The `uimm3` field encodes the 3-bit shift amount for byte elements.
 
-===== Description
+Description::
 
 PSRLI.B logically shifts each packed 8-bit element of `rs1` right by the
 immediate shift amount encoded in `uimm3` and writes the packed byte result
 to `rd`. Bits shifted out are discarded and vacated bit positions are filled
 with zeros.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11714,11 +11714,11 @@ X[rd] = d
 <<<
 ==== PSRLI.H
 
-===== Mnemonic
+Mnemonic::
 
 psrli.h _rd_, _rs1_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSRLI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
 and an immediate shift amount.
@@ -11740,14 +11740,14 @@ and an immediate shift amount.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
-===== Description
+Description::
 
 PSRLI.H logically shifts each packed 16-bit element of `rs1` right by the
 immediate shift amount encoded in `uimm4` and writes the packed halfword
 result to `rd`. Bits shifted out are discarded and vacated bit positions are
 filled with zeros.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11763,11 +11763,11 @@ X[rd] = d
 <<<
 ==== PSRLI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psrli.w _rd_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSRLI.W is encoded in the OP-IMM-32 major opcode with packed word elements
 and an immediate shift amount. Available only in RV64.
@@ -11789,14 +11789,14 @@ and an immediate shift amount. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
-===== Description
+Description::
 
 PSRLI.W logically shifts each packed 32-bit element of `rs1` right by the
 immediate shift amount encoded in `uimm5` and writes the packed word result
 to `rd`. Bits shifted out are discarded and vacated bit positions are filled
 with zeros. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11812,11 +11812,11 @@ X[rd] = d
 <<<
 ==== PSRAI.B
 
-===== Mnemonic
+Mnemonic::
 
 psrai.b _rd_, _rs1_, _uimm3_
 
-===== Encoding
+Encoding::
 
 PSRAI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
 and an immediate shift amount.
@@ -11838,14 +11838,14 @@ and an immediate shift amount.
 
 The `uimm3` field encodes the 3-bit shift amount for byte elements.
 
-===== Description
+Description::
 
 PSRAI.B arithmetically shifts each packed 8-bit element of `rs1` right by the
 immediate shift amount encoded in `uimm3` and writes the packed byte result
 to `rd`. Bits shifted out are discarded and vacated bit positions are filled
 with copies of the sign bit.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11861,11 +11861,11 @@ X[rd] = d
 <<<
 ==== PSRAI.H
 
-===== Mnemonic
+Mnemonic::
 
 psrai.h _rd_, _rs1_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSRAI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
 and an immediate shift amount.
@@ -11887,14 +11887,14 @@ and an immediate shift amount.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
-===== Description
+Description::
 
 PSRAI.H arithmetically shifts each packed 16-bit element of `rs1` right by the
 immediate shift amount encoded in `uimm4` and writes the packed halfword
 result to `rd`. Bits shifted out are discarded and vacated bit positions are
 filled with copies of the sign bit.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11910,11 +11910,11 @@ X[rd] = d
 <<<
 ==== PSRAI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psrai.w _rd_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSRAI.W is encoded in the OP-IMM-32 major opcode with packed word elements
 and an immediate shift amount. Available only in RV64.
@@ -11936,14 +11936,14 @@ and an immediate shift amount. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
-===== Description
+Description::
 
 PSRAI.W arithmetically shifts each packed 32-bit element of `rs1` right by the
 immediate shift amount encoded in `uimm5` and writes the packed word result
 to `rd`. Bits shifted out are discarded and vacated bit positions are filled
 with copies of the sign bit. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -11959,11 +11959,11 @@ X[rd] = d
 <<<
 ==== PSRARI.H
 
-===== Mnemonic
+Mnemonic::
 
 psrari.h _rd_, _rs1_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSRARI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
 and an immediate shift amount.
@@ -11985,14 +11985,14 @@ and an immediate shift amount.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
-===== Description
+Description::
 
 PSRARI.H arithmetically shifts each packed 16-bit element of `rs1` right by
 the immediate shift amount encoded in `uimm4` with rounding and writes the
 packed halfword result to `rd`. A rounding bit is added before the shift so that
 the result is rounded to the nearest integer (round-to-nearest, ties round up).
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12010,11 +12010,11 @@ X[rd] = d
 <<<
 ==== PSRARI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psrari.w _rd_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSRARI.W is encoded in the OP-IMM-32 major opcode with packed word elements
 and an immediate shift amount. Available only in RV64.
@@ -12036,7 +12036,7 @@ and an immediate shift amount. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
-===== Description
+Description::
 
 PSRARI.W arithmetically shifts each packed 32-bit element of `rs1` right by
 the immediate shift amount encoded in `uimm5` with rounding and writes the
@@ -12044,7 +12044,7 @@ packed word result to `rd`. A rounding bit is added before the shift so that the
 result is rounded to the nearest integer (round-to-nearest, ties round up).
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12062,11 +12062,11 @@ X[rd] = d
 <<<
 ==== PSLL.DBS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psll.dbs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSLL.DBS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed byte elements. Available only in RV32.
@@ -12088,7 +12088,7 @@ scalar format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSLL.DBS shifts each packed 8-bit element left by the scalar shift amount in
 `rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
@@ -12098,7 +12098,7 @@ pairs and must specify even register numbers; `rs2` is a single register. Bits
 shifted out are discarded and vacated bit positions are filled with zeros.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12119,11 +12119,11 @@ if (rd_p != 0):
 <<<
 ==== PSLL.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psll.dhs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSLL.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed halfword elements. Available only in RV32.
@@ -12145,7 +12145,7 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSLL.DHS shifts each packed 16-bit element left by the scalar shift amount in
 `rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
@@ -12155,7 +12155,7 @@ pairs and must specify even register numbers; `rs2` is a single register. Bits
 shifted out are discarded and vacated bit positions are filled with zeros.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12176,11 +12176,11 @@ if (rd_p != 0):
 <<<
 ==== PSLL.DWS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psll.dws _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSLL.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with word elements. Available only in RV32.
@@ -12202,7 +12202,7 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSLL.DWS shifts each 32-bit element left by the scalar shift amount in
 `rs2[4:0]` across a double-wide (register-pair) source. It is equivalent to two
@@ -12212,7 +12212,7 @@ must specify even register numbers; `rs2` is a single register. Bits shifted out
 are discarded and vacated bit positions are filled with zeros. Available only in
 RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12232,11 +12232,11 @@ if (rd_p != 0):
 <<<
 ==== PSRL.DBS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrl.dbs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRL.DBS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed byte elements. Available only in RV32.
@@ -12258,7 +12258,7 @@ scalar format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRL.DBS logically shifts each packed 8-bit element right by the scalar shift
 amount in `rs2[4:0]` across a double-wide (register-pair) source. It is
@@ -12268,7 +12268,7 @@ are register pairs and must specify even register numbers; `rs2` is a single
 register. Bits shifted out are discarded and vacated bit positions are filled
 with zeros. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12289,11 +12289,11 @@ if (rd_p != 0):
 <<<
 ==== PSRL.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrl.dhs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRL.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed halfword elements. Available only in RV32.
@@ -12315,7 +12315,7 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRL.DHS logically shifts each packed 16-bit element right by the scalar shift
 amount in `rs2[4:0]` across a double-wide (register-pair) source. It is
@@ -12325,7 +12325,7 @@ are register pairs and must specify even register numbers; `rs2` is a single
 register. Bits shifted out are discarded and vacated bit positions are filled
 with zeros. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12346,11 +12346,11 @@ if (rd_p != 0):
 <<<
 ==== PSRL.DWS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrl.dws _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRL.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with word elements. Available only in RV32.
@@ -12372,7 +12372,7 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRL.DWS (Packed Shift Right Logical, Double-wide Word, Scalar) performs
 logical right shift on each 32-bit word element across a double-wide
@@ -12382,7 +12382,7 @@ of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
 pairs and must specify even register numbers; `rs2` is a single register.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12402,11 +12402,11 @@ if (rd_p != 0):
 <<<
 ==== PSRA.DBS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psra.dbs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRA.DBS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed byte elements. Available only in RV32.
@@ -12428,7 +12428,7 @@ scalar format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRA.DBS (Packed Shift Right Arithmetic, Double-wide Byte, Scalar) performs
 arithmetic right shift on each packed 8-bit element across a double-wide
@@ -12439,7 +12439,7 @@ are register pairs and must specify even register numbers; `rs2` is a single
 register. Each element is sign-extended before shifting. Available only in
 RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12460,11 +12460,11 @@ if (rd_p != 0):
 <<<
 ==== PSRA.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psra.dhs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRA.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed halfword elements. Available only in RV32.
@@ -12486,7 +12486,7 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRA.DHS (Packed Shift Right Arithmetic, Double-wide Halfword, Scalar)
 performs arithmetic right shift on each packed 16-bit element across a
@@ -12497,7 +12497,7 @@ the odd registers of each pair. The destination (`rd_p`) and first source
 a single register. Each element is sign-extended before shifting. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12518,11 +12518,11 @@ if (rd_p != 0):
 <<<
 ==== PSRA.DWS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psra.dws _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSRA.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with word elements. Available only in RV32.
@@ -12544,7 +12544,7 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRA.DWS (Packed Shift Right Arithmetic, Double-wide Word, Scalar) performs
 arithmetic right shift on each 32-bit word element across a double-wide
@@ -12554,7 +12554,7 @@ of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
 pairs and must specify even register numbers; `rs2` is a single register.
 Each element is sign-extended before shifting. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12575,11 +12575,11 @@ if (rd_p != 0):
 <<<
 ==== PSLLI.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pslli.db _rd_p_, _rs1_p_, _uimm3_
 
-===== Encoding
+Encoding::
 
 PSLLI.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with packed byte elements. Available only in RV32.
@@ -12601,7 +12601,7 @@ w-uimm format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSLLI.DB (Packed Shift Left Logical Immediate, Double-wide Byte) shifts each
 packed 8-bit element left by a 3-bit unsigned immediate across a double-wide
@@ -12610,7 +12610,7 @@ the even registers and one on the odd registers of each pair. The destination
 (`rd_p`) and source (`rs1_p`) are register pairs and must specify even register
 numbers. Vacated bits are filled with zeros. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12631,11 +12631,11 @@ if (rd_p != 0):
 <<<
 ==== PSLLI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pslli.dh _rd_p_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSLLI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with packed halfword elements. Available only in RV32.
@@ -12657,7 +12657,7 @@ w-uimm format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSLLI.DH (Packed Shift Left Logical Immediate, Double-wide Halfword) shifts
 each packed 16-bit element left by a 4-bit unsigned immediate across a
@@ -12667,7 +12667,7 @@ pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
 must specify even register numbers. Vacated bits are filled with zeros.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12688,11 +12688,11 @@ if (rd_p != 0):
 <<<
 ==== PSLLI.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pslli.dw _rd_p_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSLLI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with word elements. Available only in RV32.
@@ -12714,7 +12714,7 @@ w-uimm format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSLLI.DW (Packed Shift Left Logical Immediate, Double-wide Word) shifts each
 32-bit word element left by a 5-bit unsigned immediate across a double-wide
@@ -12723,7 +12723,7 @@ even registers and one on the odd registers of each pair. The destination
 (`rd_p`) and source (`rs1_p`) are register pairs and must specify even register
 numbers. Vacated bits are filled with zeros. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12744,11 +12744,11 @@ if (rd_p != 0):
 <<<
 ==== PSRLI.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrli.db _rd_p_, _rs1_p_, _uimm3_
 
-===== Encoding
+Encoding::
 
 PSRLI.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with packed byte elements. Available only in RV32.
@@ -12770,7 +12770,7 @@ w-uimm format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRLI.DB (Packed Shift Right Logical Immediate, Double-wide Byte) shifts each
 packed 8-bit element right logically by a 3-bit unsigned immediate across a
@@ -12780,7 +12780,7 @@ pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
 must specify even register numbers. Vacated bits are filled with zeros.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12801,11 +12801,11 @@ if (rd_p != 0):
 <<<
 ==== PSRLI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrli.dh _rd_p_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSRLI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with packed halfword elements. Available only in RV32.
@@ -12827,7 +12827,7 @@ w-uimm format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRLI.DH (Packed Shift Right Logical Immediate, Double-wide Halfword) shifts
 each packed 16-bit element right logically by a 4-bit unsigned immediate
@@ -12837,7 +12837,7 @@ pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs and
 must specify even register numbers. Vacated bits are filled with zeros.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12858,11 +12858,11 @@ if (rd_p != 0):
 <<<
 ==== PSRLI.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrli.dw _rd_p_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSRLI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with word elements. Available only in RV32.
@@ -12884,7 +12884,7 @@ w-uimm format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRLI.DW (Packed Shift Right Logical Immediate, Double-wide Word) shifts each
 32-bit word element right logically by a 5-bit unsigned immediate across a
@@ -12894,7 +12894,7 @@ destination (`rd_p`) and source (`rs1_p`) are register pairs and must specify
 even register numbers. Vacated bits are filled with zeros. Available only in
 RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12915,11 +12915,11 @@ if (rd_p != 0):
 <<<
 ==== PSRAI.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrai.db _rd_p_, _rs1_p_, _uimm3_
 
-===== Encoding
+Encoding::
 
 PSRAI.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with packed byte elements. Available only in RV32.
@@ -12941,7 +12941,7 @@ w-uimm format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRAI.DB (Packed Shift Right Arithmetic Immediate, Double-wide Byte) performs
 arithmetic right shift on each packed 8-bit element by a 3-bit unsigned
@@ -12951,7 +12951,7 @@ of each pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs
 and must specify even register numbers. Each element is sign-extended before
 shifting. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -12972,11 +12972,11 @@ if (rd_p != 0):
 <<<
 ==== PSRAI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrai.dh _rd_p_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSRAI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with packed halfword elements. Available only in RV32.
@@ -12998,7 +12998,7 @@ w-uimm format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRAI.DH (Packed Shift Right Arithmetic Immediate, Double-wide Halfword)
 performs arithmetic right shift on each packed 16-bit element by a 4-bit
@@ -13008,7 +13008,7 @@ the odd registers of each pair. The destination (`rd_p`) and source (`rs1_p`)
 are register pairs and must specify even register numbers. Each element is
 sign-extended before shifting. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13029,11 +13029,11 @@ if (rd_p != 0):
 <<<
 ==== PSRAI.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrai.dw _rd_p_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSRAI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with word elements. Available only in RV32.
@@ -13055,7 +13055,7 @@ w-uimm format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRAI.DW (Packed Shift Right Arithmetic Immediate, Double-wide Word) performs
 arithmetic right shift on each 32-bit word element by a 5-bit unsigned
@@ -13065,7 +13065,7 @@ each pair. The destination (`rd_p`) and source (`rs1_p`) are register pairs
 and must specify even register numbers. Each element is sign-extended before
 shifting. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13086,11 +13086,11 @@ if (rd_p != 0):
 <<<
 ==== PSRARI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrari.dh _rd_p_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSRARI.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with packed halfword elements. Available only in RV32.
@@ -13112,7 +13112,7 @@ w-uimm format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSRARI.DH (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
 Halfword) performs arithmetic right shift with rounding on each packed 16-bit
@@ -13123,7 +13123,7 @@ and source (`rs1_p`) are register pairs and must specify even register numbers.
 The shifted-out bit immediately below the least-significant result bit is
 added for rounding. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13148,11 +13148,11 @@ if (rd_p != 0):
 <<<
 ==== PSRARI.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psrari.dw _rd_p_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSRARI.DW is encoded in the OP-IMM-32 major opcode using the double-wide
 w-uimm format with word elements. Available only in RV32.
@@ -13176,7 +13176,7 @@ w-uimm format with word elements. Available only in RV32.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
-===== Description
+Description::
 
 PSRARI.DW (Packed Shift Right Arithmetic Rounding Immediate, Double-wide
 Word) performs arithmetic right shift with rounding on each 32-bit word
@@ -13187,7 +13187,7 @@ and one on the odd registers of each pair. The destination (`rd_p`) and source
 shifted-out bit immediately below the least-significant result bit is added
 for rounding. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13214,11 +13214,11 @@ if (rd_p != 0):
 
 ==== PSSHA.HS
 
-===== Mnemonic
+Mnemonic::
 
 pssha.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHA.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -13237,13 +13237,13 @@ PSSHA.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSHA.HS instruction performs a signed variable shift on each packed 16-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts saturate
 to the signed 16-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13282,18 +13282,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHA.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pssha.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHA.WS is available only in RV64.
 
@@ -13312,13 +13312,13 @@ PSSHA.WS is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSHA.WS instruction performs a signed variable shift on each packed 32-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts
 saturate to the signed 32-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13361,11 +13361,11 @@ X[rd] = d
 <<<
 ==== PSSHAR.HS
 
-===== Mnemonic
+Mnemonic::
 
 psshar.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHAR.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -13384,13 +13384,13 @@ PSSHAR.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSHAR.HS instruction performs a signed variable shift on each packed 16-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
 rounded, and left shifts saturate to the signed 16-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13426,18 +13426,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHAR.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psshar.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHAR.WS is available only in RV64.
 
@@ -13456,13 +13456,13 @@ PSSHAR.WS is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSHAR.WS instruction performs a signed variable shift on each packed 32-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
 rounded, and left shifts saturate to the signed 32-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13502,11 +13502,11 @@ X[rd] = d
 <<<
 ==== PSSHL.HS
 
-===== Mnemonic
+Mnemonic::
 
 psshl.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHA.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -13525,13 +13525,13 @@ PSSHA.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSHL.HS instruction performs an unsigned variable shift on each packed 16-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts saturate
 to the signed 16-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13567,18 +13567,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHL.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psshl.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHL.WS is available only in RV64.
 
@@ -13597,13 +13597,13 @@ PSSHL.WS is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSHL.WS instruction performs an unsigned variable shift on each packed 32-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts
 saturate to the signed 32-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13643,11 +13643,11 @@ X[rd] = d
 <<<
 ==== PSSHLR.HS
 
-===== Mnemonic
+Mnemonic::
 
 psshlr.hs _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHLR.HS is encoded in the OP-IMM-32 major opcode.
 
@@ -13666,13 +13666,13 @@ PSSHLR.HS is encoded in the OP-IMM-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSHLR.HS instruction performs an unsigned variable shift on each packed 16-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
 rounded, and left shifts saturate to the signed 16-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13705,18 +13705,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHLR.WS (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psshlr.ws _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHLR.WS is available only in RV64.
 
@@ -13735,13 +13735,13 @@ PSSHLR.WS is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The PSSHLR.WS instruction performs a unsigned variable shift on each packed 32-bit
 element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
 rounded, and left shifts saturate to the signed 32-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13778,11 +13778,11 @@ X[rd] = d
 <<<
 ==== PSSLAI.H
 
-===== Mnemonic
+Mnemonic::
 
 psslai.h _rd_, _rs1_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSSLAI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format
 and packed halfword elements.
@@ -13804,7 +13804,7 @@ and packed halfword elements.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
-===== Description
+Description::
 
 PSSLAI.H (Packed Saturating Shift Left Arithmetic Immediate, Halfword) shifts
 each packed signed 16-bit element of `rs1` left by a 4-bit unsigned immediate.
@@ -13812,7 +13812,7 @@ If the shifted result overflows the signed 16-bit range [-2^15, 2^15-1], the
 result is saturated to the nearest boundary and the `vxsat` flag is set. The
 packed halfword results are written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13832,18 +13832,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSLAI.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 psslai.w _rd_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSSLAI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format
 and word elements. Available only in RV64.
@@ -13865,7 +13865,7 @@ and word elements. Available only in RV64.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
-===== Description
+Description::
 
 PSSLAI.W (Packed Saturating Shift Left Arithmetic Immediate, Word) shifts each
 packed signed 32-bit element of `rs1` left by a 5-bit unsigned immediate. If
@@ -13873,7 +13873,7 @@ the shifted result overflows the signed 32-bit range [-2^31, 2^31-1], the
 result is saturated to the nearest boundary and the `vxsat` flag is set. The
 packed word results are written to `rd`. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13893,18 +13893,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== SSHA (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ssha _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SSHA is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 
@@ -13923,12 +13923,12 @@ SSHA is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 The SSHA instruction performs a signed variable shift of `rs1` using the signed
 shift amount in `rs2[7:0]`. Left shifts saturate to the signed 32-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -13956,18 +13956,18 @@ else:
         X[rd] = shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== SSHAR (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 sshar _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SSHAR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 
@@ -13986,13 +13986,13 @@ SSHAR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 The SSHAR instruction performs a signed variable shift of `rs1` using the signed
 shift amount in `rs2[7:0]`. Right shifts are rounded, and left shifts saturate
 to the signed 32-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14021,18 +14021,18 @@ else:
         X[rd] = shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs.
 
 <<<
 ==== SSHL (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 sshl _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SSHL is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 
@@ -14051,12 +14051,12 @@ SSHL is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 The SSHL instruction performs an unsigned variable shift of `rs1` using the signed
 shift amount in `rs2[7:0]`. Left shifts saturate to the signed 32-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14084,18 +14084,18 @@ else:
         X[rd] = shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== SSHLR (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 sshlr _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SSHLR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 
@@ -14114,13 +14114,13 @@ SSHLR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 The SSHLR instruction performs an unsigned variable shift of `rs1` using the signed
 shift amount in `rs2[7:0]`. Right shifts are rounded, and left shifts saturate
 to the signed 32-bit range.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14146,18 +14146,18 @@ else:
         X[rd] = shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs.
 
 <<<
 ==== SSLAI (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 sslai _rd_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 SSLAI is encoded in the OP-IMM-32 major opcode with the w-uimm format as
 a scalar XLEN-wide saturating shift left arithmetic immediate.
@@ -14179,14 +14179,14 @@ a scalar XLEN-wide saturating shift left arithmetic immediate.
 
 The `uimm5` field encodes the 5-bit shift amount.
 
-===== Description
+Description::
 
 SSLAI shifts the signed XLEN-wide value in `rs1` left by the immediate
 shift amount and writes the result to `rd` with signed saturation. If the
 shifted result overflows the signed XLEN-wide range, the result is clamped
 to the nearest boundary and the `vxsat` overflow flag is set.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14205,19 +14205,19 @@ else:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== SRARI
 
-===== Mnemonic
+Mnemonic::
 
 srari _rd_, _rs1_, _uimm5_ (RV32) +
 srari _rd_, _rs1_, _uimm6_ (RV64)
 
-===== Encoding
+Encoding::
 
 SRARI is encoded in the OP-IMM-32 major opcode with the w-uimm format as
 a scalar XLEN-wide shift right arithmetic with rounding. In RV32 the shift
@@ -14260,7 +14260,7 @@ RV64:
 
 The `uimm6` field encodes the 6-bit shift amount for RV64.
 
-===== Description
+Description::
 
 SRARI arithmetically shifts the XLEN-wide value in `rs1` right by the
 immediate shift amount with rounding and writes the result to `rd`. A
@@ -14268,7 +14268,7 @@ rounding bit is added before the final shift so that the result is rounded
 to the nearest integer (round-to-nearest, ties round up). When the shift
 amount is zero the source value is written unchanged.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14289,11 +14289,11 @@ X[rd] = d
 <<<
 ==== SHA (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 sha _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SHA is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -14312,13 +14312,13 @@ SHA is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The SHA instruction performs a signed variable shift of `rs1` using the signed
 shift amount in `rs2[7:0]`. Negative shift amounts shift right; non-negative
 shift amounts shift left.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14343,11 +14343,11 @@ else:
 <<<
 ==== SHAR (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 shar _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SHAR is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -14366,13 +14366,13 @@ SHAR is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The SHAR instruction matches SHA for non-negative shift amounts. For negative
 shift amounts it performs a rounding arithmetic right shift as specified in the
 Sail code.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14399,11 +14399,11 @@ else:
 <<<
 ==== SHL (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 shl _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SHL is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -14422,13 +14422,13 @@ SHL is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The SHL instruction performs an unsigned variable shift of `rs1` using the
 signed shift amount in `rs2[7:0]`. Negative shift amounts shift right;
 non-negative shift amounts shift left.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14453,11 +14453,11 @@ else:
 <<<
 ==== SHLR (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 shlr _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SHLR is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -14476,13 +14476,13 @@ SHLR is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The SHLR instruction matches SHL for non-negative shift amounts. For negative
 shift amounts it performs a rounding logical right shift as specified in the
 Sail code.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14508,11 +14508,11 @@ else:
 <<<
 ==== PSSHA.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssha.dhs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHA.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed halfword elements. Available only in RV32.
@@ -14534,7 +14534,7 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSHA.DHS (Packed Saturating Shift Halfword Arithmetic, Double-wide, Scalar)
 performs a signed shift on each packed 16-bit element across a double-wide
@@ -14547,7 +14547,7 @@ pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
 and must specify even register numbers; `rs2` is a single register. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14576,18 +14576,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHA.DWS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pssha.dws _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHA.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with word elements. Available only in RV32.
@@ -14609,7 +14609,7 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSHA.DWS (Packed Saturating Shift Word Arithmetic, Double-wide, Scalar)
 performs a signed shift on each 32-bit word element across a double-wide
@@ -14622,7 +14622,7 @@ pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
 and must specify even register numbers; `rs2` is a single register. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14651,18 +14651,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHAR.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psshar.dhs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHAR.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed halfword elements. Available only in RV32.
@@ -14684,7 +14684,7 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSHAR.DHS (Packed Saturating Shift Halfword Arithmetic Rounding, Double-wide,
 Scalar) performs a signed shift on each packed 16-bit element across a
@@ -14698,7 +14698,7 @@ of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
 pairs and must specify even register numbers; `rs2` is a single register.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14729,18 +14729,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHAR.DWS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psshar.dws _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHAR.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with word elements. Available only in RV32.
@@ -14762,7 +14762,7 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSHAR.DWS (Packed Saturating Shift Word Arithmetic Rounding, Double-wide,
 Scalar) performs a signed shift on each 32-bit word element across a
@@ -14776,7 +14776,7 @@ pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
 and must specify even register numbers; `rs2` is a single register. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14807,18 +14807,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHL.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psshl.dhs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHL.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed halfword elements. Available only in RV32.
@@ -14839,7 +14839,7 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSHL.DHS (Packed Saturating Shift Halfword Logical, Double-wide, Scalar)
 performs an unsigned shift on each packed 16-bit element across a double-wide
@@ -14852,7 +14852,7 @@ pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
 and must specify even register numbers; `rs2` is a single register. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14879,18 +14879,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHL.DWS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psshl.dws _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHL.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with word elements. Available only in RV32.
@@ -14911,7 +14911,7 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSHL.DWS (Packed Saturating Shift Word Logical, Double-wide, Scalar)
 performs a signed shift on each 32-bit word element across a double-wide
@@ -14924,7 +14924,7 @@ pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
 and must specify even register numbers; `rs2` is a single register. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -14951,18 +14951,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHLR.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psshlr.dhs _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHLR.DHS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with packed halfword elements. Available only in RV32.
@@ -14983,7 +14983,7 @@ scalar format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSHLR.DHS (Packed Saturating Shift Halfword Logical Rounding, Double-wide,
 Scalar) performs a signed shift on each packed 16-bit element across a
@@ -14997,7 +14997,7 @@ of each pair. The destination (`rd_p`) and first source (`rs1_p`) are register
 pairs and must specify even register numbers; `rs2` is a single register.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15026,18 +15026,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSHLR.DWS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psshlr.dws _rd_p_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PSSHLR.DWS is encoded in the OP-IMM-32 major opcode using the double-wide
 scalar format with word elements. Available only in RV32.
@@ -15058,7 +15058,7 @@ scalar format with word elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PSSHLR.DWS (Packed Saturating Shift Word Logical Rounding, Double-wide,
 Scalar) performs a signed shift on each 32-bit word element across a
@@ -15072,7 +15072,7 @@ pair. The destination (`rd_p`) and first source (`rs1_p`) are register pairs
 and must specify even register numbers; `rs2` is a single register. Available
 only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15101,18 +15101,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSLAI.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psslai.dh _rd_p_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PSSLAI.DH is encoded in the OP-IMM-32 major opcode using the register-pair
 immediate format with packed halfword elements. Available only in RV32.
@@ -15136,7 +15136,7 @@ immediate format with packed halfword elements. Available only in RV32.
 
 The `uimm4` field encodes the 4-bit shift amount for halfword elements.
 
-===== Description
+Description::
 
 PSSLAI.DH performs packed 16-bit saturating shift-left arithmetic by an immediate
 on double-wide (register-pair) operands. It is equivalent to two PSSLAI.H
@@ -15145,7 +15145,7 @@ Both operands (`rd_p`, `rs1_p`) are register pairs and must specify even registe
 numbers. If any result overflows the signed 16-bit range, it is saturated and the
 `vxsat` flag is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15168,18 +15168,18 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PSSLAI.DW (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 psslai.dw _rd_p_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PSSLAI.DW is encoded in the OP-IMM-32 major opcode using the register-pair
 immediate format with word elements. Available only in RV32.
@@ -15203,7 +15203,7 @@ immediate format with word elements. Available only in RV32.
 
 The `uimm5` field encodes the 5-bit shift amount for word elements.
 
-===== Description
+Description::
 
 PSSLAI.DW performs XLEN-wide saturating shift-left arithmetic by an immediate
 on double-wide (register-pair) operands. It is equivalent to two SSLAI
@@ -15212,7 +15212,7 @@ Both operands (`rd_p`, `rs1_p`) are register pairs and must specify even registe
 numbers. If any result overflows the signed 32-bit range, it is saturated and the
 `vxsat` flag is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15235,7 +15235,7 @@ if (rd_p != 0):
     X[rd_p*2+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
@@ -15244,11 +15244,11 @@ if (rd_p != 0):
 
 ==== PPAIRE.B
 
-===== Mnemonic
+Mnemonic::
 
 ppaire.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIRE.B is encoded in the OP-32 major opcode with packed-byte pairing.
 
@@ -15267,13 +15267,13 @@ PPAIRE.B is encoded in the OP-32 major opcode with packed-byte pairing.
 ]}
 ....
 
-===== Description
+Description::
 
 The PPAIRE.B instruction forms packed 16-bit elements by pairing the low byte of each
 halfword element of `rs2` as the high byte with the low byte of the corresponding
 halfword element of `rs1` as the low byte.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15292,11 +15292,11 @@ X[rd] = d
 <<<
 ==== PPAIRE.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 ppaire.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIRE.H is encoded in the OP-32 major opcode with packed halfword elements.
 On RV32, PPAIRE.H is a pseudoinstruction aliased to PACK.
@@ -15315,7 +15315,7 @@ On RV32, PPAIRE.H is a pseudoinstruction aliased to PACK.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIRE.H (Pack Pair Even Halfwords) extracts the even (lower) halfword from
 each 32-bit word of `rs1` and `rs2`, and packs them together into the
@@ -15323,7 +15323,7 @@ corresponding 32-bit word of `rd`. Within each 32-bit group, the lower halfword
 comes from `rs1` and the upper halfword comes from `rs2`. On RV32, this
 mnemonic is an alias for PACK.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15342,11 +15342,11 @@ X[rd] = d
 <<<
 ==== PPAIREO.B
 
-===== Mnemonic
+Mnemonic::
 
 ppaireo.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIREO.B is encoded in the OP-32 major opcode with packed-byte pairing.
 
@@ -15365,12 +15365,12 @@ PPAIREO.B is encoded in the OP-32 major opcode with packed-byte pairing.
 ]}
 ....
 
-===== Description
+Description::
 
 The PPAIREO.B instruction pairs the high byte of each halfword element of `rs2` with
 the low byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15389,11 +15389,11 @@ X[rd] = d
 <<<
 ==== PPAIREO.H
 
-===== Mnemonic
+Mnemonic::
 
 ppaireo.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIREO.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -15411,7 +15411,7 @@ PPAIREO.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIREO.H (Pack Pair Even-Odd Halfwords) extracts the even (lower) halfword
 from each 32-bit word of `rs1` and the odd (upper) halfword from each 32-bit
@@ -15419,7 +15419,7 @@ word of `rs2`, and packs them together into the corresponding 32-bit word of
 `rd`. Within each 32-bit group, the lower halfword comes from the even position
 of `rs1` and the upper halfword comes from the odd position of `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15438,11 +15438,11 @@ X[rd] = d
 <<<
 ==== PPAIREO.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 ppaireo.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIREO.W is encoded in the OP-32 major opcode with packed word elements.
 Available only in RV64.
@@ -15461,14 +15461,14 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIREO.W (Pack Pair Even-Odd Words) extracts the even (lower) 32-bit word from
 `rs1` and the odd (upper) 32-bit word from `rs2`, and packs them into `rd`. The
 lower word of the result comes from the even position of `rs1` and the upper word
 comes from the odd position of `rs2`. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15485,11 +15485,11 @@ X[rd] = d
 <<<
 ==== PPAIROE.B
 
-===== Mnemonic
+Mnemonic::
 
 ppairoe.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIROE.B is encoded in the OP-32 major opcode with packed-byte pairing.
 
@@ -15508,12 +15508,12 @@ PPAIROE.B is encoded in the OP-32 major opcode with packed-byte pairing.
 ]}
 ....
 
-===== Description
+Description::
 
 The PPAIROE.B instruction pairs the low byte of each halfword element of `rs2` with
 the high byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15532,11 +15532,11 @@ X[rd] = d
 <<<
 ==== PPAIROE.H
 
-===== Mnemonic
+Mnemonic::
 
 ppairoe.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIROE.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -15554,7 +15554,7 @@ PPAIROE.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIROE.H (Pack Pair Odd-Even Halfwords) extracts the odd (upper) halfword from
 each 32-bit word of `rs1` and the even (lower) halfword from each 32-bit word
@@ -15562,7 +15562,7 @@ of `rs2`, and packs them together into the corresponding 32-bit word of `rd`.
 Within each 32-bit group, the lower halfword comes from the odd position of
 `rs1` and the upper halfword comes from the even position of `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15581,11 +15581,11 @@ X[rd] = d
 <<<
 ==== PPAIROE.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 ppairoe.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIROE.W is encoded in the OP-32 major opcode with packed word elements.
 Available only in RV64.
@@ -15604,14 +15604,14 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIROE.W (Pack Pair Odd-Even Words) extracts the odd (upper) 32-bit word from
 `rs1` and the even (lower) 32-bit word from `rs2`, and packs them into `rd`. The
 lower word of the result comes from the odd position of `rs1` and the upper word
 comes from the even position of `rs2`. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15628,11 +15628,11 @@ X[rd] = d
 <<<
 ==== PPAIRO.B
 
-===== Mnemonic
+Mnemonic::
 
 ppairo.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIRO.B is encoded in the OP-32 major opcode with packed-byte pairing.
 
@@ -15651,12 +15651,12 @@ PPAIRO.B is encoded in the OP-32 major opcode with packed-byte pairing.
 ]}
 ....
 
-===== Description
+Description::
 
 The PPAIRO.B instruction pairs the high byte of each halfword element of `rs2` with
 the high byte of the corresponding halfword element of `rs1`, producing packed halfwords.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15676,11 +15676,11 @@ X[rd] = d
 <<<
 ==== PPAIRO.H
 
-===== Mnemonic
+Mnemonic::
 
 ppairo.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIRO.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -15698,7 +15698,7 @@ PPAIRO.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIRO.H (Pack Pair Odd Halfwords) extracts the odd (upper) halfword from each
 32-bit word of `rs1` and `rs2`, and packs them together into the corresponding
@@ -15706,7 +15706,7 @@ PPAIRO.H (Pack Pair Odd Halfwords) extracts the odd (upper) halfword from each
 odd position of `rs1` and the upper halfword comes from the odd position of
 `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15725,11 +15725,11 @@ X[rd] = d
 <<<
 ==== PPAIRO.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 ppairo.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PPAIRO.W is encoded in the OP-32 major opcode with packed word elements.
 Available only in RV64.
@@ -15748,14 +15748,14 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIRO.W (Pack Pair Odd Words) extracts the odd (upper) 32-bit word from both
 `rs1` and `rs2`, and packs them into `rd`. The lower word of the result comes
 from the odd position of `rs1` and the upper word comes from the odd position of
 `rs2`. Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15772,11 +15772,11 @@ X[rd] = d
 <<<
 ==== PPAIRE.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ppaire.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PPAIRE.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed byte elements. Available only in RV32.
@@ -15798,7 +15798,7 @@ register-pair format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIRE.DB performs packed byte even-element packing on double-wide
 (register-pair) operands. It is equivalent to two PPAIRE.B operations: one on
@@ -15806,7 +15806,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15828,11 +15828,11 @@ if (rd_p != 0):
 <<<
 ==== PPAIRE.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ppaire.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PPAIRE.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed halfword elements. Available only in RV32.
@@ -15854,7 +15854,7 @@ register-pair format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIRE.DH performs packed halfword even-element packing on double-wide
 (register-pair) operands. It is equivalent to two PPAIRE.H operations: one on
@@ -15862,7 +15862,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15884,11 +15884,11 @@ if (rd_p != 0):
 <<<
 ==== PPAIREO.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ppaireo.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PPAIREO.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed byte elements. Available only in RV32.
@@ -15910,7 +15910,7 @@ register-pair format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIREO.DB performs packed byte even-odd element packing on double-wide
 (register-pair) operands. It is equivalent to two PPAIREO.B operations: one on
@@ -15918,7 +15918,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15940,11 +15940,11 @@ if (rd_p != 0):
 <<<
 ==== PPAIREO.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ppaireo.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PPAIREO.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed halfword elements. Available only in RV32.
@@ -15966,7 +15966,7 @@ register-pair format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIREO.DH performs packed halfword even-odd element packing on double-wide
 (register-pair) operands. It is equivalent to two PPAIREO.H operations: one on
@@ -15974,7 +15974,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -15996,11 +15996,11 @@ if (rd_p != 0):
 <<<
 ==== PPAIROE.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ppairoe.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PPAIROE.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed byte elements. Available only in RV32.
@@ -16022,7 +16022,7 @@ register-pair format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIROE.DB performs packed byte odd-even element packing on double-wide
 (register-pair) operands. It is equivalent to two PPAIROE.B operations: one on
@@ -16030,7 +16030,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16052,11 +16052,11 @@ if (rd_p != 0):
 <<<
 ==== PPAIROE.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ppairoe.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PPAIROE.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed halfword elements. Available only in RV32.
@@ -16078,7 +16078,7 @@ register-pair format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIROE.DH performs packed halfword odd-even element packing on double-wide
 (register-pair) operands. It is equivalent to two PPAIROE.H operations: one on
@@ -16086,7 +16086,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16108,11 +16108,11 @@ if (rd_p != 0):
 <<<
 ==== PPAIRO.DB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ppairo.db _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PPAIRO.DB is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed byte elements. Available only in RV32.
@@ -16134,7 +16134,7 @@ register-pair format with packed byte elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIRO.DB performs packed byte odd-element packing on double-wide
 (register-pair) operands. It is equivalent to two PPAIRO.B operations: one on
@@ -16142,7 +16142,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16164,11 +16164,11 @@ if (rd_p != 0):
 <<<
 ==== PPAIRO.DH (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 ppairo.dh _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 PPAIRO.DH is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format with packed halfword elements. Available only in RV32.
@@ -16190,7 +16190,7 @@ register-pair format with packed halfword elements. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PPAIRO.DH performs packed halfword odd-element packing on double-wide
 (register-pair) operands. It is equivalent to two PPAIRO.H operations: one on
@@ -16198,7 +16198,7 @@ the even registers and one on the odd registers of each pair. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16222,11 +16222,11 @@ if (rd_p != 0):
 
 ==== ZIP8P (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 zip8p _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 ZIP8P is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -16245,12 +16245,12 @@ ZIP8P is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The ZIP8P instruction interleaves bytes from `rs2` and `rs1` to form a packed 64-bit result:
 for each byte position, the corresponding byte from `rs2` is placed above the byte from `rs1`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16266,11 +16266,11 @@ X[rd] =
 <<<
 ==== ZIP8HP (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 zip8hp _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 ZIP8HP is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -16289,12 +16289,12 @@ ZIP8HP is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The ZIP8HP instruction interleaves bytes from the high 32-bit halves of `rs2` and
 `rs1` to form a 64-bit result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16310,11 +16310,11 @@ X[rd] =
 <<<
 ==== UNZIP8P (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 unzip8p _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 UNZIP8P is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -16333,12 +16333,12 @@ UNZIP8P is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The UNZIP8P instruction de-interleaves bytes from `rs2` and `rs1` to form a 64-bit
 result containing selected byte lanes from each source.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16354,11 +16354,11 @@ X[rd] =
 <<<
 ==== UNZIP8HP (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 unzip8hp _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 UNZIP8HP is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -16377,12 +16377,12 @@ UNZIP8HP is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The UNZIP8HP instruction de-interleaves bytes from `rs2` and `rs1` using the
 high-part byte selection pattern and forms a 64-bit result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16398,11 +16398,11 @@ X[rd] =
 <<<
 ==== ZIP16P (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 zip16p _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 ZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -16421,12 +16421,12 @@ ZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The ZIP16P instruction interleaves 16-bit chunks from `rs2` and `rs1` to form a
 64-bit result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16440,11 +16440,11 @@ X[rd] = s2[31:16] @ s1[31:16] @ s2[15:0] @ s1[15:0]
 <<<
 ==== ZIP16HP (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 zip16hp _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 ZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -16463,12 +16463,12 @@ ZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The ZIP16HP instruction interleaves 16-bit chunks from the high 32-bit halves of
 `rs2` and `rs1` to form a 64-bit result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16482,11 +16482,11 @@ X[rd] = s2[63:48] @ s1[63:48] @ s2[47:32] @ s1[47:32]
 <<<
 ==== UNZIP16P (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 unzip16p _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 UNZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -16505,12 +16505,12 @@ UNZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The UNZIP16P instruction de-interleaves 16-bit chunks from `rs2` and `rs1` and
 forms a 64-bit result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16524,11 +16524,11 @@ X[rd] = s2[47:32] @ s2[15:0] @ s1[47:32] @ s1[15:0]
 <<<
 ==== UNZIP16HP (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 unzip16hp _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 UNZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
 
@@ -16547,12 +16547,12 @@ UNZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 The UNZIP16HP instruction de-interleaves 16-bit chunks from the high 32-bit halves
 of `rs2` and `rs1` and forms a 64-bit result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16566,11 +16566,11 @@ X[rd] = s2[63:48] @ s2[31:16] @ s1[63:48] @ s1[31:16]
 <<<
 ==== REV16 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 rev16 _rd_, _rs1_
 
-===== Encoding
+Encoding::
 
 REV16 is a scalar instruction encoded in the OP-IMM major opcode and is available only in RV64.
 
@@ -16585,11 +16585,11 @@ REV16 is a scalar instruction encoded in the OP-IMM major opcode and is availabl
 ]}
 ....
 
-===== Description
+Description::
 
 The REV16 instruction reverses the order of 16-bit chunks within the 64-bit value in `rs1`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16602,11 +16602,11 @@ X[rd] = s1[15:0] @ s1[31:16] @ s1[47:32] @ s1[63:48]
 <<<
 ==== REV
 
-===== Mnemonic
+Mnemonic::
 
 rev _rd_, _rs1_
 
-===== Encoding
+Encoding::
 
 REV is encoded in the OP-IMM major opcode as a unary instruction. The encoding
 differs between RV32 and RV64.
@@ -16637,13 +16637,13 @@ RV64:
 ]}
 ....
 
-===== Description
+Description::
 
 REV reverses the bit order of the full XLEN-wide value in `rs1` and writes
 the result to `rd`. Bit 0 of the source becomes bit XLEN-1 of the result,
 bit 1 becomes bit XLEN-2, and so on.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16662,11 +16662,11 @@ X[rd] = d
 
 ==== ABS
 
-===== Mnemonic
+Mnemonic::
 
 abs _rd_, _rs1_, _imm12_
 
-===== Encoding
+Encoding::
 
 ABS is encoded in the OP-IMM major opcode.
 
@@ -16681,11 +16681,11 @@ ABS is encoded in the OP-IMM major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 ABS writes the absolute value of `X[rs1]` to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16697,11 +16697,11 @@ X[rd] = (signed(s1) < 0) ? (0 - s1) : s1
 <<<
 ==== ABSW (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 absw _rd_, _rs1_, _simm12_
 
-===== Encoding
+Encoding::
 
 ABSW is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 
@@ -16716,12 +16716,12 @@ ABSW is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 ABSW writes the absolute value of the low 32 bits of `rs1` (treated as signed)
 to `rd`, sign-extended to XLEN.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16733,11 +16733,11 @@ X[rd] = sign_extend(64, (signed(w) <_s 0) ? (0 - w) : w)
 <<<
 ==== CLS
 
-===== Mnemonic
+Mnemonic::
 
 cls _rd_, _rs1_, _imm12_
 
-===== Encoding
+Encoding::
 
 CLS is encoded in the OP-IMM major opcode.
 
@@ -16752,11 +16752,11 @@ CLS is encoded in the OP-IMM major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 CLS returns the count `c` produced by the Sail reference algorithm.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16776,11 +16776,11 @@ X[rd] = to_bits(XLEN, c)
 <<<
 ==== CLSW (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 clsw _rd_, _rs1_, _imm12_
 
-===== Encoding
+Encoding::
 
 CLSW is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 
@@ -16795,12 +16795,12 @@ CLSW is encoded in the OP-IMM-32 major opcode and is available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 CLSW applies the CLS definition to the low 32 bits of `rs1` and writes the count
 as an XLEN value.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16816,11 +16816,11 @@ X[rd] = to_bits(XLEN, c)
 <<<
 ==== SLX
 
-===== Mnemonic
+Mnemonic::
 
 slx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SLX is encoded in the OP-32 major opcode.
 
@@ -16838,12 +16838,12 @@ SLX is encoded in the OP-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 SLX shifts the 2*XLEN-bit concatenation `X[rd] @ X[rs1]` left by `shamt` and
 writes the upper XLEN bits to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16855,11 +16855,11 @@ X[rd] = ((X[rd] @ X[rs1]) << shamt)[(2*XLEN-1):XLEN]
 <<<
 ==== SRX
 
-===== Mnemonic
+Mnemonic::
 
 srx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 SRX is encoded in the OP-32 major opcode.
 
@@ -16877,12 +16877,12 @@ SRX is encoded in the OP-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 SRX shifts the 2*XLEN-bit concatenation `X[rs1] @ X[rd]` right by `shamt` and
 writes the lower XLEN bits to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16894,11 +16894,11 @@ X[rd] = ((X[rs1] @ X[rd]) >> shamt)[(XLEN-1):0]
 <<<
 ==== MVM
 
-===== Mnemonic
+Mnemonic::
 
 mvm _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MVM is encoded in the OP-32 major opcode.
 
@@ -16916,11 +16916,11 @@ MVM is encoded in the OP-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 MVM merges `rs1` and the prior value of `rd` under control of the mask `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16932,11 +16932,11 @@ X[rd] = (~m & X[rd]) | (m & X[rs1])
 <<<
 ==== MVMN
 
-===== Mnemonic
+Mnemonic::
 
 mvmn _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MVMN is encoded in the OP-32 major opcode.
 
@@ -16954,11 +16954,11 @@ MVMN is encoded in the OP-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 MVMN is like MVM, but swaps the roles of `rs1` and the prior `rd` value.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -16970,11 +16970,11 @@ X[rd] = (~m & X[rs1]) | (m & X[rd])
 <<<
 ==== MERGE
 
-===== Mnemonic
+Mnemonic::
 
 merge _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MERGE is encoded in the OP-32 major opcode.
 
@@ -16992,11 +16992,11 @@ MERGE is encoded in the OP-32 major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 MERGE uses the prior value of `rd` as the mask to select between `rs1` and `rs2`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17008,11 +17008,11 @@ X[rd] = (~d0 & X[rs1]) | (d0 & X[rs2])
 <<<
 ==== PACK
 
-===== Mnemonic
+Mnemonic::
 
 pack _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PACK is encoded in the OP major opcode.
 
@@ -17028,12 +17028,12 @@ PACK is encoded in the OP major opcode.
 ]}
 ....
 
-===== Description
+Description::
 
 The pack instruction packs the XLEN/2-bit lower halves of `rs1` and `rs2` into
 `rd`, with `rs1` in the lower half and `rs2` in the upper half.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17052,11 +17052,11 @@ X[rd] = d
 
 ==== ADDD (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 addd _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 ADDD is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -17078,7 +17078,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 ADDD (Add Doubleword) performs a 64-bit addition of two register-pair operands
 on RV32. The 64-bit source values are formed by concatenating the odd (high) and
@@ -17087,7 +17087,7 @@ written back to the register pair designated by `rd_p`. All three operands
 (`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
 numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17105,11 +17105,11 @@ X[rd_p * 2 + 1] = d[63:32]
 <<<
 ==== SUBD (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 subd _rd_p_, _rs1_p_, _rs2_p_
 
-===== Encoding
+Encoding::
 
 SUBD is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
@@ -17131,7 +17131,7 @@ register-pair format. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 SUBD performs a 64-bit integer subtraction using register pairs on RV32.
 The source operands `rs1_p` and `rs2_p` each designate a register pair
@@ -17139,7 +17139,7 @@ forming a 64-bit value (even register = low word, odd register = high word).
 The 64-bit difference is written to the register pair designated by `rd_p`.
 All pair operands must specify even register numbers. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17159,11 +17159,11 @@ X[rd_p * 2 + 1] = d[63:32]
 
 ==== PWADD.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwadd.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWADD.B is available only in RV32. It writes a 64-bit result to an even-odd
 register pair specified by `rd_p`.
@@ -17183,13 +17183,13 @@ register pair specified by `rd_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWADD.B sign-extends corresponding packed 8-bit elements of `rs1` and `rs2` to
 signed values, adds them, and produces four packed 16-bit results. The 64-bit
 result is written to the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17210,11 +17210,11 @@ if (rd_p != 0):
 <<<
 ==== PWADDA.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwadda.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWADDA.B is available only in RV32. It accumulates into the destination register pair.
 
@@ -17233,13 +17233,13 @@ PWADDA.B is available only in RV32. It accumulates into the destination register
 ]}
 ....
 
-===== Description
+Description::
 
 PWADDA.B performs the same packed byte-to-halfword signed additions as PWADD.B,
 then adds each 16-bit result into the corresponding 16-bit element of the
 destination register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17263,11 +17263,11 @@ if (rd_p != 0):
 <<<
 ==== PWADDU.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwaddu.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWADDU.B is available only in RV32. It writes a 64-bit result to an even-odd
 register pair specified by `rd_p`.
@@ -17287,13 +17287,13 @@ register pair specified by `rd_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWADDU.B zero-extends corresponding packed 8-bit elements of `rs1` and `rs2` to
 unsigned values, adds them, and produces four packed 16-bit results, written to
 the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17314,11 +17314,11 @@ if (rd_p != 0):
 <<<
 ==== PWADDAU.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwaddau.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWADDAU.B is available only in RV32. It accumulates into the destination register pair.
 
@@ -17337,13 +17337,13 @@ PWADDAU.B is available only in RV32. It accumulates into the destination registe
 ]}
 ....
 
-===== Description
+Description::
 
 PWADDAU.B performs the same packed byte-to-halfword unsigned additions as PWADDU.B,
 then adds each 16-bit result into the corresponding 16-bit element of the
 destination register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17367,11 +17367,11 @@ if (rd_p != 0):
 <<<
 ==== PWSUB.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsub.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSUB.B is available only in RV32. It writes a 64-bit result to an even-odd
 register pair specified by `rd_p`.
@@ -17391,14 +17391,14 @@ register pair specified by `rd_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSUB.B sign-extends corresponding packed 8-bit elements of `rs1` and `rs2`,
 subtracts them, and produces four packed 16-bit results. When `rd_p != 0`,
 the 64-bit result is written to the destination register pair
 `{X[2*rd_p+1], X[2*rd_p]}`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17419,11 +17419,11 @@ if (rd_p != 0):
 <<<
 ==== PWSUBA.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsuba.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSUBA.B is available only in RV32 and accumulates into the destination
 register pair.
@@ -17443,13 +17443,13 @@ register pair.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSUBA.B performs the same packed byte-to-halfword signed subtraction as
 PWSUB.B, then adds each 16-bit result into the corresponding 16-bit element
 of the destination register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17473,11 +17473,11 @@ if (rd_p != 0):
 <<<
 ==== PWSUBU.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsubu.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSUBU.B is available only in RV32. It writes a 64-bit result to an even-odd
 register pair specified by `rd_p`.
@@ -17497,13 +17497,13 @@ register pair specified by `rd_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSUBU.B zero-extends corresponding packed 8-bit elements of `rs1` and `rs2`,
 subtracts them as unsigned values, and produces four packed 16-bit results,
 written to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17524,11 +17524,11 @@ if (rd_p != 0):
 <<<
 ==== PWSUBAU.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsubau.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSUBAU.B is available only in RV32 and accumulates into the destination
 register pair.
@@ -17548,13 +17548,13 @@ register pair.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSUBAU.B performs the same packed byte-to-halfword unsigned subtraction as
 PWSUBU.B, then adds each 16-bit result into the corresponding 16-bit element
 of the destination register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17578,11 +17578,11 @@ if (rd_p != 0):
 <<<
 ==== PWADD.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwadd.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWADD.H is available only in RV32. It writes results to an even-odd register
 pair specified by `rd_p`.
@@ -17602,12 +17602,12 @@ pair specified by `rd_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWADD.H sign-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
 and writes two 32-bit results to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17625,11 +17625,11 @@ if (rd_p != 0):
 <<<
 ==== PWADDA.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwadda.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWADDA.H is available only in RV32 and accumulates into the destination register pair.
 
@@ -17648,12 +17648,12 @@ PWADDA.H is available only in RV32 and accumulates into the destination register
 ]}
 ....
 
-===== Description
+Description::
 
 PWADDA.H performs PWADD.H and adds each 32-bit result into the corresponding
 32-bit element of the destination register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17675,11 +17675,11 @@ if (rd_p != 0):
 <<<
 ==== PWADDU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwaddu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWADDU.H is available only in RV32.
 
@@ -17698,12 +17698,12 @@ PWADDU.H is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PWADDU.H zero-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
 and writes two 32-bit results to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17721,11 +17721,11 @@ if (rd_p != 0):
 <<<
 ==== PWADDAU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwaddau.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWADDAU.H is available only in RV32 and accumulates into the destination register pair.
 
@@ -17744,12 +17744,12 @@ PWADDAU.H is available only in RV32 and accumulates into the destination registe
 ]}
 ....
 
-===== Description
+Description::
 
 PWADDAU.H performs PWADDU.H and accumulates the two 32-bit results into the
 destination register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17771,11 +17771,11 @@ if (rd_p != 0):
 <<<
 ==== PWSUB.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsub.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSUB.H is available only in RV32.
 
@@ -17794,12 +17794,12 @@ PWSUB.H is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSUB.H sign-extends each 16-bit halfword element, subtracts element-wise, and
 writes two 32-bit results to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17817,11 +17817,11 @@ if (rd_p != 0):
 <<<
 ==== PWSUBA.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsuba.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSUBA.H is available only in RV32 and accumulates into the destination register pair.
 
@@ -17840,12 +17840,12 @@ PWSUBA.H is available only in RV32 and accumulates into the destination register
 ]}
 ....
 
-===== Description
+Description::
 
 PWSUBA.H performs PWSUB.H and accumulates the two 32-bit results into the
 destination register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17867,11 +17867,11 @@ if (rd_p != 0):
 <<<
 ==== PWSUBU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsubu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSUBU.H is available only in RV32.
 
@@ -17890,13 +17890,13 @@ PWSUBU.H is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSUBU.H zero-extends each 16-bit halfword element, subtracts element-wise as
 unsigned values, and writes two 32-bit results to the destination register pair
 when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17914,11 +17914,11 @@ if (rd_p != 0):
 <<<
 ==== PWSUBAU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsubau.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSUBAU.H is available only in RV32 and accumulates into the destination register pair.
 
@@ -17937,12 +17937,12 @@ PWSUBAU.H is available only in RV32 and accumulates into the destination registe
 ]}
 ....
 
-===== Description
+Description::
 
 PWSUBAU.H performs PWSUBU.H and accumulates the two 32-bit results into the
 destination register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -17964,11 +17964,11 @@ if (rd_p != 0):
 <<<
 ==== WADD (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wadd _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WADD is available only in RV32 and writes a 64-bit result to register pair `rd_p`.
 
@@ -17987,12 +17987,12 @@ WADD is available only in RV32 and writes a 64-bit result to register pair `rd_p
 ]}
 ....
 
-===== Description
+Description::
 
 WADD adds `rs1` and `rs2` as signed XLEN values and writes the 64-bit sum to the
 destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18007,11 +18007,11 @@ if (rd_p != 0):
 <<<
 ==== WADDA (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wadda _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WADDA is available only in RV32 and accumulates into the destination register pair.
 
@@ -18030,12 +18030,12 @@ WADDA is available only in RV32 and accumulates into the destination register pa
 ]}
 ....
 
-===== Description
+Description::
 
 WADDA performs WADD and accumulates the 64-bit result into the destination
 register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18051,11 +18051,11 @@ if (rd_p != 0):
 <<<
 ==== WADDU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 waddu _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WADDU is available only in RV32.
 
@@ -18074,12 +18074,12 @@ WADDU is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 WADDU adds `rs1` and `rs2` as unsigned XLEN values and writes the 64-bit sum to
 the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18094,11 +18094,11 @@ if (rd_p != 0):
 <<<
 ==== WADDAU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 waddau _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WADDAU is available only in RV32 and accumulates into the destination register pair.
 
@@ -18117,12 +18117,12 @@ WADDAU is available only in RV32 and accumulates into the destination register p
 ]}
 ....
 
-===== Description
+Description::
 
 WADDAU performs WADDU and accumulates the 64-bit result into the destination
 register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18138,11 +18138,11 @@ if (rd_p != 0):
 <<<
 ==== WSUB (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wsub _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WSUB is available only in RV32.
 
@@ -18161,12 +18161,12 @@ WSUB is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 WSUB subtracts `rs2` from `rs1` as signed XLEN values and writes the 64-bit
 difference to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18181,11 +18181,11 @@ if (rd_p != 0):
 <<<
 ==== WSUBA (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wsuba _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WSUBA is available only in RV32 and accumulates into the destination register pair.
 
@@ -18204,12 +18204,12 @@ WSUBA is available only in RV32 and accumulates into the destination register pa
 ]}
 ....
 
-===== Description
+Description::
 
 WSUBA performs WSUB and accumulates the 64-bit result into the destination
 register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18225,11 +18225,11 @@ if (rd_p != 0):
 <<<
 ==== WSUBU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wsubu _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WSUBU is available only in RV32.
 
@@ -18248,12 +18248,12 @@ WSUBU is available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 WSUBU subtracts `rs2` from `rs1` as unsigned XLEN values and writes the 64-bit
 difference to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18268,11 +18268,11 @@ if (rd_p != 0):
 <<<
 ==== WSUBAU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wsubau _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WSUBAU is available only in RV32 and accumulates into the destination register pair.
 
@@ -18291,12 +18291,12 @@ WSUBAU is available only in RV32 and accumulates into the destination register p
 ]}
 ....
 
-===== Description
+Description::
 
 WSUBAU performs WSUBU and accumulates the 64-bit result into the destination
 register pair.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18315,11 +18315,11 @@ if (rd_p != 0):
 
 ==== PWSLLI.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwslli.b _rd_p_, _rs1_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PWSLLI.B is available only in RV32. The shift amount is encoded in the `uimm4`
 field. The destination is a register pair `rd_p`.
@@ -18340,12 +18340,12 @@ field. The destination is a register pair `rd_p`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSLLI.B widens each 8-bit element of `rs1` to 16 bits by zero-extension, then
 shifts left by an immediate amount, producing four 16-bit results.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18365,11 +18365,11 @@ if (rd_p != 0):
 <<<
 ==== PWSLL.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsll.bs _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSLL.BS is available only in RV32. The shift amount is taken from `rs2`.
 
@@ -18389,12 +18389,12 @@ PWSLL.BS is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSLL.BS widens each 8-bit element of `rs1` to 16 bits by zero-extension, then
 shifts left by the amount in `rs2` (low 5 bits), producing four 16-bit results.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18414,11 +18414,11 @@ if (rd_p != 0):
 <<<
 ==== PWSLAI.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwslai.b _rd_p_, _rs1_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PWSLAI.B is available only in RV32. The shift amount is encoded in `uimm4`.
 
@@ -18438,12 +18438,12 @@ PWSLAI.B is available only in RV32. The shift amount is encoded in `uimm4`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSLAI.B widens each 8-bit element of `rs1` to 16 bits by sign-extension, then
 shifts left by an immediate amount, producing four 16-bit results.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18463,11 +18463,11 @@ if (rd_p != 0):
 <<<
 ==== PWSLA.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsla.bs _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSLA.BS is available only in RV32. The shift amount is taken from `rs2`.
 
@@ -18487,12 +18487,12 @@ PWSLA.BS is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSLA.BS widens each 8-bit element of `rs1` to 16 bits by sign-extension, then
 shifts left by the amount in `rs2` (low 5 bits), producing four 16-bit results.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18512,11 +18512,11 @@ if (rd_p != 0):
 <<<
 ==== PWSLLI.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwslli.h _rd_p_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PWSLLI.H is available only in RV32. The shift amount is encoded in `uimm5`.
 
@@ -18536,12 +18536,12 @@ PWSLLI.H is available only in RV32. The shift amount is encoded in `uimm5`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSLLI.H widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
 shifts left by an immediate amount, producing two 32-bit results.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18560,11 +18560,11 @@ if (rd_p != 0):
 <<<
 ==== PWSLL.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsll.hs _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSLL.HS is available only in RV32. The shift amount is taken from `rs2`.
 
@@ -18584,12 +18584,12 @@ PWSLL.HS is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSLL.HS widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
 shifts left by the amount in `rs2` (low 5 bits).
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18608,11 +18608,11 @@ if (rd_p != 0):
 <<<
 ==== PWSLAI.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwslai.h _rd_p_, _rs1_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PWSLAI.H is available only in RV32. The shift amount is encoded in `uimm5`.
 
@@ -18632,12 +18632,12 @@ PWSLAI.H is available only in RV32. The shift amount is encoded in `uimm5`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSLAI.H widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
 shifts left by an immediate amount.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18656,11 +18656,11 @@ if (rd_p != 0):
 <<<
 ==== PWSLA.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwsla.hs _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWSLA.HS is available only in RV32. The shift amount is taken from `rs2`.
 
@@ -18680,12 +18680,12 @@ PWSLA.HS is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 PWSLA.HS widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
 shifts left by the amount in `rs2` (low 5 bits).
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18704,11 +18704,11 @@ if (rd_p != 0):
 <<<
 ==== WSLL (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wsll _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WSLL is available only in RV32. The shift amount is taken from `rs2`.
 
@@ -18728,12 +18728,12 @@ WSLL is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 WSLL zero-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
 and writes the 64-bit result to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18749,11 +18749,11 @@ if (rd_p != 0):
 <<<
 ==== WSLLI (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wslli _rd_p_, _rs1_, _uimm6_
 
-===== Encoding
+Encoding::
 
 WSLLI is available only in RV32. The shift amount is encoded in `uimm6`.
 
@@ -18773,12 +18773,12 @@ WSLLI is available only in RV32. The shift amount is encoded in `uimm6`.
 ]}
 ....
 
-===== Description
+Description::
 
 WSLLI zero-extends `rs1` to 64 bits, shifts left by an immediate amount, and
 writes the 64-bit result to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18794,11 +18794,11 @@ if (rd_p != 0):
 <<<
 ==== WSLA (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wsla _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WSLA is available only in RV32. The shift amount is taken from `rs2`.
 
@@ -18818,12 +18818,12 @@ WSLA is available only in RV32. The shift amount is taken from `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 WSLA sign-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
 and writes the 64-bit result to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18839,11 +18839,11 @@ if (rd_p != 0):
 <<<
 ==== WSLAI (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wslai _rd_p_, _rs1_, _uimm6_
 
-===== Encoding
+Encoding::
 
 WSLAI is available only in RV32. The shift amount is encoded in `uimm6`.
 
@@ -18863,12 +18863,12 @@ WSLAI is available only in RV32. The shift amount is encoded in `uimm6`.
 ]}
 ....
 
-===== Description
+Description::
 
 WSLAI sign-extends `rs1` to 64 bits, shifts left by an immediate amount, and
 writes the 64-bit result to the destination register pair when `rd_p != 0`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18887,11 +18887,11 @@ if (rd_p != 0):
 
 ==== WZIP8P (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wzip8p _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WZIP8P is available only in RV32. It writes its 64-bit result to the even-odd
 register pair specified by `rd_p` (no write occurs if `rd_p = 0`).
@@ -18913,14 +18913,14 @@ It is encoded in the RV32 register-pair OP-IMM-32 format with `f=111` and `w=10`
 ]}
 ....
 
-===== Description
+Description::
 
 WZIP8P interleaves the low four bytes of `rs1` and `rs2` into a 64-bit result,
 arranged as two 32-bit halves. The lower destination register receives the
 interleaving of bytes [15:0], and the upper destination register receives the
 interleaving of bytes [31:16].
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18939,11 +18939,11 @@ if (rd_p != 0):
 <<<
 ==== WZIP16P (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wzip16p _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WZIP16P is available only in RV32. It writes its 64-bit result to the even-odd
 register pair specified by `rd_p` (no write occurs if `rd_p = 0`).
@@ -18965,13 +18965,13 @@ It is encoded in the RV32 register-pair OP-IMM-32 format with `f=111` and `w=11`
 ]}
 ....
 
-===== Description
+Description::
 
 WZIP16P interleaves 16-bit halfwords from `rs1` and `rs2` into a 64-bit result.
 The lower destination register receives `{rs2[15:0], rs1[15:0]}`, and the upper
 destination register receives `{rs2[31:16], rs1[31:16]}`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -18993,11 +18993,11 @@ if (rd_p != 0):
 
 ==== PREDSUM.DBS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 predsum.dbs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUM.DBS is available only in RV32. It reads a 64-bit packed source from the
 even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
@@ -19022,13 +19022,13 @@ set to 1, and `rs1_p` selecting the source register pair.
 ]}
 ....
 
-===== Description
+Description::
 
 PREDSUM.DBS adds the eight signed 8-bit elements contained in the 64-bit source
 register pair `rs1_p` to the signed scalar value in `rs2`, and writes the low
 32 bits of the resulting sum to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19048,11 +19048,11 @@ X[rd] = to_bits(32, sum)
 <<<
 ==== PREDSUMU.DBS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 predsumu.dbs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUMU.DBS is available only in RV32. It reads a 64-bit packed source from the
 even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
@@ -19074,13 +19074,13 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
 ]}
 ....
 
-===== Description
+Description::
 
 PREDSUMU.DBS adds the eight unsigned 8-bit elements contained in the 64-bit
 source register pair `rs1_p` to the unsigned scalar value in `rs2`, and writes
 the low 32 bits of the resulting sum to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19100,11 +19100,11 @@ X[rd] = to_bits(32, sum)
 <<<
 ==== PREDSUM.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 predsum.dhs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUM.DHS is available only in RV32. It reads a 64-bit packed source from the
 even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
@@ -19126,13 +19126,13 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
 ]}
 ....
 
-===== Description
+Description::
 
 PREDSUM.DHS adds the four signed 16-bit elements contained in the 64-bit source
 register pair `rs1_p` to the signed scalar value in `rs2`, and writes the low
 32 bits of the resulting sum to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19152,11 +19152,11 @@ X[rd] = to_bits(32, sum)
 <<<
 ==== PREDSUMU.DHS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 predsumu.dhs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PREDSUMU.DHS is available only in RV32. It reads a 64-bit packed source from the
 even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
@@ -19178,13 +19178,13 @@ in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
 ]}
 ....
 
-===== Description
+Description::
 
 PREDSUMU.DHS adds the four unsigned 16-bit elements contained in the 64-bit
 source register pair `rs1_p` to the unsigned scalar value in `rs2`, and writes
 the low 32 bits of the resulting sum to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19207,11 +19207,11 @@ X[rd] = to_bits(32, sum)
 
 ==== PNSRLI.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrli.b _rd_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PNSRLI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p` and produces a packed byte result in
@@ -19235,13 +19235,13 @@ from the register pair selected by `rs1_p` and produces a packed byte result in
 
 `uimm4` provides the 4-bit shift amount.
 
-===== Description
+Description::
 
 PNSRLI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
 a logical right shift by an immediate amount, and packs the low byte of each
 shifted lane into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19259,11 +19259,11 @@ X[rd] = d
 <<<
 ==== PNSRL.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrl.bs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNSRL.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from `rs1_p` and uses `rs2[4:0]` as the shift amount.
@@ -19284,13 +19284,13 @@ from `rs1_p` and uses `rs2[4:0]` as the shift amount.
 ]}
 ....
 
-===== Description
+Description::
 
 PNSRL.BS performs a per-lane logical right shift of four 16-bit lanes taken from
 a 64-bit register-pair source, using a shift amount from `rs2`. The low byte of
 each shifted lane is packed into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19308,11 +19308,11 @@ X[rd] = d
 <<<
 ==== PNSRAI.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrai.b _rd_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PNSRAI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p` and produces a packed byte result in
@@ -19336,13 +19336,13 @@ from the register pair selected by `rs1_p` and produces a packed byte result in
 
 `uimm4` is the shift amount.
 
-===== Description
+Description::
 
 PNSRAI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
 an arithmetic right shift by an immediate amount, and packs the low byte of each
 shifted lane into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19360,11 +19360,11 @@ X[rd] = d
 <<<
 ==== PNSRA.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsra.bs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNSRA.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from `rs1_p` and uses `rs2[4:0]` as the shift amount.
@@ -19385,13 +19385,13 @@ from `rs1_p` and uses `rs2[4:0]` as the shift amount.
 ]}
 ....
 
-===== Description
+Description::
 
 PNSRA.BS performs a per-lane arithmetic right shift of four 16-bit lanes taken
 from a 64-bit register-pair source, using a shift amount from `rs2`. The low
 byte of each shifted lane is packed into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19409,11 +19409,11 @@ X[rd] = d
 <<<
 ==== PNSRARI.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrari.b _rd_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PNSRARI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from `rs1_p` and performs a rounded arithmetic right shift by an immediate amount.
@@ -19436,13 +19436,13 @@ from `rs1_p` and performs a rounded arithmetic right shift by an immediate amoun
 
 `uimm4` is the shift amount.
 
-===== Description
+Description::
 
 PNSRARI.B performs a per-lane rounded arithmetic right shift of four 16-bit lanes
 from a 64-bit register-pair source using an immediate shift amount, and packs
 the resulting bytes into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19462,11 +19462,11 @@ X[rd] = d
 <<<
 ==== PNSRAR.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrar.bs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNSRAR.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from `rs1_p` and uses `rs2[4:0]` as the shift amount.
@@ -19487,13 +19487,13 @@ from `rs1_p` and uses `rs2[4:0]` as the shift amount.
 ]}
 ....
 
-===== Description
+Description::
 
 PNSRAR.BS performs a per-lane rounded arithmetic right shift of four 16-bit lanes
 from a 64-bit register-pair source using a shift amount from `rs2`, and packs
 the resulting bytes into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19512,11 +19512,11 @@ X[rd] = d
 <<<
 ==== PNSRLI.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrli.h _rd_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PNSRLI.H is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from `rs1_p`, shifts each 32-bit word lane right by an immediate amount, and packs
@@ -19540,13 +19540,13 @@ the low 16 bits of each shifted word into `rd`.
 
 `uimm5` provides the 5-bit shift amount.
 
-===== Description
+Description::
 
 PNSRLI.H performs a logical right shift of each 32-bit word lane in a 64-bit
 register-pair source by an immediate amount, then packs the low 16 bits of each
 shifted word into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19563,11 +19563,11 @@ X[rd] = d
 <<<
 ==== PNSRL.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrl.hs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNSRL.HS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from `rs1_p`, uses `rs2[4:0]` as the shift amount, and packs 16-bit results into
@@ -19589,13 +19589,13 @@ from `rs1_p`, uses `rs2[4:0]` as the shift amount, and packs 16-bit results into
 ]}
 ....
 
-===== Description
+Description::
 
 PNSRL.HS performs a logical right shift of each 32-bit word lane in a 64-bit
 register-pair source by a shift amount from `rs2`, then packs the low 16 bits of
 each shifted word into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19612,11 +19612,11 @@ X[rd] = d
 <<<
 ==== PNSRAI.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrai.h _rd_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PNSRAI.H is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from `rs1_p`, performs an arithmetic right shift by an immediate amount on each
@@ -19640,13 +19640,13 @@ from `rs1_p`, performs an arithmetic right shift by an immediate amount on each
 
 `uimm5` provides a 5-bit shift amount.
 
-===== Description
+Description::
 
 PNSRAI.H performs an arithmetic right shift of each 32-bit word lane in a 64-bit
 register-pair source by an immediate amount, then packs the low 16 bits of each
 shifted word into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19663,11 +19663,11 @@ X[rd] = d
 <<<
 ==== PNSRA.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsra.hs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNSRA.HS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from `rs1_p`, uses `rs2[4:0]` as the shift amount, performs per-word arithmetic
@@ -19689,13 +19689,13 @@ right shifts, and packs 16-bit results into `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 PNSRA.HS performs an arithmetic right shift of each 32-bit word lane in a 64-bit
 register-pair source by a shift amount from `rs2`, then packs the low 16 bits of
 each shifted word into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19712,11 +19712,11 @@ X[rd] = d
 <<<
 ==== PNSRARI.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrari.h _rd_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PNSRARI.H is encoded using the OP-IMM-32 major opcode. It performs a per-word
 *rounded* arithmetic right shift by an immediate amount and packs 16-bit results
@@ -19738,13 +19738,13 @@ into `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 PNSRARI.H performs a per-word *rounded* arithmetic right shift of the 64-bit
 register-pair source by an immediate amount. The low 16 bits of each rounded
 shifted word are packed into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19763,11 +19763,11 @@ X[rd] = d
 <<<
 ==== PNSRAR.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnsrar.hs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNSRAR.HS is encoded using the OP-IMM-32 major opcode. It performs a per-word
 *rounded* arithmetic right shift using `rs2[4:0]` as the shift amount.
@@ -19788,13 +19788,13 @@ PNSRAR.HS is encoded using the OP-IMM-32 major opcode. It performs a per-word
 ]}
 ....
 
-===== Description
+Description::
 
 PNSRAR.HS performs a per-word *rounded* arithmetic right shift of a 64-bit
 register-pair source using a shift amount from `rs2`, and packs 16-bit results
 into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19813,11 +19813,11 @@ X[rd] = d
 <<<
 ==== NSRLI (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nsrli _rd_, _rs1_p_, _uimm6_
 
-===== Encoding
+Encoding::
 
 NSRLI is encoded using the OP-IMM-32 major opcode. It reads a 64-bit register-pair
 source from `rs1_p`, performs a logical right shift by an immediate amount, and
@@ -19841,12 +19841,12 @@ writes the low 32 bits to `rd`.
 
 For NSRLI, `uimm6` is the shift amount.
 
-===== Description
+Description::
 
 NSRLI performs a 64-bit logical right shift of the register-pair source by an
 immediate amount and returns the low 32 bits.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19859,11 +19859,11 @@ X[rd] = (s1 >> shamt)[31:0]
 <<<
 ==== NSRL (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nsrl _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 NSRL is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
 amount.
@@ -19884,12 +19884,12 @@ amount.
 ]}
 ....
 
-===== Description
+Description::
 
 NSRL performs a 64-bit logical right shift of the register-pair source by a shift
 amount from `rs2` and returns the low 32 bits.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19902,11 +19902,11 @@ X[rd] = (s1 >> shamt)[31:0]
 <<<
 ==== NSRAI (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nsrai _rd_, _rs1_p_, _uimm6_
 
-===== Encoding
+Encoding::
 
 NSRAI is encoded using the OP-IMM-32 major opcode. It performs an arithmetic
 right shift by an immediate amount on the 64-bit register-pair source and writes
@@ -19928,12 +19928,12 @@ the low 32 bits to `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 NSRAI performs a 64-bit arithmetic right shift of the register-pair source by an
 immediate amount and returns the low 32 bits.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19946,11 +19946,11 @@ X[rd] = (sext_96(s1) >> shamt)[31:0]
 <<<
 ==== NSRA (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nsra _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 NSRA is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
 amount.
@@ -19971,12 +19971,12 @@ amount.
 ]}
 ....
 
-===== Description
+Description::
 
 NSRA performs a 64-bit arithmetic right shift of the register-pair source by a
 shift amount from `rs2` and returns the low 32 bits.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -19989,11 +19989,11 @@ X[rd] = (sext_96(s1) >> shamt)[31:0]
 <<<
 ==== NSRARI (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nsrari _rd_, _rs1_p_, _uimm6_
 
-===== Encoding
+Encoding::
 
 NSRARI is encoded using the OP-IMM-32 major opcode. It performs a *rounded*
 arithmetic right shift by an immediate amount on the 64-bit register-pair source.
@@ -20014,12 +20014,12 @@ arithmetic right shift by an immediate amount on the 64-bit register-pair source
 ]}
 ....
 
-===== Description
+Description::
 
 NSRARI performs a 64-bit *rounded* arithmetic right shift of the register-pair
 source by an immediate amount and returns the rounded low 32-bit result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20034,11 +20034,11 @@ X[rd] = (shx + 1)[32:1]
 <<<
 ==== NSRAR (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nsrar _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 NSRAR is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
 amount for a *rounded* arithmetic right shift.
@@ -20059,12 +20059,12 @@ amount for a *rounded* arithmetic right shift.
 ]}
 ....
 
-===== Description
+Description::
 
 NSRAR performs a 64-bit *rounded* arithmetic right shift of the register-pair
 source by a shift amount from `rs2` and returns the rounded low 32-bit result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20082,11 +20082,11 @@ X[rd] = (shx + 1)[32:1]
 
 ==== PNCLIPI.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipi.b _rd_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PNCLIPI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p`, uses an immediate shift amount, and
@@ -20110,7 +20110,7 @@ writes packed clipped bytes to `rd`.
 
 `uimm4` provides the 4-bit shift amount.
 
-===== Description
+Description::
 
 PNCLIPI.B performs a per-lane arithmetic right shift of four 16-bit lanes from a
 64-bit register-pair source using an immediate shift amount. Each shifted value
@@ -20118,7 +20118,7 @@ is then clipped to the signed 8-bit range [-128, 127] and packed into `rd`.
 
 When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20141,7 +20141,7 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * The source is taken from the register pair `{X[2*rs1_p+1], X[2*rs1_p]}`; if
   `rs1_p=0`, the source is treated as zero.
@@ -20150,11 +20150,11 @@ X[rd] = d
 <<<
 ==== PNCLIP.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclip.bs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIP.BS is encoded in the OP-IMM-32 major opcode with a scalar shift amount
 and packed byte narrowing. Available only in RV32.
@@ -20175,7 +20175,7 @@ and packed byte narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIP.BS performs a packed narrowing signed clip from 16-bit halfword elements
 to 8-bit byte elements with a scalar shift amount. The 64-bit source is read
@@ -20184,7 +20184,7 @@ arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
 signed 8-bit range [-128, 127]. Four byte results are packed into `rd`. If any
 element saturates, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20205,18 +20205,18 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPRI.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipri.b _rd_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PNCLIPRI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p`, uses an immediate shift amount, and
@@ -20241,7 +20241,7 @@ PNCLIPI.B.
 
 `uimm4` provides the 4-bit shift amount.
 
-===== Description
+Description::
 
 PNCLIPRI.B performs a per-lane *rounded* arithmetic right shift of four 16-bit
 lanes from a 64-bit register-pair source using an immediate shift amount. Each
@@ -20250,7 +20250,7 @@ packed into `rd`.
 
 When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20277,7 +20277,7 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * The source is taken from the register pair `{X[2*rs1_p+1], X[2*rs1_p]}`; if
   `rs1_p=0`, the source is treated as zero.
@@ -20286,11 +20286,11 @@ X[rd] = d
 <<<
 ==== PNCLIPR.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipr.bs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPR.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p`, uses `rs2[4:0]` as the shift amount,
@@ -20313,7 +20313,7 @@ PNCLIP.BS.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPR.BS performs a per-lane *rounded* arithmetic right shift of four 16-bit
 lanes from a 64-bit register-pair source using the shift amount in `rs2[4:0]`.
@@ -20322,7 +20322,7 @@ and packed into `rd`.
 
 When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20349,7 +20349,7 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * The source is taken from the register pair `{X[2*rs1_p+1], X[2*rs1_p]}`; if
   `rs1_p=0`, the source is treated as zero.
@@ -20358,11 +20358,11 @@ X[rd] = d
 <<<
 ==== PNCLIPIU.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipiu.b _rd_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PNCLIPIU.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p`, uses an immediate shift amount, and
@@ -20386,7 +20386,7 @@ writes packed *unsigned-clipped* bytes to `rd`.
 
 `uimm4` provides the 4-bit shift amount.
 
-===== Description
+Description::
 
 PNCLIPIU.B performs a per-lane logical right shift of four 16-bit lanes from a
 64-bit register-pair source using an immediate shift amount. Each shifted value
@@ -20394,7 +20394,7 @@ is then clipped to the unsigned 8-bit range [0, 255] and packed into `rd`.
 
 When clipping occurs for any lane, the `vxsat` sticky flag is set to 1.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20414,7 +20414,7 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * The source is taken from the register pair `{X[2*rs1_p+1], X[2*rs1_p]}`; if
   `rs1_p=0`, the source is treated as zero.
@@ -20423,11 +20423,11 @@ X[rd] = d
 <<<
 ==== PNCLIPU.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipu.bs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPU.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p`, uses `rs2[4:0]` as the shift amount,
@@ -20449,14 +20449,14 @@ and writes packed *unsigned-clipped* bytes to `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPU.BS performs a per-lane logical right shift of four 16-bit lanes from a
 64-bit register-pair source using a shift amount from `rs2`. Each shifted value
 is clipped to the unsigned 8-bit range [0, 255] and packed into `rd`. The `vxsat`
 sticky flag is set if any lane saturates.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20476,18 +20476,18 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPRIU.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipriu.b _rd_, _rs1_p_, _uimm4_
 
-===== Encoding
+Encoding::
 
 PNCLIPRIU.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p`, uses an immediate shift amount, and
@@ -20511,14 +20511,14 @@ writes packed *rounded unsigned-clipped* bytes to `rd`.
 
 `uimm4` provides the 4-bit shift amount.
 
-===== Description
+Description::
 
 PNCLIPRIU.B performs a per-lane *rounded* logical right shift of four 16-bit lanes
 from a 64-bit register-pair source using an immediate shift amount. Each rounded
 shifted value is clipped to the unsigned 8-bit range [0, 255] and packed into
 `rd`. The `vxsat` sticky flag is set if any lane saturates.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20541,18 +20541,18 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPRU.BS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipru.bs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPRU.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
 from the register pair selected by `rs1_p`, uses `rs2[4:0]` as the shift amount,
@@ -20574,14 +20574,14 @@ and writes packed *rounded unsigned-clipped* bytes to `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPRU.BS performs a per-lane *rounded* logical right shift of four 16-bit lanes
 from a 64-bit register-pair source using a shift amount from `rs2`. Each rounded
 shifted value is clipped to [0, 255] and packed into `rd`. The `vxsat` sticky
 flag is set if any lane saturates.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20603,18 +20603,18 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPI.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipi.h _rd_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PNCLIPI.H is encoded in the OP-IMM-32 major opcode with an immediate shift
 amount and packed halfword narrowing. Available only in RV32.
@@ -20635,7 +20635,7 @@ amount and packed halfword narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPI.H performs a packed narrowing signed clip from 32-bit word elements
 to 16-bit halfword elements with an immediate shift amount. The 64-bit source
@@ -20644,7 +20644,7 @@ arithmetically right-shifted by the 5-bit immediate, then clamped to the signed
 16-bit range [-32768, 32767]. Two halfword results are packed into `rd`. If any
 element saturates, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20665,18 +20665,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIP.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclip.hs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIP.HS is encoded in the OP-IMM-32 major opcode with a scalar shift amount
 and packed halfword narrowing. Available only in RV32.
@@ -20697,7 +20697,7 @@ and packed halfword narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIP.HS performs a packed narrowing signed clip from 32-bit word elements
 to 16-bit halfword elements with a scalar shift amount. The 64-bit source is
@@ -20706,7 +20706,7 @@ arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
 signed 16-bit range [-32768, 32767]. Two halfword results are packed into `rd`.
 If any element saturates, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20727,18 +20727,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPRI.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipri.h _rd_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PNCLIPRI.H is encoded in the OP-IMM-32 major opcode with an immediate shift
 amount, rounding, and packed halfword narrowing. Available only in RV32.
@@ -20759,7 +20759,7 @@ amount, rounding, and packed halfword narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPRI.H performs a packed narrowing signed clip with rounding from 32-bit
 word elements to 16-bit halfword elements using an immediate shift amount. The
@@ -20768,7 +20768,7 @@ element is arithmetically right-shifted with round-to-nearest-up, then clamped
 to the signed 16-bit range [-32768, 32767]. Two halfword results are packed
 into `rd`. If any element saturates, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20791,18 +20791,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPR.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipr.hs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPR.HS is encoded in the OP-IMM-32 major opcode with a scalar shift
 amount, rounding, and packed halfword narrowing. Available only in RV32.
@@ -20823,7 +20823,7 @@ amount, rounding, and packed halfword narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPR.HS performs a packed narrowing signed clip with rounding from 32-bit
 word elements to 16-bit halfword elements using a scalar shift amount. The
@@ -20833,7 +20833,7 @@ in `rs2[4:0]`, then clamped to the signed 16-bit range [-32768, 32767]. Two
 halfword results are packed into `rd`. If any element saturates, `vxsat` is
 set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20856,18 +20856,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPIU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipiu.h _rd_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PNCLIPIU.H is encoded using the OP-IMM-32 major opcode. It performs a per-word
 logical right shift by an immediate amount and clips each result to the unsigned
@@ -20889,14 +20889,14 @@ logical right shift by an immediate amount and clips each result to the unsigned
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPIU.H shifts each 32-bit word lane of the 64-bit register-pair source right
 logically by an immediate amount, then clips each shifted value to unsigned
 16-bit and packs the two halfwords into `rd`. The `vxsat` sticky flag is set if
 any lane saturates.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20916,18 +20916,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPU.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipu.hs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPU.HS is encoded using the OP-IMM-32 major opcode. It uses `rs2[4:0]` as the
 shift amount and clips to unsigned 16-bit.
@@ -20948,13 +20948,13 @@ shift amount and clips to unsigned 16-bit.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPU.HS performs a per-word logical right shift of a 64-bit register-pair
 source using `rs2` as the shift amount, clips each lane to unsigned 16-bit, and
 packs the results into `rd`. The `vxsat` sticky flag is set on saturation.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -20974,18 +20974,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPRIU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipriu.h _rd_, _rs1_p_, _uimm5_
 
-===== Encoding
+Encoding::
 
 PNCLIPRIU.H is encoded in the OP-IMM-32 major opcode with an immediate shift
 amount, rounding, and unsigned packed halfword narrowing. Available only in
@@ -21007,7 +21007,7 @@ RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPRIU.H performs a packed narrowing unsigned clip with rounding from 32-bit
 word elements to 16-bit halfword elements using an immediate shift amount. The
@@ -21016,7 +21016,7 @@ element is logically right-shifted with round-to-nearest-up, then clamped to
 the unsigned 16-bit range [0, 65535]. Two halfword results are packed into
 `rd`. If any element saturates, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21037,18 +21037,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPRU.HS (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipru.hs _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPRU.HS is encoded in the OP-IMM-32 major opcode with a scalar shift
 amount, rounding, and unsigned packed halfword narrowing. Available only in
@@ -21070,7 +21070,7 @@ RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPRU.HS performs a packed narrowing unsigned clip with rounding from 32-bit
 word elements to 16-bit halfword elements using a scalar shift amount. The
@@ -21080,7 +21080,7 @@ element is logically right-shifted with round-to-nearest-up by the amount in
 results are packed into `rd`. If any element saturates, `vxsat` is set.
 Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21101,18 +21101,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== NCLIPI (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nclipi _rd_, _rs1_p_, _uimm6_
 
-===== Encoding
+Encoding::
 
 NCLIPI is encoded in the OP-IMM-32 major opcode with an immediate shift amount
 and XLEN-wide narrowing. Available only in RV32.
@@ -21133,7 +21133,7 @@ and XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 NCLIPI performs an XLEN-wide narrowing signed clip with an immediate shift
 amount. The 64-bit source is read from the register pair designated by
@@ -21141,7 +21141,7 @@ amount. The 64-bit source is read from the register pair designated by
 clamped to the signed 32-bit range [-2^31, 2^31 - 1]. The 32-bit result is
 written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21159,18 +21159,18 @@ else:
     X[rd] = shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== NCLIP (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nclip _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 NCLIP is encoded in the OP-IMM-32 major opcode with a scalar shift amount and
 XLEN-wide narrowing. Available only in RV32.
@@ -21191,7 +21191,7 @@ XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 NCLIP performs an XLEN-wide narrowing signed clip with a scalar shift amount.
 The 64-bit source is read from the register pair designated by `rs1_p`. The
@@ -21199,7 +21199,7 @@ value is arithmetically right-shifted by the amount in `rs2[5:0]`, then clamped
 to the signed 32-bit range [-2^31, 2^31 - 1]. The 32-bit result is written to
 `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21217,18 +21217,18 @@ else:
     X[rd] = shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== NCLIPRI (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nclipri _rd_, _rs1_p_, _uimm6_
 
-===== Encoding
+Encoding::
 
 NCLIPRI is encoded in the OP-IMM-32 major opcode with an immediate shift
 amount, rounding, and XLEN-wide narrowing. Available only in RV32.
@@ -21249,7 +21249,7 @@ amount, rounding, and XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 NCLIPRI performs an XLEN-wide narrowing signed clip with rounding using an
 immediate shift amount. The 64-bit source is read from the register pair
@@ -21258,7 +21258,7 @@ round-to-nearest-up by the 6-bit immediate, then clamped to the signed 32-bit
 range [-2^31, 2^31 - 1]. The 32-bit result is written to `rd`. If saturation
 occurs, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21278,18 +21278,18 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== NCLIPR (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nclipr _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 NCLIPR is encoded in the OP-IMM-32 major opcode with a scalar shift amount,
 rounding, and XLEN-wide narrowing. Available only in RV32.
@@ -21310,7 +21310,7 @@ rounding, and XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 NCLIPR performs an XLEN-wide narrowing signed clip with rounding using a scalar
 shift amount. The 64-bit source is read from the register pair designated by
@@ -21319,7 +21319,7 @@ the amount in `rs2[5:0]`, then clamped to the signed 32-bit range
 [-2^31, 2^31 - 1]. The 32-bit result is written to `rd`. If saturation occurs,
 `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21339,18 +21339,18 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== NCLIPIU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nclipiu _rd_, _rs1_p_, _uimm6_
 
-===== Encoding
+Encoding::
 
 NCLIPIU is encoded in the OP-IMM-32 major opcode with an immediate shift
 amount and unsigned XLEN-wide narrowing. Available only in RV32.
@@ -21371,7 +21371,7 @@ amount and unsigned XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 NCLIPIU performs an XLEN-wide narrowing unsigned clip with an immediate shift
 amount. The 64-bit source is read from the register pair designated by
@@ -21379,7 +21379,7 @@ amount. The 64-bit source is read from the register pair designated by
 clamped to the unsigned 32-bit range [0, 2^32 - 1]. The 32-bit result is
 written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21395,18 +21395,18 @@ else:
     X[rd] = shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== NCLIPU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nclipu _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 NCLIPU is encoded using the OP-IMM-32 major opcode. It shifts a 64-bit register-pair
 source right logically by a shift amount from `rs2` and clips the result to the
@@ -21428,12 +21428,12 @@ unsigned 32-bit range, setting `vxsat` on saturation.
 ]}
 ....
 
-===== Description
+Description::
 
 NCLIPU performs a 64-bit logical right shift of the register-pair source and clips
 the result to 32-bit unsigned. The `vxsat` sticky flag is set if clipping occurs.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21449,18 +21449,18 @@ else:
     X[rd] = shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== NCLIPRIU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nclipriu _rd_, _rs1_p_, _uimm6_
 
-===== Encoding
+Encoding::
 
 NCLIPRIU is encoded in the OP-IMM-32 major opcode with an immediate shift
 amount, rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
@@ -21481,7 +21481,7 @@ amount, rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 NCLIPRIU performs an XLEN-wide narrowing unsigned clip with rounding using an
 immediate shift amount. The 64-bit source is read from the register pair
@@ -21490,7 +21490,7 @@ round-to-nearest-up by the 6-bit immediate, then clamped to the unsigned
 32-bit range [0, 2^32 - 1]. The 32-bit result is written to `rd`. If
 saturation occurs, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21508,18 +21508,18 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== NCLIPRU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 nclipru _rd_, _rs1_p_, _rs2_
 
-===== Encoding
+Encoding::
 
 NCLIPRU is encoded in the OP-IMM-32 major opcode with a scalar shift amount,
 rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
@@ -21540,7 +21540,7 @@ rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
 ]}
 ....
 
-===== Description
+Description::
 
 NCLIPRU performs an XLEN-wide narrowing unsigned clip with rounding using a
 scalar shift amount. The 64-bit source is read from the register pair
@@ -21549,7 +21549,7 @@ round-to-nearest-up by the amount in `rs2[5:0]`, then clamped to the unsigned
 32-bit range [0, 2^32 - 1]. The 32-bit result is written to `rd`. If
 saturation occurs, `vxsat` is set. Available only in RV32.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21567,18 +21567,18 @@ else:
     X[rd] = round_shx[31:0]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPP.B (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipp.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPP.B is encoded in the OP-32 major opcode with packed byte narrowing.
 Available only in RV64.
@@ -21598,7 +21598,7 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPP.B performs packed narrowing signed clip from 16-bit halfword elements
 to 8-bit byte elements. The 128-bit source is read from `rs2` and `rs1`. Each
@@ -21606,7 +21606,7 @@ to 8-bit byte elements. The 128-bit source is read from `rs2` and `rs1`. Each
 results are packed into `rd`. If any element saturates, `vxsat` is set.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21625,18 +21625,18 @@ for i = 0 .. 7:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPP.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipp.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPP.H is encoded in the OP-32 major opcode with packed halfword narrowing.
 Available only in RV64.
@@ -21656,7 +21656,7 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPP.H performs packed narrowing signed clip from 32-bit word elements
 to 16-bit halfword elements. The 128-bit source is read from `rs2` and `rs1`.
@@ -21664,7 +21664,7 @@ Each 32-bit element is clamped to the signed 16-bit range [-32768, 32767]. Four
 halfword results are packed into `rd`. If any element saturates, `vxsat` is set.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21683,18 +21683,18 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPP.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipp.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPP.W is encoded in the OP-32 major opcode with packed word narrowing.
 Available only in RV64.
@@ -21714,7 +21714,7 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPP.W performs packed narrowing signed clip from 64-bit doubleword elements
 to 32-bit word elements. The 128-bit source is read from `rs2` and `rs1`.
@@ -21722,7 +21722,7 @@ Each 64-bit element is clamped to the signed 32-bit range [-2^31^, 2^31^-1].
 Two word results are packed into `rd`. If any element saturates, `vxsat` is set.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21741,18 +21741,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPUP.B (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipup.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPUP.B is encoded in the OP-32 major opcode with packed byte narrowing.
 Available only in RV64.
@@ -21772,7 +21772,7 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPUP.B performs packed narrowing unsigned clip from 16-bit halfword elements
 to 8-bit byte elements. The 128-bit source is read from `rs2` and `rs1`. Each
@@ -21780,7 +21780,7 @@ to 8-bit byte elements. The 128-bit source is read from `rs2` and `rs1`. Each
 results are packed into `rd`. If any element saturates, `vxsat` is set.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21797,18 +21797,18 @@ for i = 0 .. 7:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPUP.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipup.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPUP.H is encoded in the OP-32 major opcode with packed halfword narrowing.
 Available only in RV64.
@@ -21828,7 +21828,7 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPUP.H performs packed narrowing unsigned clip from 32-bit word elements
 to 16-bit halfword elements. The 128-bit source is read from `rs2` and `rs1`.
@@ -21836,7 +21836,7 @@ Each 32-bit element is clamped to the unsigned 16-bit range [0, 65535]. Four
 halfword results are packed into `rd`. If any element saturates, `vxsat` is set.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21853,18 +21853,18 @@ for i = 0 .. 3:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PNCLIPUP.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pnclipup.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PNCLIPUP.W is encoded in the OP-32 major opcode with packed word narrowing.
 Available only in RV64.
@@ -21884,7 +21884,7 @@ Available only in RV64.
 ]}
 ....
 
-===== Description
+Description::
 
 PNCLIPUP.W performs packed narrowing unsigned clip from 64-bit doubleword elements
 to 32-bit word elements. The 128-bit source is read from `rs2` and `rs1`.
@@ -21892,7 +21892,7 @@ Each 64-bit element is clamped to the unsigned 32-bit range [0, 2^32^-1].
 Two word results are packed into `rd`. If any element saturates, `vxsat` is set.
 Available only in RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21909,7 +21909,7 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
@@ -21918,11 +21918,11 @@ X[rd] = d
 
 ==== PMULH.H
 
-===== Mnemonic
+Mnemonic::
 
 pmulh.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULH.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and returns the high half of each signed 16×16 multiplication.
@@ -21941,13 +21941,13 @@ elements and returns the high half of each signed 16×16 multiplication.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULH.H performs lane-wise signed multiplication of packed 16-bit elements from
 `rs1` and `rs2`. For each lane, the upper 16 bits of the 32-bit product are
 written to the corresponding 16-bit element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -21963,7 +21963,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The result is equivalent to arithmetic right shift by 16 of the full 32-bit
@@ -21972,11 +21972,11 @@ X[rd] = d
 <<<
 ==== PMULHR.H
 
-===== Mnemonic
+Mnemonic::
 
 pmulhr.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHR.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and returns the rounded high half of each signed 16×16 multiplication.
@@ -21995,14 +21995,14 @@ elements and returns the rounded high half of each signed 16×16 multiplication.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULHR.H performs lane-wise signed multiplication of packed 16-bit elements from
 `rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product and then
 writes the upper 16 bits of the adjusted value to the corresponding 16-bit
 element of `rd`, implementing rounding when extracting the high half.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22019,7 +22019,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane result corresponds to rounding the 32-bit product before
@@ -22028,11 +22028,11 @@ X[rd] = d
 <<<
 ==== PMULHSU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmulhsu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHSU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and returns the high half of each mixed signed×unsigned 16×16
@@ -22052,14 +22052,14 @@ multiplication.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULHSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
 and `rs2`, treating each element of `rs1` as signed and each element of `rs2` as
 unsigned. For each lane, the upper 16 bits of the 32-bit product are written to
 the corresponding 16-bit element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22075,7 +22075,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The result is equivalent to extracting bits [31:16] of the full 32-bit
@@ -22084,11 +22084,11 @@ X[rd] = d
 <<<
 ==== PMULHRSU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmulhrsu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHRSU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and returns the rounded high half of each mixed signed×unsigned 16×16
@@ -22108,7 +22108,7 @@ multiplication.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULHRSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
 and `rs2`, treating each element of `rs1` as signed and each element of `rs2` as
@@ -22116,7 +22116,7 @@ unsigned. For each lane, it adds 2^15 to the 32-bit product and then writes the
 upper 16 bits of the adjusted value to the corresponding 16-bit element of
 `rd`, implementing rounding when extracting the high half.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22133,7 +22133,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane result corresponds to rounding the mixed signed×unsigned product
@@ -22142,11 +22142,11 @@ X[rd] = d
 <<<
 ==== PMULHU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmulhu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHU.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -22164,13 +22164,13 @@ PMULHU.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULHU.H multiplies corresponding unsigned packed 16-bit halfword elements of
 `rs1` and `rs2`, producing 32-bit intermediate products, and writes the upper
 16 bits of each product to the corresponding halfword element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22189,11 +22189,11 @@ X[rd] = d
 <<<
 ==== PMULHRU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmulhru.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHRU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and returns the rounded high half of each unsigned 16×16 multiplication.
@@ -22212,14 +22212,14 @@ elements and returns the rounded high half of each unsigned 16×16 multiplicatio
 ]}
 ....
 
-===== Description
+Description::
 
 PMULHRU.H performs lane-wise unsigned multiplication of packed 16-bit elements
 from `rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product and then
 writes the upper 16 bits of the adjusted value to the corresponding 16-bit
 element of `rd`, implementing rounding when extracting the high half.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22236,7 +22236,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane result corresponds to rounding the unsigned product before
@@ -22245,11 +22245,11 @@ X[rd] = d
 <<<
 ==== PMULH.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulh.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULH.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -22267,14 +22267,14 @@ PMULH.W is encoded in the OP-32 major opcode with packed word elements (RV64 onl
 ]}
 ....
 
-===== Description
+Description::
 
 PMULH.W multiplies corresponding signed packed 32-bit word elements of `rs1`
 and `rs2`, producing 64-bit intermediate products, and writes the upper 32 bits
 of each product to the corresponding word element of `rd`. This instruction is
 available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22294,11 +22294,11 @@ X[rd] = d
 <<<
 ==== PMULHR.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulhr.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHR.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -22316,14 +22316,14 @@ PMULHR.W is encoded in the OP-32 major opcode with packed word elements (RV64 on
 ]}
 ....
 
-===== Description
+Description::
 
 PMULHR.W multiplies corresponding signed packed 32-bit word elements of `rs1`
 and `rs2`, producing 64-bit intermediate products, adds a rounding constant
 of 2^31, and writes the upper 32 bits of each rounded product to the
 corresponding word element of `rd`. This instruction is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22343,11 +22343,11 @@ X[rd] = d
 <<<
 ==== PMULHSU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulhsu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHSU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
 
@@ -22365,13 +22365,13 @@ PMULHSU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMULHSU.W instruction multiplies corresponding 32-bit elements of `rs1`
 (signed) and `rs2` (unsigned), and writes the upper 32 bits of each product
 to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22390,11 +22390,11 @@ X[rd] = d
 <<<
 ==== PMULHRSU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulhrsu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHRSU.W is encoded in the OP-32 major opcode using packed 32-bit elements
 with rounding.
@@ -22413,13 +22413,13 @@ with rounding.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMULHRSU.W instruction performs signed×unsigned packed multiplication on
 32-bit elements, applies rounding, and writes the upper 32 bits of each result
 to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22434,18 +22434,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * Rounding is performed by adding 2^31 before extracting bits [63:32].
 
 <<<
 ==== PMULHU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulhu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
 
@@ -22463,12 +22463,12 @@ PMULHU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMULHU.W instruction multiplies corresponding unsigned 32-bit elements of
 `rs1` and `rs2`, writing the upper 32 bits of each product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22487,11 +22487,11 @@ X[rd] = d
 <<<
 ==== PMULHRU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulhru.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHRU.W is encoded in the OP-32 major opcode using packed 32-bit elements
 with rounding.
@@ -22510,12 +22510,12 @@ with rounding.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMULHRU.W instruction multiplies corresponding unsigned 32-bit elements,
 applies rounding, and writes the upper 32 bits of each product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22530,18 +22530,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * Rounding is performed by adding 2^31.
 
 <<<
 ==== MULHR (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulhr _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULHR is encoded in the OP-32 major opcode as an XLEN-wide operation.
 
@@ -22559,13 +22559,13 @@ MULHR is encoded in the OP-32 major opcode as an XLEN-wide operation.
 ]}
 ....
 
-===== Description
+Description::
 
 MULHR multiplies the full signed XLEN-bit values of `rs1` and `rs2`, producing
 a 2*XLEN-bit intermediate product, adds a rounding constant of 2^(XLEN-1),
 and writes the upper XLEN bits of the rounded product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22580,11 +22580,11 @@ X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^63)[127:64]
 <<<
 ==== MULHRSU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulhrsu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULHRSU is encoded in the OP-32 major opcode using the scalar
 multiply-high rounded sub-encoding.
@@ -22603,13 +22603,13 @@ multiply-high rounded sub-encoding.
 ]}
 ....
 
-===== Description
+Description::
 
 The MULHRSU instruction multiplies `rs1` as a signed value by `rs2` as an
 unsigned value, adds 2^31 for rounding, and writes the upper 32 bits of the
 result to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22619,18 +22619,18 @@ prod = a64 * b64
 X[rd] = (prod + 2^31)[63:32]
 ----
 
-===== Notes
+Notes::
 
 * Rounding is performed by adding 2^31 before extracting bits [63:32].
 
 <<<
 ==== MULHRU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulhru _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULHRU is encoded in the OP-32 major opcode using the scalar
 multiply-high rounded sub-encoding.
@@ -22649,11 +22649,11 @@ multiply-high rounded sub-encoding.
 ]}
 ....
 
-===== Description
+Description::
 
 The MULHRU instruction multiplie
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22670,11 +22670,11 @@ X[rd] = (prod + 2^31)[63:32]
 
 ==== PMULQ.H
 
-===== Mnemonic
+Mnemonic::
 
 pmulq.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULQ.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -22692,14 +22692,14 @@ PMULQ.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULQ.H performs a Q-format multiply on corresponding signed packed 16-bit
 halfword elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
 upper 16 bits. When both inputs are the most negative value (0x8000), the
 result saturates to 0x7FFF and the `vxsat` overflow flag is set.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22718,18 +22718,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PMULQR.H
 
-===== Mnemonic
+Mnemonic::
 
 pmulqr.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULQR.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and produces a signed Q15-style rounded product with saturation.
@@ -22748,7 +22748,7 @@ elements and produces a signed Q15-style rounded product with saturation.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULQR.H performs lane-wise signed multiplication of packed 16-bit elements and
 returns a Q15-style rounded result per lane. For each lane, it adds 2^14 to the
@@ -22756,7 +22756,7 @@ returns a Q15-style rounded result per lane. For each lane, it adds 2^14 to the
 right shift by 15). If both inputs are `0x8000`, the result saturates to
 `0x7FFF` and the `vxsat` sticky flag is set.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22778,7 +22778,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set if any lane saturates; it is not cleared by this instruction.
 * The saturation case corresponds to the only overflow scenario for signed Q15
@@ -22788,11 +22788,11 @@ X[rd] = d
 <<<
 ==== PMULQ.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulq.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULQ.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -22810,7 +22810,7 @@ PMULQ.W is encoded in the OP-32 major opcode with packed word elements (RV64 onl
 ]}
 ....
 
-===== Description
+Description::
 
 PMULQ.W performs a Q-format multiply on corresponding signed packed 32-bit
 word elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
@@ -22818,7 +22818,7 @@ upper 32 bits. When both inputs are the most negative value (0x80000000), the
 result saturates to 0x7FFFFFFF and the `vxsat` overflow flag is set. This
 instruction is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22838,18 +22838,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== PMULQR.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulqr.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULQR.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -22867,7 +22867,7 @@ PMULQR.W is encoded in the OP-32 major opcode with packed word elements (RV64 on
 ]}
 ....
 
-===== Description
+Description::
 
 PMULQR.W performs a rounding Q-format multiply on corresponding signed packed
 32-bit word elements of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a
@@ -22876,7 +22876,7 @@ both inputs are the most negative value (0x80000000), the result saturates to
 0x7FFFFFFF and the `vxsat` overflow flag is set. This instruction is available
 only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22896,18 +22896,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== MULQ (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulq _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULQ is encoded in the OP-32 major opcode as an XLEN-wide operation.
 
@@ -22925,14 +22925,14 @@ MULQ is encoded in the OP-32 major opcode as an XLEN-wide operation.
 ]}
 ....
 
-===== Description
+Description::
 
 MULQ performs a Q-format multiply on the full signed XLEN-bit values of `rs1`
 and `rs2`. It computes `(a * b) << 1` and keeps the upper XLEN bits. When both
 inputs are the most negative value, the result saturates to the most positive
 value and the `vxsat` overflow flag is set.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -22955,18 +22955,18 @@ else:
     X[rd] = (signed(a) * signed(b))[126:63]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
 ==== MULQR (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulqr _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULQR is encoded in the OP-32 major opcode as an XLEN-wide operation.
 
@@ -22984,7 +22984,7 @@ MULQR is encoded in the OP-32 major opcode as an XLEN-wide operation.
 ]}
 ....
 
-===== Description
+Description::
 
 MULQR performs a rounding Q-format multiply on the full signed XLEN-bit values
 of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a rounding constant of
@@ -22992,7 +22992,7 @@ of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a rounding constant of
 are the most negative value, the result saturates to the most positive value
 and the `vxsat` overflow flag is set.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23015,7 +23015,7 @@ else:
     X[rd] = (signed(a) * signed(b) + 2^62)[126:63]
 ----
 
-===== Notes
+Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
 
@@ -23024,11 +23024,11 @@ else:
 
 ==== PMHACC.H
 
-===== Mnemonic
+Mnemonic::
 
 pmhacc.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACC.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and accumulates the high half of each signed 16×16 multiplication into
@@ -23048,14 +23048,14 @@ elements and accumulates the high half of each signed 16×16 multiplication into
 ]}
 ....
 
-===== Description
+Description::
 
 PMHACC.H performs lane-wise signed multiplication of packed 16-bit elements from
 `rs1` and `rs2`. For each lane, it extracts the upper 16 bits of the 32-bit
 product and adds that value to the corresponding 16-bit element of `rd`. The
 accumulated packed result is written back to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23074,7 +23074,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane add wraps modulo 2^16.
@@ -23082,11 +23082,11 @@ X[rd] = d
 <<<
 ==== PMHRACC.H
 
-===== Mnemonic
+Mnemonic::
 
 pmhracc.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHRACC.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and accumulates the rounded high half of each signed 16×16
@@ -23106,7 +23106,7 @@ multiplication into `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 PMHRACC.H performs lane-wise signed multiplication of packed 16-bit elements from
 `rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product, extracts the
@@ -23114,7 +23114,7 @@ upper 16 bits of the adjusted value, and accumulates that into the corresponding
 16-bit element of `rd`. The packed accumulated result is written back to `rd`,
 implementing rounding when extracting the high half.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23133,7 +23133,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane add wraps modulo 2^16.
@@ -23141,11 +23141,11 @@ X[rd] = d
 <<<
 ==== PMHACCSU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmhaccsu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACCSU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and accumulates the high half of each mixed signed×unsigned 16×16
@@ -23165,7 +23165,7 @@ multiplication into `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 PMHACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
 and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
@@ -23173,7 +23173,7 @@ each lane, it extracts the upper 16 bits of the 32-bit product and accumulates
 that value into the corresponding 16-bit element of `rd`. The packed accumulated
 result is written back to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23192,7 +23192,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane add wraps modulo 2^16.
@@ -23200,11 +23200,11 @@ X[rd] = d
 <<<
 ==== PMHRACCSU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmhraccsu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHRACCSU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and accumulates the rounded high half of each mixed signed×unsigned
@@ -23224,7 +23224,7 @@ elements and accumulates the rounded high half of each mixed signed×unsigned
 ]}
 ....
 
-===== Description
+Description::
 
 PMHRACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
 and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
@@ -23233,7 +23233,7 @@ adjusted value, and accumulates that into the corresponding 16-bit element of
 `rd`. The packed accumulated result is written back to `rd`, implementing
 rounding when extracting the high half.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23252,7 +23252,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane add wraps modulo 2^16.
@@ -23260,11 +23260,11 @@ X[rd] = d
 <<<
 ==== PMHACCU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmhaccu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACCU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and accumulates the high half of each unsigned 16×16 multiplication
@@ -23284,14 +23284,14 @@ into `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 PMHACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
 from `rs1` and `rs2`. For each lane, it extracts the upper 16 bits of the 32-bit
 product and accumulates that value into the corresponding 16-bit element of
 `rd`. The packed accumulated result is written back to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23310,7 +23310,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane add wraps modulo 2^16.
@@ -23318,11 +23318,11 @@ X[rd] = d
 <<<
 ==== PMHRACCU.H
 
-===== Mnemonic
+Mnemonic::
 
 pmhraccu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHRACCU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
 elements and accumulates the rounded high half of each unsigned 16×16
@@ -23342,7 +23342,7 @@ multiplication into `rd`.
 ]}
 ....
 
-===== Description
+Description::
 
 PMHRACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
 from `rs1` and `rs2`. For each lane, it adds 2^15 to the 32-bit product, extracts
@@ -23350,7 +23350,7 @@ the upper 16 bits of the adjusted value, and accumulates that into the
 corresponding 16-bit element of `rd`. The packed accumulated result is written
 back to `rd`, implementing rounding when extracting the high half.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23369,7 +23369,7 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction does not set `vxsat`.
 * The per-lane add wraps modulo 2^16.
@@ -23377,11 +23377,11 @@ X[rd] = d
 <<<
 ==== PMHACC.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhacc.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACC.W is encoded in the OP-32 major opcode as a packed multiply-high
 accumulate instruction.
@@ -23400,12 +23400,12 @@ accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACC.W instruction multiplies signed packed 32-bit elements and
 accumulates the upper 32 bits of each product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23422,18 +23422,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHRACC.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhracc.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHRACC.W is encoded in the OP-32 major opcode as a packed multiply-high
 rounded accumulate instruction.
@@ -23452,12 +23452,12 @@ rounded accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHRACC.W instruction performs signed packed multiplication with rounding
 and accumulates the upper 32 bits of each product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23478,11 +23478,11 @@ X[rd] = d
 <<<
 ==== PMHACCSU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhaccsu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACCSU.W is encoded in the OP-32 major opcode as a packed signed×unsigned
 multiply-high accumulate instruction.
@@ -23501,12 +23501,12 @@ multiply-high accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACCSU.W instruction multiplies signed elements of `rs1` with unsigned
 elements of `rs2` and accumulates the upper 32 bits into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23527,11 +23527,11 @@ X[rd] = d
 <<<
 ==== PMHRACCSU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhraccsu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHRACCSU.W is encoded in the OP-32 major opcode as a packed signed×unsigned
 multiply-high rounded accumulate instruction.
@@ -23550,12 +23550,12 @@ multiply-high rounded accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHRACCSU.W instruction performs signed×unsigned packed multiplication with
 rounding and accumulates the upper 32 bits into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23576,11 +23576,11 @@ X[rd] = d
 <<<
 ==== PMHACCU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhaccu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACCU.W is encoded in the OP-32 major opcode as a packed unsigned×unsigned
 multiply-high accumulate instruction.
@@ -23599,12 +23599,12 @@ multiply-high accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACCU.W instruction multiplies unsigned packed 32-bit elements and
 accumulates the upper 32 bits of each product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23625,11 +23625,11 @@ X[rd] = d
 <<<
 ==== PMHRACCU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhraccu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHRACCU.W is encoded in the OP-32 major opcode as a packed unsigned×unsigned
 multiply-high rounded accumulate instruction.
@@ -23648,12 +23648,12 @@ multiply-high rounded accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHRACCU.W instruction multiplies unsigned packed 32-bit elements with
 rounding and accumulates the upper 32 bits of each product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23674,11 +23674,11 @@ X[rd] = d
 <<<
 ==== MHACC (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhacc _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHACC is encoded in the OP-32 major opcode as a scalar
 multiply-high accumulate instruction.
@@ -23697,12 +23697,12 @@ multiply-high accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The MHACC instruction multiplies `rs1` and `rs2` as signed values, extracts
 the upper 32 bits of the product, and accumulates the result into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23712,18 +23712,18 @@ hi  = (a64 * b64)[63:32]
 X[rd] = X[rd] + hi
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MHRACC (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhracc _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHRACC is encoded in the OP-32 major opcode as a scalar
 multiply-high rounded accumulate instruction.
@@ -23742,12 +23742,12 @@ multiply-high rounded accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The MHRACC instruction multiplies `rs1` and `rs2` as signed values,
 rounds the product, and accumulates the upper 32 bits into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23757,7 +23757,7 @@ hi_rnd = (a64 * b64 + 2^31)[63:32]
 X[rd] = X[rd] + hi_rnd
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^31.
@@ -23765,11 +23765,11 @@ X[rd] = X[rd] + hi_rnd
 <<<
 ==== MHACCSU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhaccsu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHACCSU is encoded in the OP-32 major opcode as a scalar
 signed×unsigned multiply-high accumulate instruction.
@@ -23788,12 +23788,12 @@ signed×unsigned multiply-high accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The MHACCSU instruction multiplies `rs1` as signed by `rs2` as unsigned,
 extracts the upper 32 bits of the product, and accumulates the result.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23807,11 +23807,11 @@ X[rd] = X[rd] + hi
 <<<
 ==== MHRACCSU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhraccsu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHRACCSU is encoded in the OP-32 major opcode as a scalar
 signed×unsigned multiply-high rounded accumulate instruction.
@@ -23830,12 +23830,12 @@ signed×unsigned multiply-high rounded accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The MHRACCSU instruction performs a signed×unsigned multiply, rounds the
 product, and accumulates the upper 32 bits into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23849,11 +23849,11 @@ X[rd] = X[rd] + hi_rnd
 <<<
 ==== MHACCU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhaccu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHACCU is encoded in the OP-32 major opcode as a scalar
 unsigned×unsigned multiply-high accumulate instruction.
@@ -23872,12 +23872,12 @@ unsigned×unsigned multiply-high accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The MHACCU instruction multiplies `rs1` and `rs2` as unsigned values and
 accumulates the upper 32 bits of the product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23891,11 +23891,11 @@ X[rd] = X[rd] + hi
 <<<
 ==== MHRACCU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhraccu _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHRACCU is encoded in the OP-32 major opcode as a scalar
 unsigned×unsigned multiply-high rounded accumulate instruction.
@@ -23914,12 +23914,12 @@ unsigned×unsigned multiply-high rounded accumulate instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The MHRACCU instruction multiplies `rs1` and `rs2` as unsigned values,
 rounds the product, and accumulates the upper 32 bits into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23936,11 +23936,11 @@ X[rd] = X[rd] + hi_rnd
 
 ==== MQACC.H00 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mqacc.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQACC.H00 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
 instruction operating on the low halfwords of `rs1` and `rs2`.
@@ -23959,13 +23959,13 @@ instruction operating on the low halfwords of `rs1` and `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQACC.H00 instruction multiplies the low 16-bit halfwords of `rs1` and `rs2`
 as signed values, extracts bits [46:15] of the 47-bit product, and accumulates
 the extracted value into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -23975,18 +23975,18 @@ q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQACC.H01 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mqacc.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQACC.H01 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
 instruction operating on the low halfword of `rs1` and the high halfword of
@@ -24006,13 +24006,13 @@ instruction operating on the low halfword of `rs1` and the high halfword of
 ]}
 ....
 
-===== Description
+Description::
 
 The MQACC.H01 instruction multiplies `rs1[15:0]` by `rs2[31:16]` as signed
 halfwords, extracts bits [46:15] of the product, and accumulates the extracted
 value into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24022,18 +24022,18 @@ q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQACC.H11 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mqacc.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQACC.H11 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
 instruction operating on the high halfwords of `rs1` and `rs2`.
@@ -24052,13 +24052,13 @@ instruction operating on the high halfwords of `rs1` and `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQACC.H11 instruction multiplies the high 16-bit halfwords of `rs1` and
 `rs2` as signed values, extracts bits [46:15] of the product, and accumulates
 the extracted value into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24068,18 +24068,18 @@ q = (a * b)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQRACC.H00 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mqracc.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQRACC.H00 is encoded in the OP-32 major opcode as a scalar Q-format rounded
 accumulate instruction operating on the low halfwords of `rs1` and `rs2`.
@@ -24098,12 +24098,12 @@ accumulate instruction operating on the low halfwords of `rs1` and `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQRACC.H00 instruction is like MQACC.H00 but applies rounding by adding
 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24113,7 +24113,7 @@ q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^14.
@@ -24121,11 +24121,11 @@ X[rd] = X[rd] + q
 <<<
 ==== MQRACC.H01 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mqracc.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQRACC.H01 is encoded in the OP-32 major opcode as a scalar Q-format rounded
 accumulate instruction operating on `rs1[15:0]` and `rs2[31:16]`.
@@ -24144,12 +24144,12 @@ accumulate instruction operating on `rs1[15:0]` and `rs2[31:16]`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQRACC.H01 instruction is like MQACC.H01 but applies rounding by adding
 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24159,7 +24159,7 @@ q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^14.
@@ -24167,11 +24167,11 @@ X[rd] = X[rd] + q
 <<<
 ==== MQRACC.H11 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mqracc.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQRACC.H11 is encoded in the OP-32 major opcode as a scalar Q-format rounded
 accumulate instruction operating on the high halfwords of `rs1` and `rs2`.
@@ -24190,12 +24190,12 @@ accumulate instruction operating on the high halfwords of `rs1` and `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQRACC.H11 instruction is like MQACC.H11 but applies rounding by adding
 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24205,7 +24205,7 @@ q = (a * b + 2^14)[46:15]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^14.
@@ -24213,11 +24213,11 @@ X[rd] = X[rd] + q
 <<<
 ==== PMQACC.W.H00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmqacc.w.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQACC.W.H00 is encoded in the OP-32 major opcode as a packed Q-format
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -24236,13 +24236,13 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQACC.W.H00 instruction, for each 32-bit lane, multiplies the low 16-bit
 halfwords of `rs1` and `rs2` as signed values, extracts bits [46:15] of the
 product, and accumulates into the corresponding 32-bit element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24259,18 +24259,18 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMQACC.W.H01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmqacc.w.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQACC.W.H01 is encoded in the OP-32 major opcode as a packed Q-format
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -24289,13 +24289,13 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQACC.W.H01 instruction, for each 32-bit lane, multiplies the low halfword
 of `rs1` by the high halfword of `rs2` (both signed), extracts bits [46:15] of
 the product, and accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24316,11 +24316,11 @@ X[rd] = d
 <<<
 ==== PMQACC.W.H11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmqacc.w.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQACC.W.H11 is encoded in the OP-32 major opcode as a packed Q-format
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -24339,13 +24339,13 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQACC.W.H11 instruction, for each 32-bit lane, multiplies the high 16-bit
 halfwords of `rs1` and `rs2` as signed values, extracts bits [46:15] of the
 product, and accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24366,11 +24366,11 @@ X[rd] = d
 <<<
 ==== PMQRACC.W.H00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmqracc.w.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQRACC.W.H00 is encoded in the OP-32 major opcode as a packed Q-format rounded
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -24389,12 +24389,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQRACC.W.H00 instruction is like PMQACC.W.H00 but applies rounding by
 adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24411,7 +24411,7 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^14.
@@ -24419,11 +24419,11 @@ X[rd] = d
 <<<
 ==== PMQRACC.W.H01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmqracc.w.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQRACC.W.H01 is encoded in the OP-32 major opcode as a packed Q-format rounded
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -24442,12 +24442,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQRACC.W.H01 instruction is like PMQACC.W.H01 but applies rounding by
 adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24464,7 +24464,7 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^14.
@@ -24472,11 +24472,11 @@ X[rd] = d
 <<<
 ==== PMQRACC.W.H11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmqracc.w.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQRACC.W.H11 is encoded in the OP-32 major opcode as a packed Q-format rounded
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -24495,12 +24495,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQRACC.W.H11 instruction is like PMQACC.W.H11 but applies rounding by
 adding 2^14 before extracting bits [46:15], and then accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24517,7 +24517,7 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^14.
@@ -24525,11 +24525,11 @@ X[rd] = d
 <<<
 ==== PMQ2ADD.H
 
-===== Mnemonic
+Mnemonic::
 
 pmq2add.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQ2ADD.H is encoded in the OP-32 major opcode using packed halfword operands
 and producing packed 32-bit results (one per halfword pair).
@@ -24548,13 +24548,13 @@ and producing packed 32-bit results (one per halfword pair).
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQ2ADD.H instruction computes, for each 32-bit lane, the sum of two
 Q-format multiply-high results: one from the low halfword pair and one from the
 high halfword pair, and writes the packed 32-bit sums to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24578,11 +24578,11 @@ X[rd] = d
 <<<
 ==== PMQ2ADDA.H
 
-===== Mnemonic
+Mnemonic::
 
 pmq2adda.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQ2ADDA.H is encoded in the OP-32 major opcode as an accumulating form of
 PMQ2ADD.H.
@@ -24601,12 +24601,12 @@ PMQ2ADD.H.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQ2ADDA.H instruction adds the PMQ2ADD.H result into the corresponding
 packed 32-bit elements of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24627,18 +24627,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMQR2ADD.H
 
-===== Mnemonic
+Mnemonic::
 
 pmqr2add.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQR2ADD.H is encoded in the OP-32 major opcode using packed halfword operands
 and producing packed 32-bit results with rounding.
@@ -24657,13 +24657,13 @@ and producing packed 32-bit results with rounding.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQR2ADD.H instruction is like PMQ2ADD.H but applies rounding (adding 2^14)
 to each Q-format product before extracting bits [46:15], and then sums the two
 terms per 32-bit lane.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24683,18 +24683,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * Rounding is performed by adding 2^14.
 
 <<<
 ==== PMQR2ADDA.H
 
-===== Mnemonic
+Mnemonic::
 
 pmqr2adda.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQR2ADDA.H is encoded in the OP-32 major opcode as an accumulating form of
 PMQR2ADD.H.
@@ -24713,12 +24713,12 @@ PMQR2ADD.H.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQR2ADDA.H instruction adds the PMQR2ADD.H result into the corresponding
 packed 32-bit elements of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24739,7 +24739,7 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^14.
@@ -24747,11 +24747,11 @@ X[rd] = d
 <<<
 ==== MQACC.W00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mqacc.w00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQACC.W00 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
 instruction operating on the low words of `rs1` and `rs2`.
@@ -24770,13 +24770,13 @@ instruction operating on the low words of `rs1` and `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQACC.W00 instruction multiplies `rs1[31:0]` and `rs2[31:0]` as signed
 32-bit values, extracts bits [94:31] of the 95-bit product, and accumulates the
 extracted value into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24786,18 +24786,18 @@ q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQACC.W01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mqacc.w01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQACC.W01 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
 instruction operating on the low word of `rs1` and the high word of `rs2`.
@@ -24816,13 +24816,13 @@ instruction operating on the low word of `rs1` and the high word of `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQACC.W01 instruction multiplies `rs1[31:0]` by `rs2[63:32]` as signed
 32-bit values, extracts bits [94:31] of the product, and accumulates the result
 into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24832,18 +24832,18 @@ q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQACC.W11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mqacc.w11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQACC.W11 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
 instruction operating on the high words of `rs1` and `rs2`.
@@ -24862,13 +24862,13 @@ instruction operating on the high words of `rs1` and `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQACC.W11 instruction multiplies `rs1[63:32]` and `rs2[63:32]` as signed
 32-bit values, extracts bits [94:31] of the product, and accumulates the result
 into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24878,18 +24878,18 @@ q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MQRACC.W00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mqracc.w00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQRACC.W00 is encoded in the OP-32 major opcode as a scalar Q-format rounded
 accumulate instruction operating on the low words of `rs1` and `rs2`.
@@ -24908,13 +24908,13 @@ accumulate instruction operating on the low words of `rs1` and `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQRACC.W00 instruction is like MQACC.W00 but applies rounding by adding 2^30
 before extracting bits [94:31], and then accumulates the extracted value into
 `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24924,7 +24924,7 @@ q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^30.
@@ -24932,11 +24932,11 @@ X[rd] = X[rd] + q
 <<<
 ==== MQRACC.W01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mqracc.w01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQRACC.W01 is encoded in the OP-32 major opcode as a scalar Q-format rounded
 accumulate instruction operating on `rs1[31:0]` and `rs2[63:32]`.
@@ -24955,12 +24955,12 @@ accumulate instruction operating on `rs1[31:0]` and `rs2[63:32]`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQRACC.W01 instruction is like MQACC.W01 but applies rounding by adding 2^30
 before extracting bits [94:31], and then accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -24970,7 +24970,7 @@ q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^30.
@@ -24978,11 +24978,11 @@ X[rd] = X[rd] + q
 <<<
 ==== MQRACC.W11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mqracc.w11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQRACC.W11 is encoded in the OP-32 major opcode as a scalar Q-format rounded
 accumulate instruction operating on the high words of `rs1` and `rs2`.
@@ -25001,12 +25001,12 @@ accumulate instruction operating on the high words of `rs1` and `rs2`.
 ]}
 ....
 
-===== Description
+Description::
 
 The MQRACC.W11 instruction is like MQACC.W11 but applies rounding by adding 2^30
 before extracting bits [94:31], and then accumulates into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25016,7 +25016,7 @@ q = (a * b + 2^30)[94:31]
 X[rd] = X[rd] + q
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^30.
@@ -25024,11 +25024,11 @@ X[rd] = X[rd] + q
 <<<
 ==== PMQ2ADD.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmq2add.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQ2ADD.W is encoded in the OP-32 major opcode as a packed Q-format instruction
 that sums two word products to produce a scalar XLEN result.
@@ -25047,13 +25047,13 @@ that sums two word products to produce a scalar XLEN result.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQ2ADD.W instruction multiplies the low words and the high words of `rs1`
 and `rs2` as signed 32-bit values, extracts bits [94:31] from each product, and
 adds the two extracted values to produce the result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25072,11 +25072,11 @@ X[rd] = q0 + q1
 <<<
 ==== PMQ2ADDA.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmq2adda.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQ2ADDA.W is encoded in the OP-32 major opcode as an accumulating form of
 PMQ2ADD.W.
@@ -25095,11 +25095,11 @@ PMQ2ADD.W.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQ2ADDA.W instruction adds the PMQ2ADD.W result into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25114,18 +25114,18 @@ q1 = (a1 * b1)[94:31]
 X[rd] = X[rd] + q0 + q1
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMQR2ADD.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmqr2add.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQR2ADD.W is encoded in the OP-32 major opcode as a rounded form of PMQ2ADD.W.
 
@@ -25143,13 +25143,13 @@ PMQR2ADD.W is encoded in the OP-32 major opcode as a rounded form of PMQ2ADD.W.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQR2ADD.W instruction is like PMQ2ADD.W but applies rounding by adding 2^30
 to each product before extracting bits [94:31], and then sums the two extracted
 values.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25164,18 +25164,18 @@ q1 = (a1 * b1 + 2^30)[94:31]
 X[rd] = q0 + q1
 ----
 
-===== Notes
+Notes::
 
 * Rounding is performed by adding 2^30.
 
 <<<
 ==== PMQR2ADDA.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmqr2adda.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQR2ADDA.W is encoded in the OP-32 major opcode as an accumulating form of
 PMQR2ADD.W.
@@ -25194,11 +25194,11 @@ PMQR2ADD.W.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQR2ADDA.W instruction adds the PMQR2ADD.W result into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25213,7 +25213,7 @@ q1 = (a1 * b1 + 2^30)[94:31]
 X[rd] = X[rd] + q0 + q1
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^30.
@@ -25224,11 +25224,11 @@ X[rd] = X[rd] + q0 + q1
 
 ==== PMUL.H.B00
 
-===== Mnemonic
+Mnemonic::
 
 pmul.h.b00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMUL.H.B00 is encoded in the OP-32 major opcode using packed halfword elements.
 
@@ -25246,12 +25246,12 @@ PMUL.H.B00 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMUL.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` and `rs2` as
 signed 8-bit values and writes the 16-bit products to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25270,11 +25270,11 @@ X[rd] = d
 <<<
 ==== PMUL.H.B01
 
-===== Mnemonic
+Mnemonic::
 
 pmul.h.b01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMUL.H.B01 is encoded in the OP-32 major opcode using packed halfword elements.
 
@@ -25292,13 +25292,13 @@ PMUL.H.B01 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMUL.H.B01 multiplies the low byte of each 16-bit lane of `rs1` by the high byte
 of the corresponding lane of `rs2` (signed×signed), producing packed 16-bit
 products in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25317,11 +25317,11 @@ X[rd] = d
 <<<
 ==== PMUL.H.B11
 
-===== Mnemonic
+Mnemonic::
 
 pmul.h.b11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMUL.H.B11 is encoded in the OP-32 major opcode using packed halfword elements.
 
@@ -25339,12 +25339,12 @@ PMUL.H.B11 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMUL.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` and `rs2`
 as signed 8-bit values and writes packed 16-bit products to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25363,11 +25363,11 @@ X[rd] = d
 <<<
 ==== PMULSU.H.B00
 
-===== Mnemonic
+Mnemonic::
 
 pmulsu.h.b00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULSU.H.B00 is encoded in the OP-32 major opcode using packed halfword elements.
 
@@ -25385,12 +25385,12 @@ PMULSU.H.B00 is encoded in the OP-32 major opcode using packed halfword elements
 ]}
 ....
 
-===== Description
+Description::
 
 PMULSU.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` (signed) and
 `rs2` (unsigned), producing packed 16-bit products in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25409,11 +25409,11 @@ X[rd] = d
 <<<
 ==== PMULSU.H.B11
 
-===== Mnemonic
+Mnemonic::
 
 pmulsu.h.b11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULSU.H.B11 is encoded in the OP-32 major opcode using packed halfword elements.
 
@@ -25431,12 +25431,12 @@ PMULSU.H.B11 is encoded in the OP-32 major opcode using packed halfword elements
 ]}
 ....
 
-===== Description
+Description::
 
 PMULSU.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` (signed) and
 `rs2` (unsigned), producing packed 16-bit products in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25455,11 +25455,11 @@ X[rd] = d
 <<<
 ==== PMULU.H.B00
 
-===== Mnemonic
+Mnemonic::
 
 pmulu.h.b00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULU.H.B00 is encoded in the OP-32 major opcode using packed halfword elements.
 
@@ -25477,12 +25477,12 @@ PMULU.H.B00 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULU.H.B00 multiplies the low bytes of each 16-bit lane of `rs1` and `rs2`
 as unsigned 8-bit values, producing packed 16-bit products in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25501,11 +25501,11 @@ X[rd] = d
 <<<
 ==== PMULU.H.B01
 
-===== Mnemonic
+Mnemonic::
 
 pmulu.h.b01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULU.H.B01 is encoded in the OP-32 major opcode using packed halfword elements.
 
@@ -25523,13 +25523,13 @@ PMULU.H.B01 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULU.H.B01 multiplies the low byte of each 16-bit lane of `rs1` by the high
 byte of the corresponding lane of `rs2` (unsigned×unsigned), producing packed
 16-bit products in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25548,11 +25548,11 @@ X[rd] = d
 <<<
 ==== PMULU.H.B11
 
-===== Mnemonic
+Mnemonic::
 
 pmulu.h.b11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULU.H.B11 is encoded in the OP-32 major opcode using packed halfword elements.
 
@@ -25570,12 +25570,12 @@ PMULU.H.B11 is encoded in the OP-32 major opcode using packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULU.H.B11 multiplies the high bytes of each 16-bit lane of `rs1` and `rs2`
 as unsigned 8-bit values, producing packed 16-bit products in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25594,11 +25594,11 @@ X[rd] = d
 <<<
 ==== MUL.H00 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mul.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MUL.H00 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
 
@@ -25616,13 +25616,13 @@ MUL.H00 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword mult
 ]}
 ....
 
-===== Description
+Description::
 
 MUL.H00 multiplies the low 16-bit halfword (h0) of `rs1` by the low 16-bit
 halfword (h0) of `rs2`, both treated as signed, producing a full 32-bit signed
 product that is written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25636,11 +25636,11 @@ X[rd] = signed(s1_h0) * signed(s2_h0)
 <<<
 ==== MUL.H01 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mul.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MUL.H01 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
 
@@ -25658,13 +25658,13 @@ MUL.H01 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword mult
 ]}
 ....
 
-===== Description
+Description::
 
 MUL.H01 multiplies the low 16-bit halfword (h0) of `rs1` by the high 16-bit
 halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
 product that is written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25678,11 +25678,11 @@ X[rd] = signed(s1_h0) * signed(s2_h1)
 <<<
 ==== MUL.H11 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mul.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MUL.H11 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
 
@@ -25700,13 +25700,13 @@ MUL.H11 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword mult
 ]}
 ....
 
-===== Description
+Description::
 
 MUL.H11 multiplies the high 16-bit halfword (h1) of `rs1` by the high 16-bit
 halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
 product that is written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25720,11 +25720,11 @@ X[rd] = signed(s1_h1) * signed(s2_h1)
 <<<
 ==== MULSU.H00 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulsu.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULSU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 (signed×unsigned) producing a 32-bit result.
@@ -25743,12 +25743,12 @@ MULSU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and writes
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25761,11 +25761,11 @@ X[rd] = to_bits(32, a * b)
 <<<
 ==== MULSU.H11 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulsu.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULSU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 (signed×unsigned) producing a 32-bit result.
@@ -25784,12 +25784,12 @@ MULSU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and writes
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25802,11 +25802,11 @@ X[rd] = to_bits(32, a * b)
 <<<
 ==== MULU.H00 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulu.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 (unsigned×unsigned) producing a 32-bit result.
@@ -25825,12 +25825,12 @@ MULU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and writes
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25843,11 +25843,11 @@ X[rd] = to_bits(32, a * b)
 <<<
 ==== MULU.H01 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulu.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULU.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
 (unsigned×unsigned) producing a 32-bit result.
@@ -25866,12 +25866,12 @@ MULU.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and writes
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25884,11 +25884,11 @@ X[rd] = to_bits(32, a * b)
 <<<
 ==== MULU.H11 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulu.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 (unsigned×unsigned) producing a 32-bit result.
@@ -25907,12 +25907,12 @@ MULU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
 writes the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25925,11 +25925,11 @@ X[rd] = to_bits(32, a * b)
 <<<
 ==== PMUL.W.H00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmul.w.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMUL.W.H00 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -25947,14 +25947,14 @@ PMUL.W.H00 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
-===== Description
+Description::
 
 PMUL.W.H00 multiplies the low halfword (h0) of each packed 32-bit word element
 in `rs1` by the low halfword (h0) of the corresponding word element in `rs2`,
 both treated as signed, producing a 32-bit product per element that is written
 to the corresponding word of `rd`. This instruction is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -25970,11 +25970,11 @@ X[rd] = d_w1 @ d_w0
 <<<
 ==== PMUL.W.H01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmul.w.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMUL.W.H01 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -25992,14 +25992,14 @@ PMUL.W.H01 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
-===== Description
+Description::
 
 PMUL.W.H01 multiplies the low halfword (h0) of each packed 32-bit word element
 in `rs1` by the high halfword (h1) of the corresponding word element in `rs2`,
 both treated as signed, producing a 32-bit product per element that is written
 to the corresponding word of `rd`. This instruction is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26015,11 +26015,11 @@ X[rd] = d_w1 @ d_w0
 <<<
 ==== PMUL.W.H11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmul.w.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMUL.W.H11 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -26037,7 +26037,7 @@ PMUL.W.H11 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
-===== Description
+Description::
 
 PMUL.W.H11 multiplies the high halfword (h1) of each packed 32-bit word
 element in `rs1` by the high halfword (h1) of the corresponding word element in
@@ -26045,7 +26045,7 @@ element in `rs1` by the high halfword (h1) of the corresponding word element in
 written to the corresponding word of `rd`. This instruction is available only
 on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26061,11 +26061,11 @@ X[rd] = d_w1 @ d_w0
 <<<
 ==== PMULSU.W.H00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulsu.w.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULSU.W.H00 is encoded in the OP-32 major opcode producing packed 32-bit
 elements from halfword operands (signed×unsigned).
@@ -26084,12 +26084,12 @@ elements from halfword operands (signed×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 PMULSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
 and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26106,11 +26106,11 @@ X[rd] = d1 @ d0
 <<<
 ==== PMULSU.W.H11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulsu.w.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULSU.W.H11 is encoded in the OP-32 major opcode producing packed 32-bit
 elements from halfword operands (signed×unsigned).
@@ -26129,12 +26129,12 @@ elements from halfword operands (signed×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 PMULSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
 and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26151,11 +26151,11 @@ X[rd] = d1 @ d0
 <<<
 ==== PMULU.W.H00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulu.w.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULU.W.H00 is encoded in the OP-32 major opcode producing packed 32-bit
 elements from halfword operands (unsigned×unsigned).
@@ -26174,12 +26174,12 @@ elements from halfword operands (unsigned×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 PMULU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2` as
 unsigned values and writes packed 32-bit products to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26196,11 +26196,11 @@ X[rd] = d1 @ d0
 <<<
 ==== PMULU.W.H01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulu.w.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULU.W.H01 is encoded in the OP-32 major opcode producing packed 32-bit
 elements from halfword operands (unsigned×unsigned).
@@ -26219,12 +26219,12 @@ elements from halfword operands (unsigned×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 PMULU.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
 halfword of `rs2` (unsigned×unsigned) and writes packed 32-bit products to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26241,11 +26241,11 @@ X[rd] = d1 @ d0
 <<<
 ==== PMULU.W.H11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulu.w.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULU.W.H11 is encoded in the OP-32 major opcode producing packed 32-bit
 elements from halfword operands (unsigned×unsigned).
@@ -26264,12 +26264,12 @@ elements from halfword operands (unsigned×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 PMULU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
 as unsigned values and writes packed 32-bit products to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26286,11 +26286,11 @@ X[rd] = d1 @ d0
 <<<
 ==== MUL.W00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mul.w00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MUL.W00 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
 
@@ -26308,13 +26308,13 @@ MUL.W00 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only
 ]}
 ....
 
-===== Description
+Description::
 
 MUL.W00 multiplies the low 32-bit word (w0) of `rs1` by the low 32-bit word
 (w0) of `rs2`, both treated as signed, producing a full 64-bit signed product
 that is written to `rd`. This instruction is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26328,11 +26328,11 @@ X[rd] = signed(s1_w0) * signed(s2_w0)
 <<<
 ==== MUL.W01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mul.w01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MUL.W01 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
 
@@ -26350,13 +26350,13 @@ MUL.W01 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only
 ]}
 ....
 
-===== Description
+Description::
 
 MUL.W01 multiplies the low 32-bit word (w0) of `rs1` by the high 32-bit word
 (w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
 that is written to `rd`. This instruction is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26370,11 +26370,11 @@ X[rd] = signed(s1_w0) * signed(s2_w1)
 <<<
 ==== MUL.W11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mul.w11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MUL.W11 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
 
@@ -26392,13 +26392,13 @@ MUL.W11 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only
 ]}
 ....
 
-===== Description
+Description::
 
 MUL.W11 multiplies the high 32-bit word (w1) of `rs1` by the high 32-bit word
 (w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
 that is written to `rd`. This instruction is available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26412,11 +26412,11 @@ X[rd] = signed(s1_w1) * signed(s2_w1)
 <<<
 ==== MULSU.W00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mulsu.w00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 (signed×unsigned) producing a 64-bit result.
@@ -26435,12 +26435,12 @@ MULSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and writes
 the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26453,11 +26453,11 @@ X[rd] = to_bits(64, a * b)
 <<<
 ==== MULSU.W11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mulsu.w11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 (signed×unsigned) producing a 64-bit result.
@@ -26476,12 +26476,12 @@ MULSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and writes
 the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26494,11 +26494,11 @@ X[rd] = to_bits(64, a * b)
 <<<
 ==== MULU.W00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mulu.w00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 (unsigned×unsigned) producing a 64-bit result.
@@ -26517,12 +26517,12 @@ MULU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
 writes the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26535,11 +26535,11 @@ X[rd] = to_bits(64, a * b)
 <<<
 ==== MULU.W01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mulu.w01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
 (unsigned×unsigned) producing a 64-bit result.
@@ -26558,12 +26558,12 @@ MULU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
 writes the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26576,11 +26576,11 @@ X[rd] = to_bits(64, a * b)
 <<<
 ==== MULU.W11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 mulu.w11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 (unsigned×unsigned) producing a 64-bit result.
@@ -26599,12 +26599,12 @@ MULU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 ]}
 ....
 
-===== Description
+Description::
 
 MULU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
 writes the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26620,11 +26620,11 @@ X[rd] = to_bits(64, a * b)
 
 ==== MACC.H00 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 macc.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACC.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 accumulate (signed×signed).
@@ -26643,12 +26643,12 @@ accumulate (signed×signed).
 ]}
 ....
 
-===== Description
+Description::
 
 MACC.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as signed halfwords and adds the
 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26657,18 +26657,18 @@ b = sext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.H01 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 macc.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACC.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
 accumulate (signed×signed).
@@ -26687,12 +26687,12 @@ accumulate (signed×signed).
 ]}
 ....
 
-===== Description
+Description::
 
 MACC.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as signed halfwords and adds the
 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26701,18 +26701,18 @@ b = sext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.H11 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 macc.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACC.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 accumulate (signed×signed).
@@ -26731,12 +26731,12 @@ accumulate (signed×signed).
 ]}
 ....
 
-===== Description
+Description::
 
 MACC.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as signed halfwords and adds
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26745,18 +26745,18 @@ b = sext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCSU.H00 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 maccsu.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCSU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 accumulate (signed×unsigned).
@@ -26775,12 +26775,12 @@ accumulate (signed×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 MACCSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and adds
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26789,18 +26789,18 @@ b = zext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCSU.H11 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 maccsu.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCSU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 accumulate (signed×unsigned).
@@ -26819,12 +26819,12 @@ accumulate (signed×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 MACCSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and adds
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26833,18 +26833,18 @@ b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.H00 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 maccu.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
 accumulate (unsigned×unsigned).
@@ -26863,12 +26863,12 @@ accumulate (unsigned×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 MACCU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and adds
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26877,18 +26877,18 @@ b = zext_32(X[rs2][15:0])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.H01 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 maccu.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCU.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
 accumulate (unsigned×unsigned).
@@ -26907,12 +26907,12 @@ accumulate (unsigned×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 MACCU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and adds
 the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26921,18 +26921,18 @@ b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.H11 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 maccu.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
 accumulate (unsigned×unsigned).
@@ -26951,12 +26951,12 @@ accumulate (unsigned×unsigned).
 ]}
 ....
 
-===== Description
+Description::
 
 MACCU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
 adds the 32-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -26965,18 +26965,18 @@ b = zext_32(X[rs2][31:16])
 X[rd] = X[rd] + to_bits(32, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACC.W.H00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmacc.w.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMACC.W.H00 is encoded in the OP-32 major opcode as a packed multiply-accumulate
 instruction producing packed 32-bit elements.
@@ -26995,12 +26995,12 @@ instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMACC.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2` as
 signed values and accumulates the 32-bit products into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27014,18 +27014,18 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * sext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACC.W.H01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmacc.w.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMACC.W.H01 is encoded in the OP-32 major opcode as a packed multiply-accumulate
 instruction producing packed 32-bit elements.
@@ -27044,12 +27044,12 @@ instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMACC.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
 halfword of `rs2` (signed×signed) and accumulates the 32-bit products into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27063,18 +27063,18 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * sext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACC.W.H11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmacc.w.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMACC.W.H11 is encoded in the OP-32 major opcode as a packed multiply-accumulate
 instruction producing packed 32-bit elements.
@@ -27093,12 +27093,12 @@ instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMACC.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
 as signed values and accumulates the 32-bit products into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27112,18 +27112,18 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[63:48]) * sext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCSU.W.H00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmaccsu.w.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMACCSU.W.H00 is encoded in the OP-32 major opcode as a packed signed×unsigned
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -27142,12 +27142,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMACCSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
 and `rs2` (unsigned) and accumulates the 32-bit products into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27161,18 +27161,18 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCSU.W.H11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmaccsu.w.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMACCSU.W.H11 is encoded in the OP-32 major opcode as a packed signed×unsigned
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -27191,12 +27191,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMACCSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
 and `rs2` (unsigned) and accumulates the 32-bit products into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27210,18 +27210,18 @@ d1 = din[63:32] + to_bits(32, sext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCU.W.H00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmaccu.w.h00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMACCU.W.H00 is encoded in the OP-32 major opcode as a packed unsigned×unsigned
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -27240,12 +27240,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMACCU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` and `rs2`
 as unsigned values and accumulates the 32-bit products into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27259,18 +27259,18 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[47:32]) * zext_32(s2[47:32]))
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCU.W.H01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmaccu.w.h01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMACCU.W.H01 is encoded in the OP-32 major opcode as a packed unsigned×unsigned
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -27289,13 +27289,13 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMACCU.W.H01 multiplies, per 32-bit lane, the low halfword of `rs1` by the high
 halfword of `rs2` (unsigned×unsigned) and accumulates the 32-bit products into
 `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27309,18 +27309,18 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[47:32]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMACCU.W.H11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmaccu.w.h11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMACCU.W.H11 is encoded in the OP-32 major opcode as a packed unsigned×unsigned
 multiply-accumulate instruction producing packed 32-bit elements.
@@ -27339,12 +27339,12 @@ multiply-accumulate instruction producing packed 32-bit elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PMACCU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` and `rs2`
 as unsigned values and accumulates the 32-bit products into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27358,18 +27358,18 @@ d1 = din[63:32] + to_bits(32, zext_32(s1[63:48]) * zext_32(s2[63:48]))
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.W00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 macc.w00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACC.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 accumulate (signed×signed) producing a 64-bit result.
@@ -27388,12 +27388,12 @@ accumulate (signed×signed) producing a 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 MACC.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as signed 32-bit values and adds
 the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27402,18 +27402,18 @@ b = sext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.W01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 macc.w01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACC.W01 is encoded in the OP-32 major opcode as a scalar word multiply
 accumulate (signed×signed) producing a 64-bit result.
@@ -27432,12 +27432,12 @@ accumulate (signed×signed) producing a 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 MACC.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as signed 32-bit values and adds
 the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27446,18 +27446,18 @@ b = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACC.W11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 macc.w11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACC.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 accumulate (signed×signed) producing a 64-bit result.
@@ -27476,12 +27476,12 @@ accumulate (signed×signed) producing a 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 MACC.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as signed 32-bit values and
 adds the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27490,18 +27490,18 @@ b = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCSU.W00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 maccsu.w00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 accumulate (signed×unsigned) producing a 64-bit result.
@@ -27520,12 +27520,12 @@ accumulate (signed×unsigned) producing a 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 MACCSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and adds the
 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27534,18 +27534,18 @@ b = zext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCSU.W11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 maccsu.w11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 accumulate (signed×unsigned) producing a 64-bit result.
@@ -27564,12 +27564,12 @@ accumulate (signed×unsigned) producing a 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 MACCSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and adds
 the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27578,18 +27578,18 @@ b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.W00 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 maccu.w00 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
 accumulate (unsigned×unsigned) producing a 64-bit result.
@@ -27608,12 +27608,12 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 MACCU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
 adds the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27622,18 +27622,18 @@ b = zext_64(X[rs2][31:0])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.W01 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 maccu.w01 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
 accumulate (unsigned×unsigned) producing a 64-bit result.
@@ -27652,12 +27652,12 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 MACCU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
 adds the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27666,18 +27666,18 @@ b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MACCU.W11 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 maccu.w11 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MACCU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
 accumulate (unsigned×unsigned) producing a 64-bit result.
@@ -27696,12 +27696,12 @@ accumulate (unsigned×unsigned) producing a 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 MACCU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
 adds the 64-bit product to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27710,7 +27710,7 @@ b = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
@@ -27720,11 +27720,11 @@ X[rd] = X[rd] + to_bits(64, a * b)
 
 ==== PM2ADD.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2add.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADD.H is encoded in the OP-32 major opcode using packed halfword operands and
 producing packed 32-bit results (one per halfword pair).
@@ -27743,13 +27743,13 @@ producing packed 32-bit results (one per halfword pair).
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2ADD.H instruction multiplies corresponding packed halfwords in each
 32-bit lane (low×low and high×high), and adds the two 32-bit products to form
 each packed 32-bit result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27772,11 +27772,11 @@ X[rd] = d
 <<<
 ==== PM2ADDA.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2adda.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDA.H is encoded in the OP-32 major opcode as an accumulating form of
 PM2ADD.H.
@@ -27795,12 +27795,12 @@ PM2ADD.H.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2ADDA.H instruction adds the PM2ADD.H result into the corresponding packed
 32-bit elements of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27820,18 +27820,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADDSU.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2addsu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDSU.H is encoded in the OP-32 major opcode using packed halfword operands,
 performing signed×unsigned multiplies per halfword pair.
@@ -27850,13 +27850,13 @@ performing signed×unsigned multiplies per halfword pair.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2ADDSU.H instruction performs signed×unsigned halfword multiplications
 (low×low and high×high within each 32-bit lane) and sums the two 32-bit products
 to produce each packed 32-bit result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27879,11 +27879,11 @@ X[rd] = d
 <<<
 ==== PM2ADDASU.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2addasu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDASU.H is encoded in the OP-32 major opcode as an accumulating form of
 PM2ADDSU.H.
@@ -27902,12 +27902,12 @@ PM2ADDSU.H.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2ADDASU.H instruction adds the PM2ADDSU.H result into the corresponding
 packed 32-bit elements of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27927,18 +27927,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADDU.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2addu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDU.H is encoded in the OP-32 major opcode using packed halfword operands and
 performing unsigned×unsigned multiplies per halfword pair.
@@ -27957,13 +27957,13 @@ performing unsigned×unsigned multiplies per halfword pair.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2ADDU.H instruction performs unsigned×unsigned halfword multiplications
 (low×low and high×high within each 32-bit lane) and sums the two 32-bit products
 to produce each packed 32-bit result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -27986,11 +27986,11 @@ X[rd] = d
 <<<
 ==== PM2ADDAU.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2addau.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDAU.H is encoded in the OP-32 major opcode as an accumulating form of
 PM2ADDU.H.
@@ -28009,12 +28009,12 @@ PM2ADDU.H.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2ADDAU.H instruction adds the PM2ADDU.H result into the corresponding
 packed 32-bit elements of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28034,18 +28034,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADD.HX
 
-===== Mnemonic
+Mnemonic::
 
 pm2add.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADD.HX is encoded in the OP-32 major opcode using packed halfword operands and
 producing packed 32-bit results from cross products (low×high and high×low).
@@ -28064,13 +28064,13 @@ producing packed 32-bit results from cross products (low×high and high×low).
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2ADD.HX instruction multiplies cross halfword pairs within each 32-bit
 lane (low of `rs1` × high of `rs2`, and high of `rs1` × low of `rs2`) and sums the
 two 32-bit products to produce each packed 32-bit result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28093,11 +28093,11 @@ X[rd] = d
 <<<
 ==== PM2ADDA.HX
 
-===== Mnemonic
+Mnemonic::
 
 pm2adda.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDA.HX is encoded in the OP-32 major opcode as an accumulating form of
 PM2ADD.HX.
@@ -28116,12 +28116,12 @@ PM2ADD.HX.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2ADDA.HX instruction adds the PM2ADD.HX result into the corresponding
 packed 32-bit elements of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28141,18 +28141,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUBA.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2suba.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SUBA.H is encoded in the OP-32 major opcode as an accumulating
 multiply-add-subtract instruction using packed halfword operands.
@@ -28171,12 +28171,12 @@ multiply-add-subtract instruction using packed halfword operands.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2SUBA.H instruction updates each packed 32-bit element of `rd` by adding
 the low×low halfword product and subtracting the high×high halfword product.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28196,18 +28196,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUBA.HX
 
-===== Mnemonic
+Mnemonic::
 
 pm2suba.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SUBA.HX is encoded in the OP-32 major opcode as an accumulating
 multiply-add-subtract instruction using packed halfword operands with cross
@@ -28227,12 +28227,12 @@ products.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM2SUBA.HX instruction updates each packed 32-bit element of `rd` by adding
 the low×high cross product and subtracting the high×low cross product.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28252,18 +28252,18 @@ for i = 0 .. (XLEN/32 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUB.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2sub.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 
@@ -28281,14 +28281,14 @@ PM2SUB.H is encoded in the OP-32 major opcode with packed halfword elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2SUB.H multiplies two pairs of signed 16-bit halfword elements from `rs1` and
 `rs2` within each 32-bit group, then subtracts the upper product from the lower
 product. The 32-bit difference for each group is written to the corresponding
 32-bit position in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28313,11 +28313,11 @@ X[rd] = d
 <<<
 ==== PM2SUB.HX
 
-===== Mnemonic
+Mnemonic::
 
 pm2sub.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SUB.HX is encoded in the OP-32 major opcode with packed halfword elements
 and crossed operands.
@@ -28336,7 +28336,7 @@ and crossed operands.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2SUB.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
 and `rs2` within each 32-bit group using crossed `rs2` operands, then subtracts
@@ -28345,7 +28345,7 @@ multiplied with the upper halfword of `rs2`, and vice versa. The 32-bit
 difference for each group is written to the corresponding 32-bit position
 in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28370,11 +28370,11 @@ X[rd] = d
 <<<
 ==== PM2SADD.H
 
-===== Mnemonic
+Mnemonic::
 
 pm2sadd.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SADD.H is encoded in the OP-32 major opcode with packed halfword elements
 and saturating addition.
@@ -28393,14 +28393,14 @@ and saturating addition.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2SADD.H multiplies two pairs of signed 16-bit halfword elements from `rs1`
 and `rs2` within each 32-bit group, sums the two products, and saturates the
 result to the signed 32-bit range [-2^31, 2^31-1]. The saturated 32-bit result
 for each group is written to the corresponding 32-bit position in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28424,11 +28424,11 @@ X[rd] = d
 <<<
 ==== PM2SADD.HX
 
-===== Mnemonic
+Mnemonic::
 
 pm2sadd.hx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SADD.HX is encoded in the OP-32 major opcode with packed halfword elements,
 crossed operands, and saturating addition.
@@ -28447,7 +28447,7 @@ crossed operands, and saturating addition.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2SADD.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
 and `rs2` within each 32-bit group using crossed `rs2` operands, sums the two
@@ -28456,7 +28456,7 @@ The lower halfword of `rs1` is multiplied with the upper halfword of `rs2`, and
 vice versa. The saturated 32-bit result for each group is written to the
 corresponding 32-bit position in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28480,11 +28480,11 @@ X[rd] = d
 <<<
 ==== PM2ADD.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2add.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADD.W is encoded in the OP-32 major opcode as a packed word-pair multiply-add
 instruction producing a scalar 64-bit result.
@@ -28503,12 +28503,12 @@ instruction producing a scalar 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2ADD.W multiplies the low words and high words of `rs1` and `rs2` as signed
 32-bit values and adds the two 64-bit products to produce the result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28524,11 +28524,11 @@ X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 <<<
 ==== PM2ADDA.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2adda.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDA.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 
@@ -28546,13 +28546,13 @@ PM2ADDA.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 ]}
 ....
 
-===== Description
+Description::
 
 PM2ADDA.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
 `rs1` and `rs2`, sums the two 64-bit products, and accumulates the result into
 `rd`. This instruction is the accumulating variant of PM2ADD.W.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28570,11 +28570,11 @@ X[rd] = X[rd]
 <<<
 ==== PM2ADDSU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2addsu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDSU.W is encoded in the OP-32 major opcode as a packed word-pair
 signed×unsigned multiply-add instruction.
@@ -28593,12 +28593,12 @@ signed×unsigned multiply-add instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2ADDSU.W multiplies corresponding word pairs as signed×unsigned (low×low and
 high×high) and adds the two 64-bit products to produce the result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28614,11 +28614,11 @@ X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 <<<
 ==== PM2ADDASU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2addasu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDASU.W is encoded in the OP-32 major opcode as an accumulating form of
 PM2ADDSU.W.
@@ -28637,11 +28637,11 @@ PM2ADDSU.W.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2ADDASU.W adds the PM2ADDSU.W result into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28653,18 +28653,18 @@ b1 = zext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADDU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2addu.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDU.W is encoded in the OP-32 major opcode as a packed word-pair
 unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
@@ -28683,12 +28683,12 @@ unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2ADDU.W multiplies corresponding word pairs as unsigned×unsigned and adds the
 two 64-bit products to produce the result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28704,11 +28704,11 @@ X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 <<<
 ==== PM2ADDAU.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2addau.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDAU.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 
@@ -28726,13 +28726,13 @@ PM2ADDAU.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 ]}
 ....
 
-===== Description
+Description::
 
 PM2ADDAU.W (RV64 only) multiplies two pairs of unsigned 32-bit word elements
 from `rs1` and `rs2`, sums the two 64-bit products, and accumulates the result
 into `rd`. This instruction is the unsigned accumulating variant of PM2ADDU.W.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28750,11 +28750,11 @@ X[rd] = X[rd]
 <<<
 ==== PM2ADD.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2add.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADD.WX is encoded in the OP-32 major opcode as a packed word-pair multiply-add
 instruction using cross products.
@@ -28773,12 +28773,12 @@ instruction using cross products.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2ADD.WX multiplies cross word pairs (low of `rs1` × high of `rs2`, and high of
 `rs1` × low of `rs2`) as signed values and sums the two 64-bit products.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28794,11 +28794,11 @@ X[rd] = to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
 <<<
 ==== PM2ADDA.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2adda.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2ADDA.WX is encoded in the OP-32 major opcode as an accumulating form of
 PM2ADD.WX.
@@ -28817,11 +28817,11 @@ PM2ADD.WX.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2ADDA.WX adds the PM2ADD.WX result into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28833,18 +28833,18 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUBA.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2suba.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SUBA.W is encoded in the OP-32 major opcode as an accumulating
 multiply-add-subtract instruction using packed word pairs.
@@ -28863,12 +28863,12 @@ multiply-add-subtract instruction using packed word pairs.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2SUBA.W updates `rd` by adding the low×low signed word product and subtracting
 the high×high signed word product.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28880,18 +28880,18 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b0) - to_bits(64, a1 * b1)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM2SUBA.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2suba.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SUBA.WX is encoded in the OP-32 major opcode as an accumulating
 multiply-add-subtract instruction using cross word products.
@@ -28910,12 +28910,12 @@ multiply-add-subtract instruction using cross word products.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2SUBA.WX updates `rd` by adding the low×high signed word product and
 subtracting the high×low signed word product.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28927,7 +28927,7 @@ b1 = sext_64(X[rs2][63:32])
 X[rd] = X[rd] + to_bits(64, a0 * b1) - to_bits(64, a1 * b0)
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
@@ -28935,11 +28935,11 @@ X[rd] = X[rd] + to_bits(64, a0 * b1) - to_bits(64, a1 * b0)
 <<<
 ==== PM2SUB.W (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2sub.w _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SUB.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 
@@ -28957,13 +28957,13 @@ PM2SUB.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 ]}
 ....
 
-===== Description
+Description::
 
 PM2SUB.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
 `rs1` and `rs2`, then subtracts the upper product from the lower product. The
 64-bit difference is written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -28980,11 +28980,11 @@ X[rd] = sext64(signed(s1[31:0])  * signed(s2[31:0]))
 <<<
 ==== PM2SUB.WX (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm2sub.wx _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2SUB.WX is encoded in the OP-32 major opcode with word elements and crossed
 operands (RV64 only).
@@ -29003,14 +29003,14 @@ operands (RV64 only).
 ]}
 ....
 
-===== Description
+Description::
 
 PM2SUB.WX (RV64 only) multiplies two pairs of signed 32-bit word elements from
 `rs1` and `rs2` using crossed `rs2` operands, then subtracts the upper product
 from the lower product. The lower word of `rs1` is multiplied with the upper
 word of `rs2`, and vice versa. The 64-bit difference is written to `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29029,11 +29029,11 @@ X[rd] = sext64(signed(s1[31:0])  * signed(s2[63:32]))
 
 ==== PM4ADD.B
 
-===== Mnemonic
+Mnemonic::
 
 pm4add.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADD.B is encoded in the OP-32 major opcode using packed byte operands and
 producing packed 32-bit results (one per 4-byte group).
@@ -29052,13 +29052,13 @@ producing packed 32-bit results (one per 4-byte group).
 ]}
 ....
 
-===== Description
+Description::
 
 The PM4ADD.B instruction multiplies corresponding packed bytes within each
 32-bit lane as signed values and sums the four 32-bit products to produce one
 packed 32-bit result per lane in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29086,11 +29086,11 @@ X[rd] = d
 <<<
 ==== PM4ADDSU.B
 
-===== Mnemonic
+Mnemonic::
 
 pm4addsu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDSU.B is encoded in the OP-32 major opcode using packed byte operands and
 performing signed×unsigned byte multiplies within each 32-bit lane.
@@ -29109,13 +29109,13 @@ performing signed×unsigned byte multiplies within each 32-bit lane.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM4ADDSU.B instruction multiplies corresponding packed bytes within each
 32-bit lane as signed×unsigned and sums the four 32-bit products to form one
 packed 32-bit result per lane in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29143,11 +29143,11 @@ X[rd] = d
 <<<
 ==== PM4ADDU.B
 
-===== Mnemonic
+Mnemonic::
 
 pm4addu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDU.B is encoded in the OP-32 major opcode using packed byte operands and
 performing unsigned×unsigned byte multiplies within each 32-bit lane.
@@ -29166,13 +29166,13 @@ performing unsigned×unsigned byte multiplies within each 32-bit lane.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM4ADDU.B instruction multiplies corresponding packed bytes within each
 32-bit lane as unsigned values and sums the four 32-bit products to produce one
 packed 32-bit result per lane in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29200,11 +29200,11 @@ X[rd] = d
 <<<
 ==== PM4ADDA.B
 
-===== Mnemonic
+Mnemonic::
 
 pm4adda.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDA.B is encoded in the OP-32 major opcode with packed byte elements.
 
@@ -29222,14 +29222,14 @@ PM4ADDA.B is encoded in the OP-32 major opcode with packed byte elements.
 ]}
 ....
 
-===== Description
+Description::
 
 PM4ADDA.B multiplies four pairs of signed 8-bit byte elements from `rs1` and
 `rs2` within each 32-bit group, sums the four products, and accumulates the
 result into the corresponding 32-bit element of `rd`. This instruction is the
 accumulating variant of PM4ADD.B.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29262,11 +29262,11 @@ X[rd] = d
 <<<
 ==== PM4ADDASU.B
 
-===== Mnemonic
+Mnemonic::
 
 pm4addasu.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDASU.B is encoded in the OP-32 major opcode with packed byte elements and
 signed-unsigned multiplication.
@@ -29285,14 +29285,14 @@ signed-unsigned multiplication.
 ]}
 ....
 
-===== Description
+Description::
 
 PM4ADDASU.B multiplies four pairs of byte elements from `rs1` (signed) and
 `rs2` (unsigned) within each 32-bit group, sums the four products, and
 accumulates the result into the corresponding 32-bit element of `rd`. This
 instruction is the signed-unsigned accumulating variant of PM4ADDSU.B.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29325,11 +29325,11 @@ X[rd] = d
 <<<
 ==== PM4ADDAU.B
 
-===== Mnemonic
+Mnemonic::
 
 pm4addau.b _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDAU.B is encoded in the OP-32 major opcode with packed byte elements and
 unsigned multiplication.
@@ -29348,14 +29348,14 @@ unsigned multiplication.
 ]}
 ....
 
-===== Description
+Description::
 
 PM4ADDAU.B multiplies four pairs of unsigned 8-bit byte elements from `rs1` and
 `rs2` within each 32-bit group, sums the four products, and accumulates the
 result into the corresponding 32-bit element of `rd`. This instruction is the
 unsigned accumulating variant of PM4ADDU.B.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29388,11 +29388,11 @@ X[rd] = d
 <<<
 ==== PM4ADD.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm4add.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADD.H is encoded in the OP-32 major opcode as a packed halfword-group
 multiply-add instruction producing a scalar 64-bit result.
@@ -29411,13 +29411,13 @@ multiply-add instruction producing a scalar 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM4ADD.H instruction multiplies the four packed 16-bit halfwords of `rs1`
 and `rs2` as signed values and sums the four 64-bit products to produce the
 result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29435,11 +29435,11 @@ X[rd] =
 <<<
 ==== PM4ADDSU.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm4addsu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDSU.H is encoded in the OP-32 major opcode as a packed halfword-group
 signed×unsigned multiply-add instruction producing a scalar 64-bit result.
@@ -29458,13 +29458,13 @@ signed×unsigned multiply-add instruction producing a scalar 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM4ADDSU.H instruction multiplies the four packed halfwords of `rs1` (signed)
 with the four packed halfwords of `rs2` (unsigned) and sums the products to
 produce the 64-bit result in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29482,11 +29482,11 @@ X[rd] =
 <<<
 ==== PM4ADDASU.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm4addasu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDASU.H is encoded in the OP-32 major opcode as an accumulating form of
 PM4ADDSU.H.
@@ -29505,11 +29505,11 @@ PM4ADDSU.H.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM4ADDASU.H instruction adds the PM4ADDSU.H sum-of-products result into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29524,18 +29524,18 @@ X[rd] =
   + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PM4ADDU.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm4addu.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDU.H is encoded in the OP-32 major opcode as a packed halfword-group
 unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
@@ -29554,13 +29554,13 @@ unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM4ADDU.H instruction multiplies the four packed 16-bit halfwords of `rs1`
 and `rs2` as unsigned values and sums the products to produce the 64-bit result
 in `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29578,11 +29578,11 @@ X[rd] =
 <<<
 ==== PM4ADDAU.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm4addau.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDAU.H is encoded in the OP-32 major opcode as an accumulating form of
 PM4ADDU.H.
@@ -29601,11 +29601,11 @@ PM4ADDU.H.
 ]}
 ....
 
-===== Description
+Description::
 
 The PM4ADDAU.H instruction adds the PM4ADDU.H sum-of-products result into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29620,7 +29620,7 @@ X[rd] =
   + to_bits(64, zext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
@@ -29628,11 +29628,11 @@ X[rd] =
 <<<
 ==== PM4ADDA.H (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pm4adda.h _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM4ADDA.H is encoded in the OP-32 major opcode with packed halfword elements
 (RV64 only).
@@ -29651,13 +29651,13 @@ PM4ADDA.H is encoded in the OP-32 major opcode with packed halfword elements
 ]}
 ....
 
-===== Description
+Description::
 
 PM4ADDA.H (RV64 only) multiplies four pairs of signed 16-bit halfword elements
 from `rs1` and `rs2`, sums the four 64-bit products, and accumulates the result
 into `rd`. This instruction is the accumulating variant of PM4ADD.H.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29679,11 +29679,11 @@ X[rd] = X[rd]
 
 ==== PMULH.H.B0
 
-===== Mnemonic
+Mnemonic::
 
 pmulh.h.b0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULH.H.B0 is encoded in the OP-32 major opcode using packed halfword elements.
 It multiplies each 16-bit element of `rs1` by the low byte of the corresponding
@@ -29704,13 +29704,13 @@ product.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMULH.H.B0 instruction multiplies each packed 16-bit element of `rs1` by the
 low byte of the corresponding element of `rs2` (signed×signed) and writes the
 upper 16 bits of each 24-bit product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29730,11 +29730,11 @@ X[rd] = d
 <<<
 ==== PMULH.H.B1
 
-===== Mnemonic
+Mnemonic::
 
 pmulh.h.b1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULH.H.B1 is encoded in the OP-32 major opcode using packed halfword elements.
 It multiplies each 16-bit element of `rs1` by the high byte of the corresponding
@@ -29755,13 +29755,13 @@ product.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMULH.H.B1 instruction multiplies each packed 16-bit element of `rs1` by the
 high byte of the corresponding element of `rs2` (signed×signed) and writes the
 upper 16 bits of each 24-bit product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29781,11 +29781,11 @@ X[rd] = d
 <<<
 ==== PMULHSU.H.B0
 
-===== Mnemonic
+Mnemonic::
 
 pmulhsu.h.b0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHSU.H.B0 is encoded in the OP-32 major opcode using packed halfword elements.
 It multiplies each 16-bit element of `rs1` (signed) by the low byte of the
@@ -29806,13 +29806,13 @@ corresponding element of `rs2` (unsigned) and returns the high 16 bits of the
 ]}
 ....
 
-===== Description
+Description::
 
 The PMULHSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
 (signed) by the low byte of the corresponding element of `rs2` (unsigned), and
 writes the upper 16 bits of each 24-bit product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29832,11 +29832,11 @@ X[rd] = d
 <<<
 ==== PMULHSU.H.B1
 
-===== Mnemonic
+Mnemonic::
 
 pmulhsu.h.b1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHSU.H.B1 is encoded in the OP-32 major opcode using packed halfword elements.
 It multiplies each 16-bit element of `rs1` (signed) by the high byte of the
@@ -29857,13 +29857,13 @@ corresponding element of `rs2` (unsigned) and returns the high 16 bits of the
 ]}
 ....
 
-===== Description
+Description::
 
 The PMULHSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
 (signed) by the high byte of the corresponding element of `rs2` (unsigned), and
 writes the upper 16 bits of each 24-bit product into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29883,11 +29883,11 @@ X[rd] = d
 <<<
 ==== PMHACC.H.B0
 
-===== Mnemonic
+Mnemonic::
 
 pmhacc.h.b0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACC.H.B0 is encoded in the OP-32 major opcode as an accumulating form of
 PMULH.H.B0.
@@ -29906,14 +29906,14 @@ PMULH.H.B0.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACC.H.B0 instruction multiplies each packed 16-bit element of `rs1` by
 the low byte of the corresponding element of `rs2` (signed×signed), takes the
 upper 16 bits of the 24-bit product, and accumulates it into the corresponding
 halfword element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29931,18 +29931,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACC.H.B1
 
-===== Mnemonic
+Mnemonic::
 
 pmhacc.h.b1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACC.H.B1 is encoded in the OP-32 major opcode as an accumulating form of
 PMULH.H.B1.
@@ -29961,14 +29961,14 @@ PMULH.H.B1.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACC.H.B1 instruction multiplies each packed 16-bit element of `rs1` by
 the high byte of the corresponding element of `rs2` (signed×signed), takes the
 upper 16 bits of the 24-bit product, and accumulates it into the corresponding
 halfword element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -29986,18 +29986,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACCSU.H.B0
 
-===== Mnemonic
+Mnemonic::
 
 pmhaccsu.h.b0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACCSU.H.B0 is encoded in the OP-32 major opcode as an accumulating form of
 PMULHSU.H.B0.
@@ -30016,13 +30016,13 @@ PMULHSU.H.B0.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACCSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
 (signed) by the low byte of the corresponding element of `rs2` (unsigned), takes
 the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30040,18 +30040,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACCSU.H.B1
 
-===== Mnemonic
+Mnemonic::
 
 pmhaccsu.h.b1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACCSU.H.B1 is encoded in the OP-32 major opcode as an accumulating form of
 PMULHSU.H.B1.
@@ -30070,13 +30070,13 @@ PMULHSU.H.B1.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACCSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
 (signed) by the high byte of the corresponding element of `rs2` (unsigned), takes
 the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30094,18 +30094,18 @@ for i = 0 .. (XLEN/16 - 1):
 X[rd] = d
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MULH.H0 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulh.h0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULH.H0 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using a halfword.
 
@@ -30123,14 +30123,14 @@ MULH.H0 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using
 ]}
 ....
 
-===== Description
+Description::
 
 MULH.H0 multiplies the full signed XLEN-bit value of `rs1` by the low 16-bit
 halfword (h0) of `rs2` treated as signed, producing a (XLEN+16)-bit
 intermediate product, and writes bits [47:16] to `rd`, effectively providing
 the upper XLEN bits of the product after discarding the low 16 bits.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30143,11 +30143,11 @@ X[rd] = (signed(X[rs1]) * signed(s2_h0))[47:16]
 <<<
 ==== MULH.H1 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulh.h1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULH.H1 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using a halfword.
 
@@ -30165,14 +30165,14 @@ MULH.H1 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using
 ]}
 ....
 
-===== Description
+Description::
 
 MULH.H1 multiplies the full signed XLEN-bit value of `rs1` by the high 16-bit
 halfword (h1) of `rs2` treated as signed, producing a (XLEN+16)-bit
 intermediate product, and writes bits [47:16] to `rd`, effectively providing
 the upper XLEN bits of the product after discarding the low 16 bits.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30185,11 +30185,11 @@ X[rd] = (signed(X[rs1]) * signed(s2_h1))[47:16]
 <<<
 ==== MULHSU.H0 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulhsu.h0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULHSU.H0 is encoded in the OP-32 major opcode with a scalar `rs1` and a
 halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
@@ -30209,13 +30209,13 @@ halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
 ]}
 ....
 
-===== Description
+Description::
 
 MULHSU.H0 multiplies the 32-bit signed value in `rs1` by the low halfword of
 `rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
 `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30229,11 +30229,11 @@ X[rd] = to_bits(48, p)[47:16]
 <<<
 ==== MULHSU.H1 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mulhsu.h1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MULHSU.H1 is encoded in the OP-32 major opcode with a scalar `rs1` and a
 halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
@@ -30253,13 +30253,13 @@ halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
 ]}
 ....
 
-===== Description
+Description::
 
 MULHSU.H1 multiplies the 32-bit signed value in `rs1` by the high halfword of
 `rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
 `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30273,11 +30273,11 @@ X[rd] = to_bits(48, p)[47:16]
 <<<
 ==== MHACC.H0 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhacc.h0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHACC.H0 is encoded in the OP-32 major opcode as an accumulating form of
 MULH.H0 (signed×signed), producing the high 32 bits of a 48-bit product.
@@ -30296,13 +30296,13 @@ MULH.H0 (signed×signed), producing the high 32 bits of a 48-bit product.
 ]}
 ....
 
-===== Description
+Description::
 
 MHACC.H0 multiplies the signed 32-bit value in `rs1` by the low halfword of
 `rs2` treated as signed, takes bits [47:16] of the 48-bit product, and
 accumulates the extracted value into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30312,18 +30312,18 @@ p  = a * b0
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MHACC.H1 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhacc.h1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHACC.H1 is encoded in the OP-32 major opcode as an accumulating form of
 MULH.H1 (signed×signed), producing the high 32 bits of a 48-bit product.
@@ -30342,13 +30342,13 @@ MULH.H1 (signed×signed), producing the high 32 bits of a 48-bit product.
 ]}
 ....
 
-===== Description
+Description::
 
 MHACC.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
 `rs2` treated as signed, takes bits [47:16] of the 48-bit product, and
 accumulates the extracted value into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30358,18 +30358,18 @@ p  = a * b1
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MHACCSU.H0 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhaccsu.h0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHACCSU.H0 is encoded in the OP-32 major opcode as an accumulating form of
 MULHSU.H0 (signed×unsigned), producing the high 32 bits of a 48-bit product.
@@ -30388,13 +30388,13 @@ MULHSU.H0 (signed×unsigned), producing the high 32 bits of a 48-bit product.
 ]}
 ....
 
-===== Description
+Description::
 
 MHACCSU.H0 multiplies the signed 32-bit value in `rs1` by the low halfword of
 `rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
 accumulates the extracted value into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30404,18 +30404,18 @@ p  = a * b0
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== MHACCSU.H1 (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mhaccsu.h1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MHACCSU.H1 is encoded in the OP-32 major opcode as an accumulating form of
 MULHSU.H1 (signed×unsigned), producing the high 32 bits of a 48-bit product.
@@ -30434,13 +30434,13 @@ MULHSU.H1 (signed×unsigned), producing the high 32 bits of a 48-bit product.
 ]}
 ....
 
-===== Description
+Description::
 
 MHACCSU.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
 `rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
 accumulates the extracted value into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30450,18 +30450,18 @@ p  = a * b1
 X[rd] = X[rd] + to_bits(48, p)[47:16]
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMULH.W.H0 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulh.w.h0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULH.W.H0 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -30479,7 +30479,7 @@ PMULH.W.H0 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
-===== Description
+Description::
 
 PMULH.W.H0 multiplies each signed packed 32-bit word element of `rs1` by the
 low halfword (h0) of the corresponding word element of `rs2` treated as signed,
@@ -30487,7 +30487,7 @@ producing a 48-bit intermediate product per element, and writes bits [47:16] of
 each product to the corresponding word of `rd`. This instruction is available
 only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30503,11 +30503,11 @@ X[rd] = d_w1 @ d_w0
 <<<
 ==== PMULH.W.H1 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulh.w.h1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULH.W.H1 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
@@ -30525,7 +30525,7 @@ PMULH.W.H1 is encoded in the OP-32 major opcode with packed word elements (RV64 
 ]}
 ....
 
-===== Description
+Description::
 
 PMULH.W.H1 multiplies each signed packed 32-bit word element of `rs1` by the
 high halfword (h1) of the corresponding word element of `rs2` treated as
@@ -30533,7 +30533,7 @@ signed, producing a 48-bit intermediate product per element, and writes bits
 [47:16] of each product to the corresponding word of `rd`. This instruction is
 available only on RV64.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30549,11 +30549,11 @@ X[rd] = d_w1 @ d_w0
 <<<
 ==== PMULHSU.W.H0 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulhsu.w.h0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHSU.W.H0 is encoded in the OP-32 major opcode producing packed 32-bit
 elements from word×halfword operands (signed×unsigned), taking the high 32 bits
@@ -30573,13 +30573,13 @@ of each 48-bit product.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULHSU.W.H0 multiplies each 32-bit word of `rs1` (signed) by the low halfword of
 the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of each
 48-bit product, and packs the two 32-bit results into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30599,11 +30599,11 @@ X[rd] = d1 @ d0
 <<<
 ==== PMULHSU.W.H1 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmulhsu.w.h1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMULHSU.W.H1 is encoded in the OP-32 major opcode producing packed 32-bit
 elements from word×halfword operands (signed×unsigned), taking the high 32 bits
@@ -30623,13 +30623,13 @@ of each 48-bit product.
 ]}
 ....
 
-===== Description
+Description::
 
 PMULHSU.W.H1 multiplies each 32-bit word of `rs1` (signed) by the high halfword
 of the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of
 each 48-bit product, and packs the two 32-bit results into `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30649,11 +30649,11 @@ X[rd] = d1 @ d0
 <<<
 ==== PMHACC.W.H0 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhacc.w.h0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACC.W.H0 is encoded in the OP-32 major opcode. It performs a packed
 multiply-high-accumulate using signed word operands from `rs1` and signed
@@ -30674,14 +30674,14 @@ halfword operands selected from `rs2` (H0 selection per word), producing packed
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACC.W.H0 instruction multiplies each signed 32-bit word of `rs1` by the
 low halfword (H0) of the corresponding 32-bit word of `rs2` as signed, extracts
 bits [47:16] of each 48-bit product (the “high” 32 bits), and accumulates the
 result into the corresponding 32-bit element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30699,18 +30699,18 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACC.W.H1 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhacc.w.h1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACC.W.H1 is encoded in the OP-32 major opcode. It performs a packed
 multiply-high-accumulate using signed word operands from `rs1` and signed
@@ -30731,14 +30731,14 @@ halfword operands selected from `rs2` (H1 selection per word), producing packed
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACC.W.H1 instruction multiplies each signed 32-bit word of `rs1` by the
 high halfword (H1) of the corresponding 32-bit word of `rs2` as signed, extracts
 bits [47:16] of each 48-bit product, and accumulates the result into the
 corresponding 32-bit element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30756,18 +30756,18 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACCSU.W.H0 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhaccsu.w.h0 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACCSU.W.H0 is encoded in the OP-32 major opcode. It performs a packed
 multiply-high-accumulate using signed word operands from `rs1` and unsigned
@@ -30788,14 +30788,14 @@ halfword operands selected from `rs2` (H0 selection per word), producing packed
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACCSU.W.H0 instruction multiplies each signed 32-bit word of `rs1` by the
 low halfword (H0) of the corresponding 32-bit word of `rs2` treated as unsigned,
 extracts bits [47:16] of each 48-bit product, and accumulates the result into
 the corresponding 32-bit element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30813,18 +30813,18 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
 <<<
 ==== PMHACCSU.W.H1 (RV64)
 
-===== Mnemonic
+Mnemonic::
 
 pmhaccsu.w.h1 _rd_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMHACCSU.W.H1 is encoded in the OP-32 major opcode. It performs a packed
 multiply-high-accumulate using signed word operands from `rs1` and unsigned
@@ -30845,14 +30845,14 @@ halfword operands selected from `rs2` (H1 selection per word), producing packed
 ]}
 ....
 
-===== Description
+Description::
 
 The PMHACCSU.W.H1 instruction multiplies each signed 32-bit word of `rs1` by the
 high halfword (H1) of the corresponding 32-bit word of `rs2` treated as unsigned,
 extracts bits [47:16] of each 48-bit product, and accumulates the result into
 the corresponding 32-bit element of `rd`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30870,7 +30870,7 @@ d1 = din[63:32] + to_bits(48, p1)[47:16]
 X[rd] = d1 @ d0
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes `rd`.
 
@@ -30880,11 +30880,11 @@ X[rd] = d1 @ d0
 
 ==== PWMUL.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmul.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMUL.B is encoded in the widening register-pair format with packed byte
 elements (RV32 only).
@@ -30904,14 +30904,14 @@ elements (RV32 only).
 ]}
 ....
 
-===== Description
+Description::
 
 PWMUL.B (RV32 only) performs packed widening signed multiplication of four 8-bit
 byte element pairs from `rs1` and `rs2`. Each pair of signed bytes produces a
 signed 16-bit halfword product. The four halfword results are written as a
 64-bit register pair `rd_p`. If `rd_p` is 0, the result is discarded.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30934,11 +30934,11 @@ if (rd_p != 0):
 <<<
 ==== PWMULSU.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmulsu.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMULSU.B is encoded in a register-pair (rd_p) OP-IMM-32 format. It writes a 64-bit
 result into the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
@@ -30958,14 +30958,14 @@ result into the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
 ]}
 ....
 
-===== Description
+Description::
 
 The PWMULSU.B instruction performs four signed×unsigned byte multiplications
 between corresponding bytes of `rs1` and `rs2`. Each 16-bit product is packed
 into a 64-bit result, which is written to the destination register pair selected
 by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -30982,7 +30982,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * If `rd_p=0`, the result is not written (no architectural destination).
 * The destination is the register pair `{X[2*rd_p+1], X[2*rd_p]}`.
@@ -30990,11 +30990,11 @@ if (rd_p != 0):
 <<<
 ==== PWMULU.B (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmulu.b _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMULU.B is encoded in the widening register-pair format with packed byte
 elements and unsigned multiplication (RV32 only).
@@ -31014,7 +31014,7 @@ elements and unsigned multiplication (RV32 only).
 ]}
 ....
 
-===== Description
+Description::
 
 PWMULU.B (RV32 only) performs packed widening unsigned multiplication of four
 8-bit byte element pairs from `rs1` and `rs2`. Each pair of unsigned bytes
@@ -31022,7 +31022,7 @@ produces an unsigned 16-bit halfword product. The four halfword results are
 written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
 discarded.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31045,11 +31045,11 @@ if (rd_p != 0):
 <<<
 ==== PWMUL.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmul.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMUL.H is encoded in the widening register-pair format with packed halfword
 elements (RV32 only).
@@ -31069,14 +31069,14 @@ elements (RV32 only).
 ]}
 ....
 
-===== Description
+Description::
 
 PWMUL.H (RV32 only) performs packed widening signed multiplication of two 16-bit
 halfword element pairs from `rs1` and `rs2`. Each pair of signed halfwords
 produces a signed 32-bit word product. The two word results are written as a
 64-bit register pair `rd_p`. If `rd_p` is 0, the result is discarded.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31097,11 +31097,11 @@ if (rd_p != 0):
 <<<
 ==== PWMULSU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmulsu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMULSU.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It writes two 32-bit
 results into the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
@@ -31121,14 +31121,14 @@ results into the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
 ]}
 ....
 
-===== Description
+Description::
 
 The PWMULSU.H instruction multiplies each signed 16-bit halfword of `rs1` by the
 corresponding unsigned 16-bit halfword of `rs2`, producing two 32-bit products.
 The low-halfword product is written to `X[2*rd_p]` and the high-halfword product
 is written to `X[2*rd_p+1]`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31143,7 +31143,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = d1
 ----
 
-===== Notes
+Notes::
 
 * If `rd_p=0`, the result is not written.
 * The destination is the register pair `X[2*rd_p]` and `X[2*rd_p+1]`.
@@ -31151,11 +31151,11 @@ if (rd_p != 0):
 <<<
 ==== PWMULU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmulu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMULU.H is encoded in the widening register-pair format with packed halfword
 elements and unsigned multiplication (RV32 only).
@@ -31175,7 +31175,7 @@ elements and unsigned multiplication (RV32 only).
 ]}
 ....
 
-===== Description
+Description::
 
 PWMULU.H (RV32 only) performs packed widening unsigned multiplication of two
 16-bit halfword element pairs from `rs1` and `rs2`. Each pair of unsigned
@@ -31183,7 +31183,7 @@ halfwords produces an unsigned 32-bit word product. The two word results are
 written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
 discarded.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31204,11 +31204,11 @@ if (rd_p != 0):
 <<<
 ==== WMUL (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wmul _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WMUL is encoded in the widening register-pair format (RV32 only).
 
@@ -31227,14 +31227,14 @@ WMUL is encoded in the widening register-pair format (RV32 only).
 ]}
 ....
 
-===== Description
+Description::
 
 WMUL (RV32 only) performs a widening signed multiplication of the full 32-bit
 values in `rs1` and `rs2`, producing a 64-bit signed product. The result is
 written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
 discarded.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31251,11 +31251,11 @@ if (rd_p != 0):
 <<<
 ==== WMULSU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wmulsu _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WMULSU is encoded in a register-pair (rd_p) OP-IMM-32 format. It computes a 64-bit
 signed×unsigned product and writes it to the destination register pair selected
@@ -31276,13 +31276,13 @@ by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
-===== Description
+Description::
 
 The WMULSU instruction multiplies `rs1` as a signed 32-bit integer by `rs2` as an
 unsigned 32-bit integer, producing a 64-bit product. The product is written to
 the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31293,7 +31293,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = p[63:32]
 ----
 
-===== Notes
+Notes::
 
 * If `rd_p=0`, the result is not written.
 * The destination is the register pair `{X[2*rd_p+1], X[2*rd_p]}`.
@@ -31302,11 +31302,11 @@ if (rd_p != 0):
 <<<
 ==== WMULU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wmulu _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WMULU is encoded in the widening register-pair format with unsigned
 multiplication (RV32 only).
@@ -31326,14 +31326,14 @@ multiplication (RV32 only).
 ]}
 ....
 
-===== Description
+Description::
 
 WMULU (RV32 only) performs a widening unsigned multiplication of the full 32-bit
 values in `rs1` and `rs2`, producing a 64-bit unsigned product. The result is
 written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
 discarded.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31352,11 +31352,11 @@ if (rd_p != 0):
 
 ==== PWMACC.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmacc.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMACC.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an accumulating
 halfword multiply instruction.
@@ -31376,13 +31376,13 @@ halfword multiply instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PWMACC.H instruction multiplies corresponding signed 16-bit halfwords of
 `rs1` and `rs2` to form two 32-bit products, then accumulates them into the
 32-bit values held in the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31400,7 +31400,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes the destination register pair.
 * If `rd_p=0`, the instruction does not write back; the upper accumulator input is
@@ -31409,11 +31409,11 @@ if (rd_p != 0):
 <<<
 ==== PWMACCSU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmaccsu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMACCSU.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an accumulating
 signed×unsigned halfword multiply instruction.
@@ -31433,13 +31433,13 @@ signed×unsigned halfword multiply instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PWMACCSU.H instruction performs signed×unsigned halfword multiplications
 between `rs1` and `rs2`, producing two 32-bit products that are accumulated into
 the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31457,7 +31457,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes the destination register pair.
 * If `rd_p=0`, the instruction does not write back; the upper accumulator input is
@@ -31466,11 +31466,11 @@ if (rd_p != 0):
 <<<
 ==== PWMACCU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pwmaccu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PWMACCU.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an accumulating
 unsigned×unsigned halfword multiply instruction.
@@ -31490,13 +31490,13 @@ unsigned×unsigned halfword multiply instruction.
 ]}
 ....
 
-===== Description
+Description::
 
 The PWMACCU.H instruction multiplies corresponding unsigned 16-bit halfwords of
 `rs1` and `rs2` to form two 32-bit products, then accumulates them into the
 destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31514,7 +31514,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc1
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes the destination register pair.
 * If `rd_p=0`, the instruction does not write back; the upper accumulator input is
@@ -31523,11 +31523,11 @@ if (rd_p != 0):
 <<<
 ==== WMACC (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wmacc _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WMACC is encoded in the widening register-pair format with multiply-accumulate
 (RV32 only).
@@ -31547,7 +31547,7 @@ WMACC is encoded in the widening register-pair format with multiply-accumulate
 ]}
 ....
 
-===== Description
+Description::
 
 WMACC (RV32 only) performs a widening signed multiply-accumulate. It multiplies
 the full 32-bit signed values in `rs1` and `rs2`, producing a 64-bit signed
@@ -31555,7 +31555,7 @@ product, and adds the product to the existing 64-bit value in register pair
 `rd_p`. The result is written back to register pair `rd_p`. If `rd_p` is 0,
 the result is discarded.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31575,11 +31575,11 @@ if (rd_p != 0):
 <<<
 ==== WMACCSU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wmaccsu _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WMACCSU is encoded in a register-pair (rd_p) OP-IMM-32 format as an accumulating form
 of WMULSU.
@@ -31599,13 +31599,13 @@ of WMULSU.
 ]}
 ....
 
-===== Description
+Description::
 
 The WMACCSU instruction multiplies `rs1` (signed 32-bit) by `rs2` (unsigned
 32-bit) and accumulates the 64-bit product into the 64-bit accumulator stored in
 the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31619,7 +31619,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes the destination register pair.
 * If `rd_p=0`, the accumulator is treated as zero and no result is written back.
@@ -31628,11 +31628,11 @@ if (rd_p != 0):
 <<<
 ==== WMACCU (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 wmaccu _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 WMACCU is encoded in the widening register-pair format with unsigned
 multiply-accumulate (RV32 only).
@@ -31652,7 +31652,7 @@ multiply-accumulate (RV32 only).
 ]}
 ....
 
-===== Description
+Description::
 
 WMACCU (RV32 only) performs a widening unsigned multiply-accumulate. It
 multiplies the full 32-bit unsigned values in `rs1` and `rs2`, producing a
@@ -31660,7 +31660,7 @@ multiplies the full 32-bit unsigned values in `rs1` and `rs2`, producing a
 register pair `rd_p`. The result is written back to register pair `rd_p`. If
 `rd_p` is 0, the result is discarded.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31682,11 +31682,11 @@ if (rd_p != 0):
 
 ==== PMQWACC.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmqwacc.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQWACC.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It uses `rd_p` to
 select the destination register pair `{X[2*rd_p+1], X[2*rd_p]}`.
@@ -31706,7 +31706,7 @@ select the destination register pair `{X[2*rd_p+1], X[2*rd_p]}`.
 ]}
 ....
 
-===== Description
+Description::
 
 The PMQWACC.H instruction multiplies the two signed 16-bit halfwords of `rs1`
 and `rs2`. For each halfword, it extracts bits [46:15] of the signed 47-bit
@@ -31714,7 +31714,7 @@ product (equivalent to an arithmetic right shift by 15) and accumulates the
 32-bit extracted value into the corresponding 32-bit lane of a 64-bit
 accumulator held in the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31737,7 +31737,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Notes
+Notes::
 
 * If `rd_p=0`, the accumulator is treated as zero and the result is not written
   back (i.e., the instruction has no architectural destination).
@@ -31746,11 +31746,11 @@ if (rd_p != 0):
 <<<
 ==== PMQRWACC.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pmqrwacc.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PMQRWACC.H is encoded in the same register-pair (rd_p) OP-IMM-32 format as PMQWACC.H,
 but uses the rounded variant.
@@ -31770,13 +31770,13 @@ but uses the rounded variant.
 ]}
 ....
 
-===== Description
+Description::
 
 PMQRWACC.H is the rounded form of PMQWACC.H. It adds a rounding bias of 2^14 to
 each halfword product before extracting bits [46:15], then accumulates the
 result into the 64-bit destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31797,7 +31797,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Notes
+Notes::
 
 * If `rd_p=0`, the accumulator is treated as zero and the result is not written
   back.
@@ -31806,11 +31806,11 @@ if (rd_p != 0):
 <<<
 ==== MQWACC (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mqwacc _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQWACC is encoded in a register-pair (rd_p) OP-IMM-32 format and accumulates into the
 64-bit destination register pair selected by `rd_p`.
@@ -31830,14 +31830,14 @@ MQWACC is encoded in a register-pair (rd_p) OP-IMM-32 format and accumulates int
 ]}
 ....
 
-===== Description
+Description::
 
 The MQWACC instruction multiplies `rs1` and `rs2` as signed 32-bit integers,
 takes the product shifted right by 31 (i.e., bits [94:31] of the sign-extended
 wide product), and accumulates the 64-bit term into the destination register
 pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31855,7 +31855,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Notes
+Notes::
 
 * If `rd_p=0`, the accumulator is treated as zero and the result is not written
   back.
@@ -31864,11 +31864,11 @@ if (rd_p != 0):
 <<<
 ==== MQRWACC (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 mqrwacc _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 MQRWACC is encoded in the same register-pair (rd_p) OP-IMM-32 format as MQWACC, but
 uses the rounded variant.
@@ -31888,13 +31888,13 @@ uses the rounded variant.
 ]}
 ....
 
-===== Description
+Description::
 
 MQRWACC is the rounded form of MQWACC. It adds a rounding bias of 2^30 before
 taking the product shifted right by 31, then accumulates the 64-bit term into
 the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31912,7 +31912,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Notes
+Notes::
 
 * If `rd_p=0`, the accumulator is treated as zero and the result is not written
   back.
@@ -31924,11 +31924,11 @@ if (rd_p != 0):
 
 ==== PM2WADD.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2wadd.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WADD.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It produces a 64-bit
 sum of two halfword products and writes it to the register pair
@@ -31949,13 +31949,13 @@ sum of two halfword products and writes it to the register pair
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WADD.H multiplies the two signed 16-bit halfwords of `rs1` and `rs2`
 (halfword0×halfword0 and halfword1×halfword1), sums the two 64-bit products, and
 writes the 64-bit result to the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -31971,7 +31971,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = d[63:32]
 ----
 
-===== Notes
+Notes::
 
 * If `rd_p=0`, no result is written.
 * The destination is the register pair `{X[2*rd_p+1], X[2*rd_p]}`.
@@ -31979,11 +31979,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WADDSU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2waddsu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WADDSU.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It performs
 signed×unsigned halfword multiplications and writes a 64-bit sum to the register
@@ -32004,13 +32004,13 @@ pair selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WADDSU.H multiplies each signed 16-bit halfword of `rs1` by the corresponding
 unsigned 16-bit halfword of `rs2`, sums the two 64-bit products, and writes the
 64-bit result to the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32030,11 +32030,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WADDASU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2waddasu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WADDASU.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an accumulating
 form of PM2WADDSU.H.
@@ -32054,13 +32054,13 @@ form of PM2WADDSU.H.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WADDASU.H multiplies corresponding halfwords of `rs1` (signed) and `rs2`
 (unsigned), sums the two 64-bit products, and accumulates the sum into the 64-bit
 accumulator held in the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32079,7 +32079,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes the destination register pair.
 * If `rd_p=0`, the accumulator is treated as zero and no result is written back.
@@ -32087,11 +32087,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WADDU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2waddu.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WADDU.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It performs
 unsigned×unsigned halfword multiplications and writes a 64-bit sum to the
@@ -32112,13 +32112,13 @@ register pair selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WADDU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and `rs2`,
 sums the two 64-bit products, and writes the 64-bit result to the destination
 register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32138,11 +32138,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WADDAU.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2waddau.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WADDAU.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an accumulating
 form of PM2WADDU.H.
@@ -32162,13 +32162,13 @@ form of PM2WADDU.H.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WADDAU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and
 `rs2`, sums the two 64-bit products, and accumulates the sum into the 64-bit
 accumulator held in the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32187,7 +32187,7 @@ if (rd_p != 0):
     X[2*rd_p+1] = acc[63:32]
 ----
 
-===== Notes
+Notes::
 
 * This instruction reads and writes the destination register pair.
 * If `rd_p=0`, the accumulator is treated as zero and no result is written back.
@@ -32195,11 +32195,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WADD.HX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2wadd.hx _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WADD.HX is encoded in a register-pair (rd_p) OP-IMM-32 format. It uses cross
 halfword products (h0×h1 and h1×h0) and writes a 64-bit sum to the register pair
@@ -32220,14 +32220,14 @@ selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WADD.HX multiplies the low halfword of `rs1` by the high halfword of `rs2` and
 the high halfword of `rs1` by the low halfword of `rs2` (both signed), sums the
 two 64-bit products, and writes the 64-bit result to the destination register
 pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32247,11 +32247,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WSUB.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2wsub.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WSUB.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It subtracts the
 high-halfword product from the low-halfword product and writes a 64-bit result to
@@ -32272,13 +32272,13 @@ the register pair selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WSUB.H multiplies corresponding signed halfwords of `rs1` and `rs2` and
 computes (low×low) minus (high×high), writing the 64-bit result to the register
 pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32298,11 +32298,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WSUB.HX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2wsub.hx _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WSUB.HX is encoded in a register-pair (rd_p) OP-IMM-32 format. It uses cross
 halfword products (h0×h1 and h1×h0) and writes the 64-bit difference to the
@@ -32323,13 +32323,13 @@ register pair selected by `rd_p` when `rd_p != 0`.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WSUB.HX multiplies cross halfword pairs and computes (h0 of `rs1` × h1 of
 `rs2`) minus (h1 of `rs1` × h0 of `rs2`), writing the 64-bit result to the
 destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32350,11 +32350,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WADDA.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2wadda.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WADDA.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an
 accumulating form of PM2WADD.H.
@@ -32374,14 +32374,14 @@ accumulating form of PM2WADD.H.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WADDA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`
 (halfword0*halfword0 and halfword1*halfword1), sums the two 64-bit products, and
 accumulates the sum into the 64-bit accumulator held in the destination register
 pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32405,11 +32405,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WADDA.HX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2wadda.hx _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WADDA.HX is encoded in a register-pair (rd_p) OP-IMM-32 format as an
 accumulating cross-halfword form of PM2WADD.HX.
@@ -32429,14 +32429,14 @@ accumulating cross-halfword form of PM2WADD.HX.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WADDA.HX multiplies cross halfword pairs of `rs1` and `rs2` (low halfword of
 `rs1` by high halfword of `rs2`, and high halfword of `rs1` by low halfword of
 `rs2`), both signed, sums the two 64-bit products, and accumulates the sum into
 the 64-bit accumulator held in the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32460,11 +32460,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WSUBA.H (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2wsuba.h _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WSUBA.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an
 accumulating form of PM2WSUB.H.
@@ -32484,13 +32484,13 @@ accumulating form of PM2WSUB.H.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WSUBA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`,
 computes (low*low) minus (high*high), and accumulates the 64-bit difference into
 the accumulator held in the destination register pair selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----
@@ -32514,11 +32514,11 @@ if (rd_p != 0):
 <<<
 ==== PM2WSUBA.HX (RV32)
 
-===== Mnemonic
+Mnemonic::
 
 pm2wsuba.hx _rd_p_, _rs1_, _rs2_
 
-===== Encoding
+Encoding::
 
 PM2WSUBA.HX is encoded in a register-pair (rd_p) OP-IMM-32 format as an
 accumulating cross-halfword form of PM2WSUB.HX.
@@ -32538,7 +32538,7 @@ accumulating cross-halfword form of PM2WSUB.HX.
 ]}
 ....
 
-===== Description
+Description::
 
 PM2WSUBA.HX multiplies cross halfword pairs of `rs1` and `rs2` (low halfword of
 `rs1` by high halfword of `rs2`, and high halfword of `rs1` by low halfword of
@@ -32546,7 +32546,7 @@ PM2WSUBA.HX multiplies cross halfword pairs of `rs1` and `rs2` (low halfword of
 accumulates the result into the accumulator held in the destination register pair
 selected by `rd_p`.
 
-===== Operation
+Operation::
 
 [source,pseudocode]
 ----


### PR DESCRIPTION
This matches what is done in the ISA manual for bitmanip and scalar crypto.