### PR TITLE
Fix typo in PSSHA.HS to PSSHL.HS

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -13508,7 +13508,7 @@ psshl.hs _rd_, _rs1_, _rs2_
 
 ===== Encoding
 
-PSSHA.HS is encoded in the OP-IMM-32 major opcode.
+PSSHL.HS is encoded in the OP-IMM-32 major opcode.
 
 [wavedrom, ,svg]
 ....


### PR DESCRIPTION
Looks like `PSSHL.HS` was spelled `PSSHA.HS` in its description section.