### PR TITLE
Reorder instruction descriptions to group similar operations together.

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -861,95 +861,6 @@ X[rd] = d
 
 
 <<<
-==== PLUI.H
-
-Mnemonic::
-
-plui.h _rd_, _simm10_
-
-Encoding::
-
-PLUI.H is encoded in the OP-IMM-32 major opcode with a 10-bit immediate
-loaded into the upper bits of each halfword element.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 10, name: 'imm[6|15:7]' },
-    { bits: 2, name: 0x0 },
-    { bits: 5, name: 0x1e, attr: ['PLUI.H'] },
-]}
-....
-
-Description::
-
-PLUI.H (Packed Load Upper Immediate, Halfword) loads a 10-bit signed immediate
-into the most-significant 10 bits of each 16-bit halfword element, with the
-lower 6 bits set to zero, and replicates the result into every halfword
-element of `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-imm_h = sign_extend(16, imm[9:0] << 6)
-
-for i = 0 .. (XLEN/16 - 1):
-    d[(16*i+15):(16*i)] = imm_h
-
-X[rd] = d
-----
-
-
-<<<
-==== PLUI.W (RV64)
-
-Mnemonic::
-
-plui.w _rd_, _simm10_
-
-Encoding::
-
-PLUI.W is encoded in the OP-IMM-32 major opcode with a 10-bit immediate
-loaded into the upper bits of each word element. This instruction exists
-only for RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 10, name: 'imm[22|31:23]' },
-    { bits: 2, name: 0x1 },
-    { bits: 5, name: 0x1e, attr: ['PLUI.W'] },
-]}
-....
-
-Description::
-
-PLUI.W (Packed Load Upper Immediate, Word) loads a 10-bit signed immediate
-into the most-significant 10 bits of each 32-bit word element, with the
-lower 22 bits set to zero, and replicates the result into every word element
-of `rd`. This instruction is available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-imm_w = sign_extend(32, imm[9:0] << 22)
-
-for i = 0 .. (XLEN/32 - 1):
-    d[(32*i+31):(32*i)] = imm_w
-
-X[rd] = d
-----
-
-
-<<<
 ==== PLI.DB (RV32)
 
 Mnemonic::
@@ -1043,6 +954,95 @@ for i = 0 .. 3:
 if (rd_p != 0):
     X[2*rd_p] = d[31:0]
     X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
+==== PLUI.H
+
+Mnemonic::
+
+plui.h _rd_, _simm10_
+
+Encoding::
+
+PLUI.H is encoded in the OP-IMM-32 major opcode with a 10-bit immediate
+loaded into the upper bits of each halfword element.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 10, name: 'imm[6|15:7]' },
+    { bits: 2, name: 0x0 },
+    { bits: 5, name: 0x1e, attr: ['PLUI.H'] },
+]}
+....
+
+Description::
+
+PLUI.H (Packed Load Upper Immediate, Halfword) loads a 10-bit signed immediate
+into the most-significant 10 bits of each 16-bit halfword element, with the
+lower 6 bits set to zero, and replicates the result into every halfword
+element of `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+imm_h = sign_extend(16, imm[9:0] << 6)
+
+for i = 0 .. (XLEN/16 - 1):
+    d[(16*i+15):(16*i)] = imm_h
+
+X[rd] = d
+----
+
+
+<<<
+==== PLUI.W (RV64)
+
+Mnemonic::
+
+plui.w _rd_, _simm10_
+
+Encoding::
+
+PLUI.W is encoded in the OP-IMM-32 major opcode with a 10-bit immediate
+loaded into the upper bits of each word element. This instruction exists
+only for RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 10, name: 'imm[22|31:23]' },
+    { bits: 2, name: 0x1 },
+    { bits: 5, name: 0x1e, attr: ['PLUI.W'] },
+]}
+....
+
+Description::
+
+PLUI.W (Packed Load Upper Immediate, Word) loads a 10-bit signed immediate
+into the most-significant 10 bits of each 32-bit word element, with the
+lower 22 bits set to zero, and replicates the result into every word element
+of `rd`. This instruction is available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+imm_w = sign_extend(32, imm[9:0] << 22)
+
+for i = 0 .. (XLEN/32 - 1):
+    d[(32*i+31):(32*i)] = imm_w
+
+X[rd] = d
 ----
 
 
@@ -1238,150 +1238,6 @@ X[rd] = d
 
 
 <<<
-==== PADD.BS
-
-Mnemonic::
-
-padd.bs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PADD.BS is encoded using the OP-IMM-32 major opcode with a scalar second source
-operand and packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['PADD.BS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PADD.BS instruction adds the least-significant byte of `rs2` to each packed
-8-bit element of `rs1`, producing a packed byte result in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-s2_b0 = X[rs2][7:0]          // least-significant byte of X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    s1_b = s1[(8*i+7) : (8*i)]
-    d[(8*i+7) : (8*i)] = s1_b + s2_b0
-
-X[rd] = d
-----
-
-Notes::
-
-* Each 8-bit element addition wraps modulo 2^8^.
-* The scalar operand is taken only from bits [7:0] of `rs2`; higher bits are ignored.
-
-<<<
-==== PADD.HS
-
-Mnemonic::
-
-padd.hs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PADD.HS is encoded in the OP-IMM-32 major opcode with a scalar second source
-operand and packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['PADD.HS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PADD.HS instruction adds the least-significant halfword of `rs2` to each
-packed 16-bit element of `rs1`, producing a packed halfword result in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-s2_h0 = X[rs2][15:0]
-
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15) : (16*i)]
-    d[(16*i+15) : (16*i)] = h + s2_h0
-
-X[rd] = d
-----
-
-
-<<<
-==== PADD.WS (RV64)
-
-Mnemonic::
-
-padd.ws _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PADD.WS is encoded in the OP-IMM-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x1, attr: ['PADD.WS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PADD.WS instruction adds the least-significant word of `rs2` to each packed
-32-bit element of `rs1`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-s2_w0 = X[rs2][31:0]
-
-d[31:0]  = s1[31:0]  + s2_w0
-d[63:32] = s1[63:32] + s2_w0
-
-X[rd] = d
-----
-
-
-
-<<<
 ==== PADD.DB (RV32)
 
 Mnemonic::
@@ -1547,6 +1403,150 @@ if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
 ----
+
+
+<<<
+==== PADD.BS
+
+Mnemonic::
+
+padd.bs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PADD.BS is encoded using the OP-IMM-32 major opcode with a scalar second source
+operand and packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x1, attr: ['PADD.BS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PADD.BS instruction adds the least-significant byte of `rs2` to each packed
+8-bit element of `rs1`, producing a packed byte result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+s2_b0 = X[rs2][7:0]          // least-significant byte of X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    s1_b = s1[(8*i+7) : (8*i)]
+    d[(8*i+7) : (8*i)] = s1_b + s2_b0
+
+X[rd] = d
+----
+
+Notes::
+
+* Each 8-bit element addition wraps modulo 2^8^.
+* The scalar operand is taken only from bits [7:0] of `rs2`; higher bits are ignored.
+
+<<<
+==== PADD.HS
+
+Mnemonic::
+
+padd.hs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PADD.HS is encoded in the OP-IMM-32 major opcode with a scalar second source
+operand and packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x1, attr: ['PADD.HS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PADD.HS instruction adds the least-significant halfword of `rs2` to each
+packed 16-bit element of `rs1`, producing a packed halfword result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+s2_h0 = X[rs2][15:0]
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15) : (16*i)]
+    d[(16*i+15) : (16*i)] = h + s2_h0
+
+X[rd] = d
+----
+
+
+<<<
+==== PADD.WS (RV64)
+
+Mnemonic::
+
+padd.ws _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PADD.WS is encoded in the OP-IMM-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x1, attr: ['PADD.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PADD.WS instruction adds the least-significant word of `rs2` to each packed
+32-bit element of `rs1`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+s2_w0 = X[rs2][31:0]
+
+d[31:0]  = s1[31:0]  + s2_w0
+d[63:32] = s1[63:32] + s2_w0
+
+X[rd] = d
+----
+
 
 
 <<<
@@ -2031,6 +2031,58 @@ if (rd_p != 0):
 === Saturating Add
 
 
+==== SADD (RV32)
+
+Mnemonic::
+
+sadd _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SADD is encoded in the OP-32 major opcode as a scalar XLEN-wide signed
+saturating addition. This instruction is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['SADD'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+SADD performs signed saturating addition of the full XLEN-wide values in `rs1`
+and `rs2`, writing the result to `rd`. The result is clamped to the range
+[-(2^(XLEN-1)), 2^(XLEN-1)-1]. Corresponds to KADDW in the earlier P extension
+draft.
+
+Operation::
+
+[source,pseudocode]
+----
+a = signed(X[rs1])
+b = signed(X[rs2])
+result = a + b
+
+if result > (2^(XLEN-1) - 1):
+    d = to_bits(XLEN, 2^(XLEN-1) - 1)
+else if result < -(2^(XLEN-1)):
+    d = to_bits(XLEN, -(2^(XLEN-1)))
+else:
+    d = to_bits(XLEN, result)
+
+X[rd] = d
+----
+
+
+<<<
 ==== PSADD.B
 
 Mnemonic::
@@ -2188,263 +2240,6 @@ for i = 0 .. 1:
         d[(32*i+31):(32*i)] = to_bits(32, -2147483648)
     else:
         d[(32*i+31):(32*i)] = to_bits(32, result)
-
-X[rd] = d
-----
-
-
-<<<
-==== PSADDU.B
-
-Mnemonic::
-
-psaddu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSADDU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x6, attr: ['PSADDU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSADDU.B performs unsigned saturating addition on packed 8-bit byte elements of
-`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
-the range [0, 255]. Corresponds to UKADD8 in the earlier P extension draft.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    result = a + b
-    if result > 255:
-        d[(8*i+7):(8*i)] = to_bits(8, 255)
-    else:
-        d[(8*i+7):(8*i)] = to_bits(8, result)
-
-X[rd] = d
-----
-
-
-<<<
-==== PSADDU.H
-
-Mnemonic::
-
-psaddu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x6, attr: ['PSADDU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSADDU.H performs unsigned saturating addition on packed 16-bit halfword
-elements of `rs1` and `rs2`, writing the results to `rd`. Each element result is
-clamped to the range [0, 65535]. Corresponds to UKADD16 in the earlier P
-extension draft.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1[(16*i+15):(16*i)])
-    b = unsigned(s2[(16*i+15):(16*i)])
-    result = a + b
-    if result > 65535:
-        d[(16*i+15):(16*i)] = to_bits(16, 65535)
-    else:
-        d[(16*i+15):(16*i)] = to_bits(16, result)
-
-X[rd] = d
-----
-
-
-<<<
-==== PSADDU.W (RV64)
-
-Mnemonic::
-
-psaddu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSADDU.W is encoded in the OP-32 major opcode with packed word elements.
-Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x6, attr: ['PSADDU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSADDU.W performs unsigned saturating addition on packed 32-bit word elements of
-`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
-the range [0, 2^32^-1]. Corresponds to UKADD32 in the earlier P extension draft.
-Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Two packed 32-bit unsigned saturating additions
-for i = 0 .. 1:
-    a = unsigned(s1[(32*i+31):(32*i)])
-    b = unsigned(s2[(32*i+31):(32*i)])
-    result = a + b
-    if result > 4294967295:
-        d[(32*i+31):(32*i)] = to_bits(32, 4294967295)
-    else:
-        d[(32*i+31):(32*i)] = to_bits(32, result)
-
-X[rd] = d
-----
-
-
-<<<
-==== SADD (RV32)
-
-Mnemonic::
-
-sadd _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SADD is encoded in the OP-32 major opcode as a scalar XLEN-wide signed
-saturating addition. This instruction is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['SADD'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-SADD performs signed saturating addition of the full XLEN-wide values in `rs1`
-and `rs2`, writing the result to `rd`. The result is clamped to the range
-[-(2^(XLEN-1)), 2^(XLEN-1)-1]. Corresponds to KADDW in the earlier P extension
-draft.
-
-Operation::
-
-[source,pseudocode]
-----
-a = signed(X[rs1])
-b = signed(X[rs2])
-result = a + b
-
-if result > (2^(XLEN-1) - 1):
-    d = to_bits(XLEN, 2^(XLEN-1) - 1)
-else if result < -(2^(XLEN-1)):
-    d = to_bits(XLEN, -(2^(XLEN-1)))
-else:
-    d = to_bits(XLEN, result)
-
-X[rd] = d
-----
-
-
-<<<
-==== SADDU (RV32)
-
-Mnemonic::
-
-saddu _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SADDU is encoded in the OP-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x6, attr: ['SADDU'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-SADDU performs unsigned saturating addition of the full XLEN-wide values in
-`rs1` and `rs2`, writing the result to `rd`. The result is clamped to the range
-[0, 2^XLEN-1]. Corresponds to UKADDW in the earlier P extension draft.
-
-Operation::
-
-[source,pseudocode]
-----
-a = unsigned(X[rs1])
-b = unsigned(X[rs2])
-result = a + b
-
-if result > (2^XLEN - 1):
-    d = to_bits(XLEN, 2^XLEN - 1)
-else:
-    d = to_bits(XLEN, result)
 
 X[rd] = d
 ----
@@ -2640,6 +2435,211 @@ if (rd_p != 0):
 
 
 <<<
+==== SADDU (RV32)
+
+Mnemonic::
+
+saddu _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SADDU is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['SADDU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+SADDU performs unsigned saturating addition of the full XLEN-wide values in
+`rs1` and `rs2`, writing the result to `rd`. The result is clamped to the range
+[0, 2^XLEN-1]. Corresponds to UKADDW in the earlier P extension draft.
+
+Operation::
+
+[source,pseudocode]
+----
+a = unsigned(X[rs1])
+b = unsigned(X[rs2])
+result = a + b
+
+if result > (2^XLEN - 1):
+    d = to_bits(XLEN, 2^XLEN - 1)
+else:
+    d = to_bits(XLEN, result)
+
+X[rd] = d
+----
+
+
+<<<
+==== PSADDU.B
+
+Mnemonic::
+
+psaddu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSADDU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSADDU.B performs unsigned saturating addition on packed 8-bit byte elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [0, 255]. Corresponds to UKADD8 in the earlier P extension draft.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    result = a + b
+    if result > 255:
+        d[(8*i+7):(8*i)] = to_bits(8, 255)
+    else:
+        d[(8*i+7):(8*i)] = to_bits(8, result)
+
+X[rd] = d
+----
+
+
+<<<
+==== PSADDU.H
+
+Mnemonic::
+
+psaddu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSADDU.H performs unsigned saturating addition on packed 16-bit halfword
+elements of `rs1` and `rs2`, writing the results to `rd`. Each element result is
+clamped to the range [0, 65535]. Corresponds to UKADD16 in the earlier P
+extension draft.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    result = a + b
+    if result > 65535:
+        d[(16*i+15):(16*i)] = to_bits(16, 65535)
+    else:
+        d[(16*i+15):(16*i)] = to_bits(16, result)
+
+X[rd] = d
+----
+
+
+<<<
+==== PSADDU.W (RV64)
+
+Mnemonic::
+
+psaddu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSADDU.W is encoded in the OP-32 major opcode with packed word elements.
+Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PSADDU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSADDU.W performs unsigned saturating addition on packed 32-bit word elements of
+`rs1` and `rs2`, writing the results to `rd`. Each element result is clamped to
+the range [0, 2^32^-1]. Corresponds to UKADD32 in the earlier P extension draft.
+Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Two packed 32-bit unsigned saturating additions
+for i = 0 .. 1:
+    a = unsigned(s1[(32*i+31):(32*i)])
+    b = unsigned(s2[(32*i+31):(32*i)])
+    result = a + b
+    if result > 4294967295:
+        d[(32*i+31):(32*i)] = to_bits(32, 4294967295)
+    else:
+        d[(32*i+31):(32*i)] = to_bits(32, result)
+
+X[rd] = d
+----
+
+
+<<<
 ==== PSADDU.DB (RV32)
 
 Mnemonic::
@@ -2822,6 +2822,57 @@ if (rd_p != 0):
 === Saturating Subtract
 
 
+==== SSUB (RV32)
+
+Mnemonic::
+
+ssub _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SSUB is encoded in the OP-32 major opcode. On RV32 it operates on a single
+XLEN-wide (32-bit) value; on RV64 it is the PSSUB.W instruction.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['SSUB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+SSUB performs signed saturating subtraction of `rs2` from `rs1`, writing the
+result to `rd`. The result is clamped to the range [-(2^(XLEN-1)),
+2^(XLEN-1)-1]. On RV32 this is the XLEN-wide scalar form; on RV64 this
+encoding is used by PSSUB.W.
+
+Operation::
+
+[source,pseudocode]
+----
+a = signed(X[rs1])
+b = signed(X[rs2])
+res = a - b
+
+if res > 2^(XLEN-1) - 1:
+    res = 2^(XLEN-1) - 1
+else if res < -(2^(XLEN-1)):
+    res = -(2^(XLEN-1))
+
+X[rd] = res[XLEN-1:0]
+----
+
+
+<<<
+<<<
 ==== PSSUB.B
 
 Mnemonic::
@@ -2984,260 +3035,6 @@ else if res_hi < -(2^31):
 d[63:32] = res_hi[31:0]
 
 X[rd] = d
-----
-
-
-<<<
-==== PSSUBU.B
-
-Mnemonic::
-
-pssubu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSUBU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xe, attr: ['PSSUBU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSSUBU.B performs unsigned saturating subtraction on corresponding packed
-8-bit byte elements of `rs1` and `rs2`, writing the results to `rd`. Each
-element result is clamped to the range [0, 2^8^-1].
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    res = a - b
-    if res < 0:
-        res = 0
-    d[(8*i+7):(8*i)] = res[7:0]
-
-X[rd] = d
-----
-
-
-<<<
-==== PSSUBU.H
-
-Mnemonic::
-
-pssubu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xe, attr: ['PSSUBU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSSUBU.H performs unsigned saturating subtraction on corresponding packed
-16-bit halfword elements of `rs1` and `rs2`, writing the results to `rd`.
-Each element result is clamped to the range [0, 2^16^-1].
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1[(16*i+15):(16*i)])
-    b = unsigned(s2[(16*i+15):(16*i)])
-    res = a - b
-    if res < 0:
-        res = 0
-    d[(16*i+15):(16*i)] = res[15:0]
-
-X[rd] = d
-----
-
-
-<<<
-==== PSSUBU.W (RV64)
-
-Mnemonic::
-
-pssubu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xe, attr: ['PSSUBU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSSUBU.W performs unsigned saturating subtraction on corresponding packed
-32-bit word elements of `rs1` and `rs2`, writing the results to `rd`. Each
-element result is clamped to the range [0, 2^32^-1]. Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Lower 32-bit element
-a_lo = unsigned(s1[31:0])
-b_lo = unsigned(s2[31:0])
-res_lo = a_lo - b_lo
-if res_lo < 0:
-    res_lo = 0
-d[31:0] = res_lo[31:0]
-
-// Upper 32-bit element
-a_hi = unsigned(s1[63:32])
-b_hi = unsigned(s2[63:32])
-res_hi = a_hi - b_hi
-if res_hi < 0:
-    res_hi = 0
-d[63:32] = res_hi[31:0]
-
-X[rd] = d
-----
-
-
-<<<
-==== SSUB (RV32)
-
-Mnemonic::
-
-ssub _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SSUB is encoded in the OP-32 major opcode. On RV32 it operates on a single
-XLEN-wide (32-bit) value; on RV64 it is the PSSUB.W instruction.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xa, attr: ['SSUB'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-SSUB performs signed saturating subtraction of `rs2` from `rs1`, writing the
-result to `rd`. The result is clamped to the range [-(2^(XLEN-1)),
-2^(XLEN-1)-1]. On RV32 this is the XLEN-wide scalar form; on RV64 this
-encoding is used by PSSUB.W.
-
-Operation::
-
-[source,pseudocode]
-----
-a = signed(X[rs1])
-b = signed(X[rs2])
-res = a - b
-
-if res > 2^(XLEN-1) - 1:
-    res = 2^(XLEN-1) - 1
-else if res < -(2^(XLEN-1)):
-    res = -(2^(XLEN-1))
-
-X[rd] = res[XLEN-1:0]
-----
-
-
-<<<
-==== SSUBU (RV32)
-
-Mnemonic::
-
-ssubu _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SSUBU is encoded in the OP-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xe, attr: ['SSUBU'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-SSUBU performs unsigned saturating subtraction of `rs2` from `rs1`, writing
-the result to `rd`. The result is clamped to the range [0, 2^XLEN-1]. This
-instruction is available only on RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-a = unsigned(X[rs1])
-b = unsigned(X[rs2])
-res = a - b
-
-if res < 0:
-    res = 0
-
-X[rd] = res[XLEN-1:0]
 ----
 
 
@@ -3425,6 +3222,210 @@ if (rd_p != 0):
 
 
 <<<
+==== SSUBU (RV32)
+
+Mnemonic::
+
+ssubu _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SSUBU is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['SSUBU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+SSUBU performs unsigned saturating subtraction of `rs2` from `rs1`, writing
+the result to `rd`. The result is clamped to the range [0, 2^XLEN-1]. This
+instruction is available only on RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+a = unsigned(X[rs1])
+b = unsigned(X[rs2])
+res = a - b
+
+if res < 0:
+    res = 0
+
+X[rd] = res[XLEN-1:0]
+----
+
+
+<<<
+==== PSSUBU.B
+
+Mnemonic::
+
+pssubu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSUBU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSSUBU.B performs unsigned saturating subtraction on corresponding packed
+8-bit byte elements of `rs1` and `rs2`, writing the results to `rd`. Each
+element result is clamped to the range [0, 2^8^-1].
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    res = a - b
+    if res < 0:
+        res = 0
+    d[(8*i+7):(8*i)] = res[7:0]
+
+X[rd] = d
+----
+
+
+<<<
+==== PSSUBU.H
+
+Mnemonic::
+
+pssubu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSSUBU.H performs unsigned saturating subtraction on corresponding packed
+16-bit halfword elements of `rs1` and `rs2`, writing the results to `rd`.
+Each element result is clamped to the range [0, 2^16^-1].
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    res = a - b
+    if res < 0:
+        res = 0
+    d[(16*i+15):(16*i)] = res[15:0]
+
+X[rd] = d
+----
+
+
+<<<
+==== PSSUBU.W (RV64)
+
+Mnemonic::
+
+pssubu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['PSSUBU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSSUBU.W performs unsigned saturating subtraction on corresponding packed
+32-bit word elements of `rs1` and `rs2`, writing the results to `rd`. Each
+element result is clamped to the range [0, 2^32^-1]. Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Lower 32-bit element
+a_lo = unsigned(s1[31:0])
+b_lo = unsigned(s2[31:0])
+res_lo = a_lo - b_lo
+if res_lo < 0:
+    res_lo = 0
+d[31:0] = res_lo[31:0]
+
+// Upper 32-bit element
+a_hi = unsigned(s1[63:32])
+b_hi = unsigned(s2[63:32])
+res_hi = a_hi - b_hi
+if res_hi < 0:
+    res_hi = 0
+d[63:32] = res_hi[31:0]
+
+X[rd] = d
+----
+
+
+<<<
 ==== PSSUBU.DB (RV32)
 
 Mnemonic::
@@ -3605,6 +3606,50 @@ if (rd_p != 0):
 === Averaging Add
 
 
+==== AADD (RV32)
+
+Mnemonic::
+
+aadd _rd_, _rs1_, _rs2_
+
+Encoding::
+
+AADD is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x3, attr: ['AADD'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+AADD performs a signed averaging addition on a single XLEN-wide value. It adds
+the signed values in `rs1` and `rs2` at full precision (33 bits), then shifts
+the result right by 1 (toward negative infinity), and writes the lower 32 bits
+to `rd`. Available only in RV32; the RV64 counterpart is PAADD.W.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = signed(X[rs1])
+s2 = signed(X[rs2])
+
+sum = s1 + s2
+X[rd] = to_bits(32, sum >> 1)
+----
+
+
+<<<
 ==== PAADD.B
 
 Mnemonic::
@@ -3754,246 +3799,6 @@ sum_hi = a_hi + b_hi
 d[63:32] = to_bits(32, sum_hi >> 1)
 
 X[rd] = d
-----
-
-
-<<<
-==== PAADDU.B
-
-Mnemonic::
-
-paaddu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PAADDU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x7, attr: ['PAADDU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PAADDU.B performs an unsigned averaging addition on packed 8-bit elements. For
-each byte lane, it adds the unsigned elements from `rs1` and `rs2` at full
-precision (9 bits), then shifts the result right by 1, and writes the lower
-8 bits to the corresponding byte of `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    sum = a + b
-    d[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
-
-X[rd] = d
-----
-
-
-<<<
-==== PAADDU.H
-
-Mnemonic::
-
-paaddu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PAADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x7, attr: ['PAADDU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PAADDU.H performs an unsigned averaging addition on packed 16-bit halfword
-elements. For each halfword lane, it adds the unsigned elements from `rs1` and
-`rs2` at full precision (17 bits), then shifts the result right by 1, and writes
-the lower 16 bits to the corresponding halfword of `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1[(16*i+15):(16*i)])
-    b = unsigned(s2[(16*i+15):(16*i)])
-    sum = a + b
-    d[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
-
-X[rd] = d
-----
-
-
-<<<
-==== PAADDU.W (RV64)
-
-Mnemonic::
-
-paaddu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PAADDU.W is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x7, attr: ['PAADDU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PAADDU.W performs an unsigned averaging addition on packed 32-bit word elements.
-For each word lane, it adds the unsigned elements from `rs1` and `rs2` at full
-precision (33 bits), then shifts the result right by 1, and writes the lower
-32 bits to the corresponding word of `rd`. Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Unsigned averaging add on packed 32-bit elements
-a_lo = unsigned(s1[31:0])
-b_lo = unsigned(s2[31:0])
-sum_lo = a_lo + b_lo
-d[31:0] = to_bits(32, sum_lo >> 1)
-
-a_hi = unsigned(s1[63:32])
-b_hi = unsigned(s2[63:32])
-sum_hi = a_hi + b_hi
-d[63:32] = to_bits(32, sum_hi >> 1)
-
-X[rd] = d
-----
-
-
-<<<
-==== AADD (RV32)
-
-Mnemonic::
-
-aadd _rd_, _rs1_, _rs2_
-
-Encoding::
-
-AADD is encoded in the OP-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x3, attr: ['AADD'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-AADD performs a signed averaging addition on a single XLEN-wide value. It adds
-the signed values in `rs1` and `rs2` at full precision (33 bits), then shifts
-the result right by 1 (toward negative infinity), and writes the lower 32 bits
-to `rd`. Available only in RV32; the RV64 counterpart is PAADD.W.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = signed(X[rs1])
-s2 = signed(X[rs2])
-
-sum = s1 + s2
-X[rd] = to_bits(32, sum >> 1)
-----
-
-
-<<<
-==== AADDU (RV32)
-
-Mnemonic::
-
-aaddu _rd_, _rs1_, _rs2_
-
-Encoding::
-
-AADDU is encoded in the OP-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x7, attr: ['AADDU'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-AADDU performs an unsigned averaging addition on a single XLEN-wide value. It
-adds the unsigned values in `rs1` and `rs2` at full precision (33 bits), then
-shifts the result right by 1, and writes the lower 32 bits to `rd`. Available
-only in RV32; the RV64 counterpart is PAADDU.W.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = unsigned(X[rs1])
-s2 = unsigned(X[rs2])
-
-sum = s1 + s2
-X[rd] = to_bits(32, sum >> 1)
 ----
 
 
@@ -4166,6 +3971,202 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== AADDU (RV32)
+
+Mnemonic::
+
+aaddu _rd_, _rs1_, _rs2_
+
+Encoding::
+
+AADDU is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['AADDU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+AADDU performs an unsigned averaging addition on a single XLEN-wide value. It
+adds the unsigned values in `rs1` and `rs2` at full precision (33 bits), then
+shifts the result right by 1, and writes the lower 32 bits to `rd`. Available
+only in RV32; the RV64 counterpart is PAADDU.W.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = unsigned(X[rs1])
+s2 = unsigned(X[rs2])
+
+sum = s1 + s2
+X[rd] = to_bits(32, sum >> 1)
+----
+
+
+<<<
+==== PAADDU.B
+
+Mnemonic::
+
+paaddu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PAADDU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PAADDU.B performs an unsigned averaging addition on packed 8-bit elements. For
+each byte lane, it adds the unsigned elements from `rs1` and `rs2` at full
+precision (9 bits), then shifts the result right by 1, and writes the lower
+8 bits to the corresponding byte of `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    sum = a + b
+    d[(8*i+7):(8*i)] = to_bits(8, sum >> 1)
+
+X[rd] = d
+----
+
+
+<<<
+==== PAADDU.H
+
+Mnemonic::
+
+paaddu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PAADDU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PAADDU.H performs an unsigned averaging addition on packed 16-bit halfword
+elements. For each halfword lane, it adds the unsigned elements from `rs1` and
+`rs2` at full precision (17 bits), then shifts the result right by 1, and writes
+the lower 16 bits to the corresponding halfword of `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    sum = a + b
+    d[(16*i+15):(16*i)] = to_bits(16, sum >> 1)
+
+X[rd] = d
+----
+
+
+<<<
+==== PAADDU.W (RV64)
+
+Mnemonic::
+
+paaddu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PAADDU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['PAADDU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PAADDU.W performs an unsigned averaging addition on packed 32-bit word elements.
+For each word lane, it adds the unsigned elements from `rs1` and `rs2` at full
+precision (33 bits), then shifts the result right by 1, and writes the lower
+32 bits to the corresponding word of `rd`. Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Unsigned averaging add on packed 32-bit elements
+a_lo = unsigned(s1[31:0])
+b_lo = unsigned(s2[31:0])
+sum_lo = a_lo + b_lo
+d[31:0] = to_bits(32, sum_lo >> 1)
+
+a_hi = unsigned(s1[63:32])
+b_hi = unsigned(s2[63:32])
+sum_hi = a_hi + b_hi
+d[63:32] = to_bits(32, sum_hi >> 1)
+
+X[rd] = d
 ----
 
 
@@ -4346,6 +4347,50 @@ if (rd_p != 0):
 === Averaging Subtract
 
 
+==== ASUB (RV32)
+
+Mnemonic::
+
+asub _rd_, _rs1_, _rs2_
+
+Encoding::
+
+ASUB is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['ASUB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+ASUB performs a signed averaging subtraction on a single XLEN-wide value. It
+subtracts the signed value in `rs2` from `rs1` at full precision (33 bits), then
+shifts the result right by 1 (toward negative infinity), and writes the lower
+32 bits to `rd`. Available only in RV32; the RV64 counterpart is PASUB.W.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = signed(X[rs1])
+s2 = signed(X[rs2])
+
+diff = s1 - s2
+X[rd] = to_bits(32, diff >> 1)
+----
+
+
+<<<
 ==== PASUB.B
 
 Mnemonic::
@@ -4497,248 +4542,6 @@ diff_hi = a_hi - b_hi
 d[63:32] = to_bits(32, diff_hi >> 1)
 
 X[rd] = d
-----
-
-
-<<<
-==== PASUBU.B
-
-Mnemonic::
-
-pasubu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PASUBU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xf, attr: ['PASUBU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PASUBU.B performs an unsigned averaging subtraction on packed 8-bit elements.
-For each byte lane, it subtracts the unsigned element in `rs2` from the unsigned
-element in `rs1` at full precision (9 bits), then shifts the result right by 1,
-and writes the lower 8 bits to the corresponding byte of `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    diff = a - b
-    d[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
-
-X[rd] = d
-----
-
-
-<<<
-==== PASUBU.H
-
-Mnemonic::
-
-pasubu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PASUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xf, attr: ['PASUBU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PASUBU.H performs an unsigned averaging subtraction on packed 16-bit halfword
-elements. For each halfword lane, it subtracts the unsigned element in `rs2`
-from the unsigned element in `rs1` at full precision (17 bits), then shifts the
-result right by 1, and writes the lower 16 bits to the corresponding halfword
-of `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1[(16*i+15):(16*i)])
-    b = unsigned(s2[(16*i+15):(16*i)])
-    diff = a - b
-    d[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
-
-X[rd] = d
-----
-
-
-<<<
-==== PASUBU.W (RV64)
-
-Mnemonic::
-
-pasubu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PASUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xf, attr: ['PASUBU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PASUBU.W performs an unsigned averaging subtraction on packed 32-bit word
-elements. For each word lane, it subtracts the unsigned element in `rs2` from
-the unsigned element in `rs1` at full precision (33 bits), then shifts the
-result right by 1, and writes the lower 32 bits to the corresponding word of
-`rd`. Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Unsigned averaging subtract on packed 32-bit elements
-a_lo = unsigned(s1[31:0])
-b_lo = unsigned(s2[31:0])
-diff_lo = a_lo - b_lo
-d[31:0] = to_bits(32, diff_lo >> 1)
-
-a_hi = unsigned(s1[63:32])
-b_hi = unsigned(s2[63:32])
-diff_hi = a_hi - b_hi
-d[63:32] = to_bits(32, diff_hi >> 1)
-
-X[rd] = d
-----
-
-
-<<<
-==== ASUB (RV32)
-
-Mnemonic::
-
-asub _rd_, _rs1_, _rs2_
-
-Encoding::
-
-ASUB is encoded in the OP-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xb, attr: ['ASUB'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-ASUB performs a signed averaging subtraction on a single XLEN-wide value. It
-subtracts the signed value in `rs2` from `rs1` at full precision (33 bits), then
-shifts the result right by 1 (toward negative infinity), and writes the lower
-32 bits to `rd`. Available only in RV32; the RV64 counterpart is PASUB.W.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = signed(X[rs1])
-s2 = signed(X[rs2])
-
-diff = s1 - s2
-X[rd] = to_bits(32, diff >> 1)
-----
-
-
-<<<
-==== ASUBU (RV32)
-
-Mnemonic::
-
-asubu _rd_, _rs1_, _rs2_
-
-Encoding::
-
-ASUBU is encoded in the OP-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xf, attr: ['ASUBU'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-ASUBU performs an unsigned averaging subtraction on a single XLEN-wide value. It
-subtracts the unsigned value in `rs2` from `rs1` at full precision (33 bits),
-then shifts the result right by 1, and writes the lower 32 bits to `rd`.
-Available only in RV32; the RV64 counterpart is PASUBU.W.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = unsigned(X[rs1])
-s2 = unsigned(X[rs2])
-
-diff = s1 - s2
-X[rd] = to_bits(32, diff >> 1)
 ----
 
 
@@ -4910,6 +4713,204 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== ASUBU (RV32)
+
+Mnemonic::
+
+asubu _rd_, _rs1_, _rs2_
+
+Encoding::
+
+ASUBU is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['ASUBU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+ASUBU performs an unsigned averaging subtraction on a single XLEN-wide value. It
+subtracts the unsigned value in `rs2` from `rs1` at full precision (33 bits),
+then shifts the result right by 1, and writes the lower 32 bits to `rd`.
+Available only in RV32; the RV64 counterpart is PASUBU.W.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = unsigned(X[rs1])
+s2 = unsigned(X[rs2])
+
+diff = s1 - s2
+X[rd] = to_bits(32, diff >> 1)
+----
+
+
+<<<
+==== PASUBU.B
+
+Mnemonic::
+
+pasubu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PASUBU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PASUBU.B performs an unsigned averaging subtraction on packed 8-bit elements.
+For each byte lane, it subtracts the unsigned element in `rs2` from the unsigned
+element in `rs1` at full precision (9 bits), then shifts the result right by 1,
+and writes the lower 8 bits to the corresponding byte of `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    diff = a - b
+    d[(8*i+7):(8*i)] = to_bits(8, diff >> 1)
+
+X[rd] = d
+----
+
+
+<<<
+==== PASUBU.H
+
+Mnemonic::
+
+pasubu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PASUBU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PASUBU.H performs an unsigned averaging subtraction on packed 16-bit halfword
+elements. For each halfword lane, it subtracts the unsigned element in `rs2`
+from the unsigned element in `rs1` at full precision (17 bits), then shifts the
+result right by 1, and writes the lower 16 bits to the corresponding halfword
+of `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    diff = a - b
+    d[(16*i+15):(16*i)] = to_bits(16, diff >> 1)
+
+X[rd] = d
+----
+
+
+<<<
+==== PASUBU.W (RV64)
+
+Mnemonic::
+
+pasubu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PASUBU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['PASUBU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PASUBU.W performs an unsigned averaging subtraction on packed 32-bit word
+elements. For each word lane, it subtracts the unsigned element in `rs2` from
+the unsigned element in `rs1` at full precision (33 bits), then shifts the
+result right by 1, and writes the lower 32 bits to the corresponding word of
+`rd`. Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Unsigned averaging subtract on packed 32-bit elements
+a_lo = unsigned(s1[31:0])
+b_lo = unsigned(s2[31:0])
+diff_lo = a_lo - b_lo
+d[31:0] = to_bits(32, diff_lo >> 1)
+
+a_hi = unsigned(s1[63:32])
+b_hi = unsigned(s2[63:32])
+diff_hi = a_hi - b_hi
+d[63:32] = to_bits(32, diff_hi >> 1)
+
+X[rd] = d
 ----
 
 
@@ -5179,6 +5180,182 @@ X[rd] = d
 
 
 <<<
+==== PSH1ADD.DH (RV32)
+
+Mnemonic::
+
+psh1add.dh _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PSH1ADD.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PSH1ADD.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSH1ADD.DH (Packed Shift-left-by-1 and Add, Double-wide Halfword) performs a
+packed halfword shift-left-by-1-and-add across register pairs. For each 16-bit
+element, it shifts the element from `rs1` left by 1 and adds the corresponding
+element from `rs2`, wrapping modulo 2^16^. It is equivalent to performing
+PSH1ADD.H independently on both the even and odd registers of the source and
+destination pairs. This instruction is available only on RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PSH1ADD.H operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 3:
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (a << 1) + b
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PSH1ADD.DW (RV32)
+
+Mnemonic::
+
+psh1add.dw _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PSH1ADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PSH1ADD.DW'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSH1ADD.DW (Packed Shift-left-by-1 and Add, Double-wide Word) performs a 32-bit
+word shift-left-by-1-and-add across register pairs. For each 32-bit element, it
+shifts the element from `rs1` left by 1 and adds the corresponding element from
+`rs2`, wrapping modulo 2^32^. It is equivalent to performing SH1ADD independently
+on both the even and odd registers of the source and destination pairs. This
+instruction is available only on RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two SH1ADD operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (a << 1) + b
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== SSH1SADD (RV32)
+
+Mnemonic::
+
+ssh1sadd _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SSH1SADD is encoded in the OP-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x3, attr: ['SSH1SADD'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SSH1SADD instruction performs a signed saturating left shift by 1 on `rs1`,
+followed by a signed saturating add with `rs2`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Saturating shift-left-by-1
+t = s1 << 1
+if t overflows signed32:
+    vxsat = 1
+    t = (s1 <_s 0) ? 0x80000000 : 0x7FFFFFFF
+
+// Saturating add
+s = signed(t) + signed(s2)
+if s < -2^31:
+    vxsat = 1
+    X[rd] = 0x80000000
+else if s > 2^31-1:
+    vxsat = 1
+    X[rd] = 0x7FFFFFFF
+else
+    X[rd] = to_bits(32, s)
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PSSH1SADD.H
 
 Mnemonic::
@@ -5318,182 +5495,6 @@ X[rd] = d
 Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== SSH1SADD (RV32)
-
-Mnemonic::
-
-ssh1sadd _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SSH1SADD is encoded in the OP-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x3, attr: ['SSH1SADD'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SSH1SADD instruction performs a signed saturating left shift by 1 on `rs1`,
-followed by a signed saturating add with `rs2`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Saturating shift-left-by-1
-t = s1 << 1
-if t overflows signed32:
-    vxsat = 1
-    t = (s1 <_s 0) ? 0x80000000 : 0x7FFFFFFF
-
-// Saturating add
-s = signed(t) + signed(s2)
-if s < -2^31:
-    vxsat = 1
-    X[rd] = 0x80000000
-else if s > 2^31-1:
-    vxsat = 1
-    X[rd] = 0x7FFFFFFF
-else
-    X[rd] = to_bits(32, s)
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PSH1ADD.DH (RV32)
-
-Mnemonic::
-
-psh1add.dh _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PSH1ADD.DH is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x2, attr: ['PSH1ADD.DH'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSH1ADD.DH (Packed Shift-left-by-1 and Add, Double-wide Halfword) performs a
-packed halfword shift-left-by-1-and-add across register pairs. For each 16-bit
-element, it shifts the element from `rs1` left by 1 and adds the corresponding
-element from `rs2`, wrapping modulo 2^16^. It is equivalent to performing
-PSH1ADD.H independently on both the even and odd registers of the source and
-destination pairs. This instruction is available only on RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PSH1ADD.H operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 3:
-    a = s1[(16*i+15):(16*i)]
-    b = s2[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = (a << 1) + b
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PSH1ADD.DW (RV32)
-
-Mnemonic::
-
-psh1add.dw _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PSH1ADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x2, attr: ['PSH1ADD.DW'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSH1ADD.DW (Packed Shift-left-by-1 and Add, Double-wide Word) performs a 32-bit
-word shift-left-by-1-and-add across register pairs. For each 32-bit element, it
-shifts the element from `rs1` left by 1 and adds the corresponding element from
-`rs2`, wrapping modulo 2^32^. It is equivalent to performing SH1ADD independently
-on both the even and odd registers of the source and destination pairs. This
-instruction is available only on RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two SH1ADD operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 1:
-    a = s1[(32*i+31):(32*i)]
-    b = s2[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = (a << 1) + b
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
 
 <<<
 ==== PSSH1SADD.DH (RV32)
@@ -5867,6 +5868,70 @@ X[rd] = d
 
 
 <<<
+==== PAS.DHX (RV32)
+
+Mnemonic::
+
+pas.dhx _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x0, attr: ['PAS.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PAS.DHX (Packed Add-Subtract, Double-wide Cross Halfword) performs packed
+16-bit cross add-subtract on double-wide (register-pair) operands. It is
+equivalent to two PAS.HX operations: one on the even registers and one on the
+odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`) are
+register pairs and must specify even register numbers. For each pair of
+halfwords, the upper halfword is added cross with the lower halfword of the
+other operand, and vice versa with subtraction. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PAS.HX operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 1:
+    // Even halfword: subtract
+    a_even = s1[(32*i+15):(32*i)]
+    b_odd = s2[(32*i+31):(32*i+16)]
+    d[(32*i+15):(32*i)] = a_even - b_odd
+
+    // Odd halfword: add
+    a_odd = s1[(32*i+31):(32*i+16)]
+    b_even = s2[(32*i+15):(32*i)]
+    d[(32*i+31):(32*i+16)] = a_odd + b_even
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
 ==== PSAS.HX
 
 Mnemonic::
@@ -6002,6 +6067,75 @@ else if res_odd < -(2^31):
 d[63:32] = res_odd[31:0]
 
 X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PSAS.DHX (RV32)
+
+Mnemonic::
+
+psas.dhx _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PSAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PSAS.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSAS.DHX (Packed Saturating Add-Subtract, Double-wide Cross Halfword) performs
+signed saturating cross add-subtract on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PSAS.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Results are saturated to the signed 16-bit range [-2^15^, 2^15^-1]. If saturation
+occurs, the overflow flag `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PSAS.HX operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 1:
+    // Even halfword: saturating subtract
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    diff = a_even - b_odd
+    d[(32*i+15):(32*i)] = SAT16(diff)
+
+    // Odd halfword: saturating add
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    sum = a_odd + b_even
+    d[(32*i+31):(32*i+16)] = SAT16(sum)
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 Notes::
@@ -6151,6 +6285,75 @@ Notes::
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
+==== PSSA.DHX (RV32)
+
+Mnemonic::
+
+pssa.dhx _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PSSA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x2, attr: ['PSSA.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSSA.DHX (Packed Saturating Subtract-Add, Double-wide Cross Halfword) performs
+signed saturating cross subtract-add on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PSSA.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Results are saturated to the signed 16-bit range [-2^15^, 2^15^-1]. If saturation
+occurs, the overflow flag `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PSSA.HX operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 1:
+    // Even halfword: saturating add
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    sum = a_even + b_odd
+    d[(32*i+15):(32*i)] = SAT16(sum)
+
+    // Odd halfword: saturating subtract
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    diff = a_odd - b_even
+    d[(32*i+31):(32*i+16)] = SAT16(diff)
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PAAS.HX
 
 Mnemonic::
@@ -6266,6 +6469,72 @@ diff = a_lo - b_hi
 d[31:0] = to_bits(32, diff >> 1)
 
 X[rd] = d
+----
+
+
+<<<
+==== PAAS.DHX (RV32)
+
+Mnemonic::
+
+paas.dhx _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PAAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x3, attr: ['PAAS.DHX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PAAS.DHX (Packed Averaging Add-Subtract, Double-wide Cross Halfword) performs
+signed averaging cross add-subtract on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PAAS.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Each result is computed at full precision and then shifted right by 1 (toward
+negative infinity). Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PAAS.HX operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 1:
+    // Even halfword: averaging subtract
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    diff = a_even - b_odd
+    d[(32*i+15):(32*i)] = to_bits(16, diff >> 1)
+
+    // Odd halfword: averaging add
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    sum = a_odd + b_even
+    d[(32*i+31):(32*i+16)] = to_bits(16, sum >> 1)
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -6389,15 +6658,15 @@ X[rd] = d
 
 
 <<<
-==== PAS.DHX (RV32)
+==== PASA.DHX (RV32)
 
 Mnemonic::
 
-pas.dhx _rd_p_, _rs1_p_, _rs2_p_
+pasa.dhx _rd_p_, _rs1_p_, _rs2_p_
 
 Encoding::
 
-PAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
+PASA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
 register-pair format. Available only in RV32.
 
 [wavedrom, ,svg]
@@ -6411,40 +6680,42 @@ register-pair format. Available only in RV32.
     { bits: 4, name: 'rs1_p' },
     { bits: 1, name: 0x1 },
     { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x0, attr: ['PAS.DHX'] },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x3, attr: ['PASA.DHX'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-PAS.DHX (Packed Add-Subtract, Double-wide Cross Halfword) performs packed
-16-bit cross add-subtract on double-wide (register-pair) operands. It is
-equivalent to two PAS.HX operations: one on the even registers and one on the
-odd registers of each pair. All three operands (`rd_p`, `rs1_p`, `rs2_p`) are
-register pairs and must specify even register numbers. For each pair of
-halfwords, the upper halfword is added cross with the lower halfword of the
-other operand, and vice versa with subtraction. Available only in RV32.
+PASA.DHX (Packed Averaging Subtract-Add, Double-wide Cross Halfword) performs
+signed averaging cross subtract-add on packed 16-bit halfword elements across
+register pairs. It is equivalent to two PASA.HX operations: one on the even
+registers and one on the odd registers of each pair. All three operands (`rd_p`,
+`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
+Each result is computed at full precision and then shifted right by 1 (toward
+negative infinity). Available only in RV32.
 
 Operation::
 
 [source,pseudocode]
 ----
-// Equivalent to two PAS.HX operations on even/odd register pairs
+// Equivalent to two PASA.HX operations on even/odd register pairs
 s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
 s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
 
 for i = 0 .. 1:
-    // Even halfword: subtract
-    a_even = s1[(32*i+15):(32*i)]
-    b_odd = s2[(32*i+31):(32*i+16)]
-    d[(32*i+15):(32*i)] = a_even - b_odd
+    // Even halfword: averaging add
+    a_even = signed(s1[(32*i+15):(32*i)])
+    b_odd = signed(s2[(32*i+31):(32*i+16)])
+    sum = a_even + b_odd
+    d[(32*i+15):(32*i)] = to_bits(16, sum >> 1)
 
-    // Odd halfword: add
-    a_odd = s1[(32*i+31):(32*i+16)]
-    b_even = s2[(32*i+15):(32*i)]
-    d[(32*i+31):(32*i+16)] = a_odd + b_even
+    // Odd halfword: averaging subtract
+    a_odd = signed(s1[(32*i+31):(32*i+16)])
+    b_even = signed(s2[(32*i+15):(32*i)])
+    diff = a_odd - b_even
+    d[(32*i+31):(32*i+16)] = to_bits(16, diff >> 1)
 
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
@@ -6510,276 +6781,6 @@ for i = 0 .. 1:
     a_odd = s1[(32*i+31):(32*i+16)]
     b_even = s2[(32*i+15):(32*i)]
     d[(32*i+31):(32*i+16)] = a_odd - b_even
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PSAS.DHX (RV32)
-
-Mnemonic::
-
-psas.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PSAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x2, attr: ['PSAS.DHX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSAS.DHX (Packed Saturating Add-Subtract, Double-wide Cross Halfword) performs
-signed saturating cross add-subtract on packed 16-bit halfword elements across
-register pairs. It is equivalent to two PSAS.HX operations: one on the even
-registers and one on the odd registers of each pair. All three operands (`rd_p`,
-`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
-Results are saturated to the signed 16-bit range [-2^15^, 2^15^-1]. If saturation
-occurs, the overflow flag `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PSAS.HX operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 1:
-    // Even halfword: saturating subtract
-    a_even = signed(s1[(32*i+15):(32*i)])
-    b_odd = signed(s2[(32*i+31):(32*i+16)])
-    diff = a_even - b_odd
-    d[(32*i+15):(32*i)] = SAT16(diff)
-
-    // Odd halfword: saturating add
-    a_odd = signed(s1[(32*i+31):(32*i+16)])
-    b_even = signed(s2[(32*i+15):(32*i)])
-    sum = a_odd + b_even
-    d[(32*i+31):(32*i+16)] = SAT16(sum)
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PSSA.DHX (RV32)
-
-Mnemonic::
-
-pssa.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PSSA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x2, attr: ['PSSA.DHX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSSA.DHX (Packed Saturating Subtract-Add, Double-wide Cross Halfword) performs
-signed saturating cross subtract-add on packed 16-bit halfword elements across
-register pairs. It is equivalent to two PSSA.HX operations: one on the even
-registers and one on the odd registers of each pair. All three operands (`rd_p`,
-`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
-Results are saturated to the signed 16-bit range [-2^15^, 2^15^-1]. If saturation
-occurs, the overflow flag `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PSSA.HX operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 1:
-    // Even halfword: saturating add
-    a_even = signed(s1[(32*i+15):(32*i)])
-    b_odd = signed(s2[(32*i+31):(32*i+16)])
-    sum = a_even + b_odd
-    d[(32*i+15):(32*i)] = SAT16(sum)
-
-    // Odd halfword: saturating subtract
-    a_odd = signed(s1[(32*i+31):(32*i+16)])
-    b_even = signed(s2[(32*i+15):(32*i)])
-    diff = a_odd - b_even
-    d[(32*i+31):(32*i+16)] = SAT16(diff)
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PAAS.DHX (RV32)
-
-Mnemonic::
-
-paas.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PAAS.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x3, attr: ['PAAS.DHX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PAAS.DHX (Packed Averaging Add-Subtract, Double-wide Cross Halfword) performs
-signed averaging cross add-subtract on packed 16-bit halfword elements across
-register pairs. It is equivalent to two PAAS.HX operations: one on the even
-registers and one on the odd registers of each pair. All three operands (`rd_p`,
-`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
-Each result is computed at full precision and then shifted right by 1 (toward
-negative infinity). Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PAAS.HX operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 1:
-    // Even halfword: averaging subtract
-    a_even = signed(s1[(32*i+15):(32*i)])
-    b_odd = signed(s2[(32*i+31):(32*i+16)])
-    diff = a_even - b_odd
-    d[(32*i+15):(32*i)] = to_bits(16, diff >> 1)
-
-    // Odd halfword: averaging add
-    a_odd = signed(s1[(32*i+31):(32*i+16)])
-    b_even = signed(s2[(32*i+15):(32*i)])
-    sum = a_odd + b_even
-    d[(32*i+31):(32*i+16)] = to_bits(16, sum >> 1)
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PASA.DHX (RV32)
-
-Mnemonic::
-
-pasa.dhx _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PASA.DHX is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x3, attr: ['PASA.DHX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PASA.DHX (Packed Averaging Subtract-Add, Double-wide Cross Halfword) performs
-signed averaging cross subtract-add on packed 16-bit halfword elements across
-register pairs. It is equivalent to two PASA.HX operations: one on the even
-registers and one on the odd registers of each pair. All three operands (`rd_p`,
-`rs1_p`, `rs2_p`) are register pairs and must specify even register numbers.
-Each result is computed at full precision and then shifted right by 1 (toward
-negative infinity). Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PASA.HX operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 1:
-    // Even halfword: averaging add
-    a_even = signed(s1[(32*i+15):(32*i)])
-    b_odd = signed(s2[(32*i+31):(32*i+16)])
-    sum = a_even + b_odd
-    d[(32*i+15):(32*i)] = to_bits(16, sum >> 1)
-
-    // Odd halfword: averaging subtract
-    a_odd = signed(s1[(32*i+31):(32*i+16)])
-    b_even = signed(s2[(32*i+15):(32*i)])
-    diff = a_odd - b_even
-    d[(32*i+31):(32*i+16)] = to_bits(16, diff >> 1)
 
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
@@ -6883,209 +6884,6 @@ for i = 0 .. (XLEN/16 - 1):
     d[(16*i+15) : (16*i)] = (a <_s b) ? (b - a) : (a - b)
 
 X[rd] = d
-----
-
-
-<<<
-==== PABDU.B
-
-Mnemonic::
-
-pabdu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PABDU.B is encoded in the OP-32 major opcode. It uses packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xd, attr: ['PABDU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PABDU.B instruction computes the absolute difference of corresponding packed
-8-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
-result to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = s1[(8*i+7) : (8*i)]
-    b = s2[(8*i+7) : (8*i)]
-    d[(8*i+7) : (8*i)] = (a <_u b) ? (b - a) : (a - b)
-
-X[rd] = d
-----
-
-Notes::
-
-* Unsigned ordering is used to determine the magnitude of each element difference.
-
-<<<
-==== PABDU.H
-
-Mnemonic::
-
-pabdu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PABDU.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x0 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xd, attr: ['PABDU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PABDU.H instruction computes the absolute difference of corresponding packed
-16-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
-result to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = s1[(16*i+15) : (16*i)]
-    b = s2[(16*i+15) : (16*i)]
-    d[(16*i+15) : (16*i)] = (a <_u b) ? (b - a) : (a - b)
-
-X[rd] = d
-----
-
-
-
-<<<
-==== PABDSUMU.B
-
-Mnemonic::
-
-pabdsumu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PABDSUMU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x6, attr: ['PABDSUMU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PABDSUMU.B (Packed Absolute Difference Sum, Unsigned Byte) computes the sum of
-absolute differences of packed unsigned 8-bit byte elements from `rs1` and
-`rs2`. For each byte lane, the unsigned absolute difference is computed, and all
-differences are summed into a single scalar result written to `rd`. This
-instruction is commonly used in motion estimation and image processing
-algorithms.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-sum = 0
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    diff = (a >= b) ? (a - b) : (b - a)
-    sum = sum + diff
-
-X[rd] = to_bits(XLEN, sum)
-----
-
-
-<<<
-==== PABDSUMAU.B
-
-Mnemonic::
-
-pabdsumau.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PABDSUMAU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x7, attr: ['PABDSUMAU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PABDSUMAU.B (Packed Absolute Difference Sum Accumulate, Unsigned Byte) computes
-the sum of absolute differences of packed unsigned 8-bit byte elements from
-`rs1` and `rs2`, and accumulates the result into `rd`. For each byte lane, the
-unsigned absolute difference is computed. All differences are summed and added to
-the current value of `rd`. This accumulating form is useful for iteratively
-computing the sum of absolute differences across multiple register-widths of
-data, as commonly needed in motion estimation and image processing algorithms.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-sum = unsigned(X[rd])
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    diff = (a >= b) ? (a - b) : (b - a)
-    sum = sum + diff
-
-X[rd] = to_bits(XLEN, sum)
 ----
 
 
@@ -7206,6 +7004,104 @@ if (rd_p != 0):
 
 
 <<<
+==== PABDU.B
+
+Mnemonic::
+
+pabdu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PABDU.B is encoded in the OP-32 major opcode. It uses packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xd, attr: ['PABDU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PABDU.B instruction computes the absolute difference of corresponding packed
+8-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
+result to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = s1[(8*i+7) : (8*i)]
+    b = s2[(8*i+7) : (8*i)]
+    d[(8*i+7) : (8*i)] = (a <_u b) ? (b - a) : (a - b)
+
+X[rd] = d
+----
+
+Notes::
+
+* Unsigned ordering is used to determine the magnitude of each element difference.
+
+<<<
+==== PABDU.H
+
+Mnemonic::
+
+pabdu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PABDU.H is encoded in the OP-32 major opcode. It uses packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x0 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xd, attr: ['PABDU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PABDU.H instruction computes the absolute difference of corresponding packed
+16-bit elements of `rs1` and `rs2`, using unsigned comparison, and writes the
+result to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1[(16*i+15) : (16*i)]
+    b = s2[(16*i+15) : (16*i)]
+    d[(16*i+15) : (16*i)] = (a <_u b) ? (b - a) : (a - b)
+
+X[rd] = d
+----
+
+
+
+<<<
 ==== PABDU.DB (RV32)
 
 Mnemonic::
@@ -7318,6 +7214,111 @@ for i = 0 .. 3:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PABDSUMU.B
+
+Mnemonic::
+
+pabdsumu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PABDSUMU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x6, attr: ['PABDSUMU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PABDSUMU.B (Packed Absolute Difference Sum, Unsigned Byte) computes the sum of
+absolute differences of packed unsigned 8-bit byte elements from `rs1` and
+`rs2`. For each byte lane, the unsigned absolute difference is computed, and all
+differences are summed into a single scalar result written to `rd`. This
+instruction is commonly used in motion estimation and image processing
+algorithms.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+sum = 0
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    diff = (a >= b) ? (a - b) : (b - a)
+    sum = sum + diff
+
+X[rd] = to_bits(XLEN, sum)
+----
+
+
+<<<
+==== PABDSUMAU.B
+
+Mnemonic::
+
+pabdsumau.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PABDSUMAU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x7, attr: ['PABDSUMAU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PABDSUMAU.B (Packed Absolute Difference Sum Accumulate, Unsigned Byte) computes
+the sum of absolute differences of packed unsigned 8-bit byte elements from
+`rs1` and `rs2`, and accumulates the result into `rd`. For each byte lane, the
+unsigned absolute difference is computed. All differences are summed and added to
+the current value of `rd`. This accumulating form is useful for iteratively
+computing the sum of absolute differences across multiple register-widths of
+data, as commonly needed in motion estimation and image processing algorithms.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+sum = unsigned(X[rd])
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    diff = (a >= b) ? (a - b) : (b - a)
+    sum = sum + diff
+
+X[rd] = to_bits(XLEN, sum)
 ----
 
 
@@ -7978,417 +7979,6 @@ X[rd] = d
 
 
 <<<
-==== PMINU.B
-
-Mnemonic::
-
-pminu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMINU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xd, attr: ['PMINU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMINU.B computes the unsigned minimum of corresponding packed 8-bit byte
-elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    d[(8*i+7):(8*i)] = (a < b) ? a : b
-
-X[rd] = d
-----
-
-
-<<<
-==== PMINU.H
-
-Mnemonic::
-
-pminu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMINU.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xd, attr: ['PMINU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMINU.H computes the unsigned minimum of corresponding packed 16-bit halfword
-elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1[(16*i+15):(16*i)])
-    b = unsigned(s2[(16*i+15):(16*i)])
-    d[(16*i+15):(16*i)] = (a < b) ? a : b
-
-X[rd] = d
-----
-
-
-<<<
-==== PMINU.W (RV64)
-
-Mnemonic::
-
-pminu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMINU.W is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xd, attr: ['PMINU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMINU.W computes the unsigned minimum of corresponding packed 32-bit word
-elements of `rs1` and `rs2` and writes the packed word results to `rd`.
-Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-d[31:0]  = (unsigned(s1[31:0])  < unsigned(s2[31:0]))  ? s1[31:0]  : s2[31:0]
-d[63:32] = (unsigned(s1[63:32]) < unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
-
-X[rd] = d
-----
-
-
-<<<
-==== PMAX.B
-
-Mnemonic::
-
-pmax.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMAX.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xe, attr: ['PMAX.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMAX.B computes the signed maximum of corresponding packed 8-bit byte elements
-of `rs1` and `rs2` and writes the packed byte results to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1[(8*i+7):(8*i)])
-    b = signed(s2[(8*i+7):(8*i)])
-    d[(8*i+7):(8*i)] = (a > b) ? a : b
-
-X[rd] = d
-----
-
-
-<<<
-==== PMAX.H
-
-Mnemonic::
-
-pmax.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMAX.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xe, attr: ['PMAX.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMAX.H computes the signed maximum of corresponding packed 16-bit halfword
-elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1[(16*i+15):(16*i)])
-    b = signed(s2[(16*i+15):(16*i)])
-    d[(16*i+15):(16*i)] = (a > b) ? a : b
-
-X[rd] = d
-----
-
-
-<<<
-==== PMAX.W (RV64)
-
-Mnemonic::
-
-pmax.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMAX.W is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xe, attr: ['PMAX.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMAX.W computes the signed maximum of corresponding packed 32-bit word elements
-of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
-in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-d[31:0]  = (signed(s1[31:0])  > signed(s2[31:0]))  ? s1[31:0]  : s2[31:0]
-d[63:32] = (signed(s1[63:32]) > signed(s2[63:32])) ? s1[63:32] : s2[63:32]
-
-X[rd] = d
-----
-
-
-<<<
-==== PMAXU.B
-
-Mnemonic::
-
-pmaxu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMAXU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xf, attr: ['PMAXU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMAXU.B computes the unsigned maximum of corresponding packed 8-bit byte
-elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    d[(8*i+7):(8*i)] = (a > b) ? a : b
-
-X[rd] = d
-----
-
-
-<<<
-==== PMAXU.H
-
-Mnemonic::
-
-pmaxu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMAXU.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xf, attr: ['PMAXU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMAXU.H computes the unsigned maximum of corresponding packed 16-bit halfword
-elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1[(16*i+15):(16*i)])
-    b = unsigned(s2[(16*i+15):(16*i)])
-    d[(16*i+15):(16*i)] = (a > b) ? a : b
-
-X[rd] = d
-----
-
-
-<<<
-==== PMAXU.W (RV64)
-
-Mnemonic::
-
-pmaxu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMAXU.W is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xf, attr: ['PMAXU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMAXU.W computes the unsigned maximum of corresponding packed 32-bit word
-elements of `rs1` and `rs2` and writes the packed word results to `rd`.
-Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-d[31:0]  = (unsigned(s1[31:0])  > unsigned(s2[31:0]))  ? s1[31:0]  : s2[31:0]
-d[63:32] = (unsigned(s1[63:32]) > unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
-
-X[rd] = d
-----
-
-
-<<<
 ==== PMIN.DB (RV32)
 
 Mnemonic::
@@ -8553,6 +8143,143 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PMINU.B
+
+Mnemonic::
+
+pminu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMINU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xd, attr: ['PMINU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMINU.B computes the unsigned minimum of corresponding packed 8-bit byte
+elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? a : b
+
+X[rd] = d
+----
+
+
+<<<
+==== PMINU.H
+
+Mnemonic::
+
+pminu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMINU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xd, attr: ['PMINU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMINU.H computes the unsigned minimum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? a : b
+
+X[rd] = d
+----
+
+
+<<<
+==== PMINU.W (RV64)
+
+Mnemonic::
+
+pminu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMINU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xd, attr: ['PMINU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMINU.W computes the unsigned minimum of corresponding packed 32-bit word
+elements of `rs1` and `rs2` and writes the packed word results to `rd`.
+Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = (unsigned(s1[31:0])  < unsigned(s2[31:0]))  ? s1[31:0]  : s2[31:0]
+d[63:32] = (unsigned(s1[63:32]) < unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
+
+X[rd] = d
 ----
 
 
@@ -8725,6 +8452,143 @@ if (rd_p != 0):
 
 
 <<<
+==== PMAX.B
+
+Mnemonic::
+
+pmax.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMAX.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xe, attr: ['PMAX.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMAX.B computes the signed maximum of corresponding packed 8-bit byte elements
+of `rs1` and `rs2` and writes the packed byte results to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a > b) ? a : b
+
+X[rd] = d
+----
+
+
+<<<
+==== PMAX.H
+
+Mnemonic::
+
+pmax.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMAX.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xe, attr: ['PMAX.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMAX.H computes the signed maximum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a > b) ? a : b
+
+X[rd] = d
+----
+
+
+<<<
+==== PMAX.W (RV64)
+
+Mnemonic::
+
+pmax.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMAX.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['PMAX.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMAX.W computes the signed maximum of corresponding packed 32-bit word elements
+of `rs1` and `rs2` and writes the packed word results to `rd`. Available only
+in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = (signed(s1[31:0])  > signed(s2[31:0]))  ? s1[31:0]  : s2[31:0]
+d[63:32] = (signed(s1[63:32]) > signed(s2[63:32])) ? s1[63:32] : s2[63:32]
+
+X[rd] = d
+----
+
+
+<<<
 ==== PMAX.DB (RV32)
 
 Mnemonic::
@@ -8889,6 +8753,143 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PMAXU.B
+
+Mnemonic::
+
+pmaxu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMAXU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMAXU.B computes the unsigned maximum of corresponding packed 8-bit byte
+elements of `rs1` and `rs2` and writes the packed byte results to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a > b) ? a : b
+
+X[rd] = d
+----
+
+
+<<<
+==== PMAXU.H
+
+Mnemonic::
+
+pmaxu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMAXU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMAXU.H computes the unsigned maximum of corresponding packed 16-bit halfword
+elements of `rs1` and `rs2` and writes the packed halfword results to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a > b) ? a : b
+
+X[rd] = d
+----
+
+
+<<<
+==== PMAXU.W (RV64)
+
+Mnemonic::
+
+pmaxu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMAXU.W is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['PMAXU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMAXU.W computes the unsigned maximum of corresponding packed 32-bit word
+elements of `rs1` and `rs2` and writes the packed word results to `rd`.
+Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d[31:0]  = (unsigned(s1[31:0])  > unsigned(s2[31:0]))  ? s1[31:0]  : s2[31:0]
+d[63:32] = (unsigned(s1[63:32]) > unsigned(s2[63:32])) ? s1[63:32] : s2[63:32]
+
+X[rd] = d
 ----
 
 
@@ -9063,6 +9064,44 @@ if (rd_p != 0):
 <<<
 === Comparison
 
+==== MSEQ (RV32)
+
+Mnemonic::
+
+mseq _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MSEQ is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x8, attr: ['MSEQ'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MSEQ instruction sets `rd` to all ones if `rs1` equals `rs2`; otherwise it
+sets `rd` to zero.
+
+Operation::
+
+[source,pseudocode]
+----
+X[rd] = (X[rs1] == X[rs2]) ? 0xFFFFFFFF : 0x00000000
+----
+
+
+<<<
 ==== PMSEQ.B
 
 Mnemonic::
@@ -9198,397 +9237,6 @@ d0 = (s1[31:0]  == s2[31:0])  ? 0xFFFFFFFF : 0x00000000
 d1 = (s1[63:32] == s2[63:32]) ? 0xFFFFFFFF : 0x00000000
 X[rd] = d1 @ d0
 ----
-
-
-<<<
-==== PMSLT.B
-
-Mnemonic::
-
-pmslt.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMSLT.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xa, attr: ['PMSLT.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMSLT.B performs a signed less-than comparison on corresponding packed 8-bit byte
-elements of `rs1` and `rs2`. For each element, if the signed value of `rs1` is
-less than the signed value of `rs2`, the corresponding byte in `rd` is set to
-all-ones (0xFF); otherwise it is set to all-zeros (0x00).
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = signed(s1[(8*i+7):(8*i)])
-    b = signed(s2[(8*i+7):(8*i)])
-    d[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
-
-X[rd] = d
-----
-
-
-<<<
-==== PMSLT.H
-
-Mnemonic::
-
-pmslt.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMSLT.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xa, attr: ['PMSLT.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMSLT.H performs a signed less-than comparison on corresponding packed 16-bit
-halfword elements of `rs1` and `rs2`. For each element, if the signed value of
-`rs1` is less than the signed value of `rs2`, the corresponding halfword in `rd`
-is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1[(16*i+15):(16*i)])
-    b = signed(s2[(16*i+15):(16*i)])
-    d[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
-
-X[rd] = d
-----
-
-
-<<<
-==== PMSLT.W (RV64)
-
-Mnemonic::
-
-pmslt.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMSLT.W is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xa, attr: ['PMSLT.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMSLT.W instruction performs signed less-than comparisons on corresponding
-packed 32-bit elements and produces a packed word mask in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d0 = (s1[31:0]  <_s s2[31:0])  ? 0xFFFFFFFF : 0x00000000
-d1 = (s1[63:32] <_s s2[63:32]) ? 0xFFFFFFFF : 0x00000000
-X[rd] = d1 @ d0
-----
-
-
-<<<
-==== PMSLTU.B
-
-Mnemonic::
-
-pmsltu.b _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMSLTU.B is encoded in the OP-32 major opcode with packed byte elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xb, attr: ['PMSLTU.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMSLTU.B performs an unsigned less-than comparison on corresponding packed 8-bit
-byte elements of `rs1` and `rs2`. For each element, if the unsigned value of
-`rs1` is less than the unsigned value of `rs2`, the corresponding byte in `rd` is
-set to all-ones (0xFF); otherwise it is set to all-zeros (0x00).
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/8 - 1):
-    a = unsigned(s1[(8*i+7):(8*i)])
-    b = unsigned(s2[(8*i+7):(8*i)])
-    d[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
-
-X[rd] = d
-----
-
-
-<<<
-==== PMSLTU.H
-
-Mnemonic::
-
-pmsltu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMSLTU.H is encoded in the OP-32 major opcode with packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xb, attr: ['PMSLTU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMSLTU.H performs an unsigned less-than comparison on corresponding packed 16-bit
-halfword elements of `rs1` and `rs2`. For each element, if the unsigned value of
-`rs1` is less than the unsigned value of `rs2`, the corresponding halfword in
-`rd` is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/16 - 1):
-    a = unsigned(s1[(16*i+15):(16*i)])
-    b = unsigned(s2[(16*i+15):(16*i)])
-    d[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
-
-X[rd] = d
-----
-
-
-<<<
-==== PMSLTU.W (RV64)
-
-Mnemonic::
-
-pmsltu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMSLTU.W is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xb, attr: ['PMSLTU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMSLTU.W instruction performs unsigned less-than comparisons on corresponding
-packed 32-bit elements and produces a packed word mask in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d0 = (s1[31:0]  <_u s2[31:0])  ? 0xFFFFFFFF : 0x00000000
-d1 = (s1[63:32] <_u s2[63:32]) ? 0xFFFFFFFF : 0x00000000
-X[rd] = d1 @ d0
-----
-
-
-<<<
-==== MSEQ (RV32)
-
-Mnemonic::
-
-mseq _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MSEQ is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x8, attr: ['MSEQ'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MSEQ instruction sets `rd` to all ones if `rs1` equals `rs2`; otherwise it
-sets `rd` to zero.
-
-Operation::
-
-[source,pseudocode]
-----
-X[rd] = (X[rs1] == X[rs2]) ? 0xFFFFFFFF : 0x00000000
-----
-
-
-<<<
-==== MSLT (RV32)
-
-Mnemonic::
-
-mslt _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MSLT is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xa, attr: ['MSLT'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MSLT instruction sets `rd` to all ones if `rs1` is less than `rs2` using
-signed comparison; otherwise it sets `rd` to zero.
-
-Operation::
-
-[source,pseudocode]
-----
-X[rd] = (X[rs1] <_s X[rs2]) ? 0xFFFFFFFF : 0x00000000
-----
-
-
-<<<
-==== MSLTU (RV32)
-
-Mnemonic::
-
-msltu _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MSLTU is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x6 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xb, attr: ['MSLTU'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MSLTU instruction sets `rd` to all ones if `rs1` is less than `rs2` using
-unsigned comparison; otherwise it sets `rd` to zero.
-
-Operation::
-
-[source,pseudocode]
-----
-X[rd] = (X[rs1] <_u X[rs2]) ? 0xFFFFFFFF : 0x00000000
-----
-
 
 
 <<<
@@ -9763,6 +9411,182 @@ if (rd_p != 0):
 
 
 <<<
+==== MSLT (RV32)
+
+Mnemonic::
+
+mslt _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MSLT is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['MSLT'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MSLT instruction sets `rd` to all ones if `rs1` is less than `rs2` using
+signed comparison; otherwise it sets `rd` to zero.
+
+Operation::
+
+[source,pseudocode]
+----
+X[rd] = (X[rs1] <_s X[rs2]) ? 0xFFFFFFFF : 0x00000000
+----
+
+
+<<<
+==== PMSLT.B
+
+Mnemonic::
+
+pmslt.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMSLT.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xa, attr: ['PMSLT.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMSLT.B performs a signed less-than comparison on corresponding packed 8-bit byte
+elements of `rs1` and `rs2`. For each element, if the signed value of `rs1` is
+less than the signed value of `rs2`, the corresponding byte in `rd` is set to
+all-ones (0xFF); otherwise it is set to all-zeros (0x00).
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = signed(s1[(8*i+7):(8*i)])
+    b = signed(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+
+X[rd] = d
+----
+
+
+<<<
+==== PMSLT.H
+
+Mnemonic::
+
+pmslt.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMSLT.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xa, attr: ['PMSLT.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMSLT.H performs a signed less-than comparison on corresponding packed 16-bit
+halfword elements of `rs1` and `rs2`. For each element, if the signed value of
+`rs1` is less than the signed value of `rs2`, the corresponding halfword in `rd`
+is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    b = signed(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+
+X[rd] = d
+----
+
+
+<<<
+==== PMSLT.W (RV64)
+
+Mnemonic::
+
+pmslt.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMSLT.W is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['PMSLT.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMSLT.W instruction performs signed less-than comparisons on corresponding
+packed 32-bit elements and produces a packed word mask in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d0 = (s1[31:0]  <_s s2[31:0])  ? 0xFFFFFFFF : 0x00000000
+d1 = (s1[63:32] <_s s2[63:32]) ? 0xFFFFFFFF : 0x00000000
+X[rd] = d1 @ d0
+----
+
+
+<<<
 ==== PMSLT.DB (RV32)
 
 Mnemonic::
@@ -9933,6 +9757,183 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== MSLTU (RV32)
+
+Mnemonic::
+
+msltu _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MSLTU is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['MSLTU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MSLTU instruction sets `rd` to all ones if `rs1` is less than `rs2` using
+unsigned comparison; otherwise it sets `rd` to zero.
+
+Operation::
+
+[source,pseudocode]
+----
+X[rd] = (X[rs1] <_u X[rs2]) ? 0xFFFFFFFF : 0x00000000
+----
+
+
+
+<<<
+==== PMSLTU.B
+
+Mnemonic::
+
+pmsltu.b _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMSLTU.B is encoded in the OP-32 major opcode with packed byte elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xb, attr: ['PMSLTU.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMSLTU.B performs an unsigned less-than comparison on corresponding packed 8-bit
+byte elements of `rs1` and `rs2`. For each element, if the unsigned value of
+`rs1` is less than the unsigned value of `rs2`, the corresponding byte in `rd` is
+set to all-ones (0xFF); otherwise it is set to all-zeros (0x00).
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/8 - 1):
+    a = unsigned(s1[(8*i+7):(8*i)])
+    b = unsigned(s2[(8*i+7):(8*i)])
+    d[(8*i+7):(8*i)] = (a < b) ? 0xFF : 0x00
+
+X[rd] = d
+----
+
+
+<<<
+==== PMSLTU.H
+
+Mnemonic::
+
+pmsltu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMSLTU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xb, attr: ['PMSLTU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMSLTU.H performs an unsigned less-than comparison on corresponding packed 16-bit
+halfword elements of `rs1` and `rs2`. For each element, if the unsigned value of
+`rs1` is less than the unsigned value of `rs2`, the corresponding halfword in
+`rd` is set to all-ones (0xFFFF); otherwise it is set to all-zeros (0x0000).
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = unsigned(s1[(16*i+15):(16*i)])
+    b = unsigned(s2[(16*i+15):(16*i)])
+    d[(16*i+15):(16*i)] = (a < b) ? 0xFFFF : 0x0000
+
+X[rd] = d
+----
+
+
+<<<
+==== PMSLTU.W (RV64)
+
+Mnemonic::
+
+pmsltu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMSLTU.W is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x6 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['PMSLTU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMSLTU.W instruction performs unsigned less-than comparisons on corresponding
+packed 32-bit elements and produces a packed word mask in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d0 = (s1[31:0]  <_u s2[31:0])  ? 0xFFFFFFFF : 0x00000000
+d1 = (s1[63:32] <_u s2[63:32]) ? 0xFFFFFFFF : 0x00000000
+X[rd] = d1 @ d0
 ----
 
 
@@ -10396,6 +10397,105 @@ if (rd_p != 0):
 <<<
 === Saturation/Clipping
 
+==== SATI
+
+Mnemonic::
+
+sati _rd_, _rs1_, _width_
+
+Encoding::
+
+SATI is encoded in the OP-IMM-32 major opcode.
+
+RV32:
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['SATI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+RV64:
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['SATI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SATI instruction saturates `rs1` to the signed range
+[-(2^width-1^), 2^width-1^-1] where `width` is specified by `uimm5`+1(RV32) or
+`uimm6`+1(RV64). If the value exceeds the range, the result is clamped to the
+nearest bound and the `vxsat` overflow flag is set. Values within the range are
+passed through unchanged.
+
+Operation::
+
+RV32:
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n  = uimm5[4:0]
+
+minval = 0xFFFF_FFFF << n
+maxval = ~minval
+
+if (s1 <_s minval):
+    vxsat = 1
+    X[rd] = minval
+else if (s1 >_s maxval):
+    vxsat = 1
+    X[rd] = maxval
+else:
+    X[rd] = s1
+----
+
+RV64:
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n  = uimm6[5:0]
+
+minval = 0xFFFF_FFFF_FFFF_FFFF << n
+maxval = ~minval
+
+if (s1 <_s minval):
+    vxsat = 1
+    X[rd] = minval
+else if (s1 >_s maxval):
+    vxsat = 1
+    X[rd] = maxval
+else:
+    X[rd] = s1
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs.
+
+<<<
 ==== PSATI.H
 
 Mnemonic::
@@ -10518,326 +10618,6 @@ X[rd] = d
 Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PUSATI.H
-
-Mnemonic::
-
-pusati.h _rd_, _rs1_, _uimm4_
-
-Encoding::
-
-PUSATI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format for
-packed halfword elements with a 4-bit unsigned immediate.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 4, name: 'uimm4' },
-    { bits: 3, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x2, attr: ['PUSATI.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PUSATI.H performs unsigned saturation on each packed 16-bit halfword element of
-`rs1` to the range [0, 2^width^-1], where `width` is specified by `uimm4`.
-Negative values are clamped to zero and values exceeding the maximum are clamped
-to 2^width^-1. When clamping occurs, the `vxsat` overflow flag is set.
-Elements already within range are passed through unchanged.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-n = uimm4[3:0]
-maxval_h = ~(0xFFFF << n) & 0xFFFF
-
-for i = 0 .. (XLEN/16 - 1):
-    e = signed(s1[(16*i+15):(16*i)])
-    if e < 0:
-        d[(16*i+15):(16*i)] = 0x0000
-        vxsat = 1
-    else if e > signed(maxval_h):
-        d[(16*i+15):(16*i)] = maxval_h
-        vxsat = 1
-    else:
-        d[(16*i+15):(16*i)] = s1[(16*i+15):(16*i)]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PUSATI.W (RV64)
-
-Mnemonic::
-
-pusati.w _rd_, _rs1_, _uimm5_
-
-Encoding::
-
-PUSATI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format for
-packed word elements with a 5-bit unsigned immediate. Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x2, attr: ['PUSATI.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PUSATI.W performs unsigned saturation on each packed 32-bit word element of `rs1`
-to the range [0, 2^width^-1], where `width` is specified by `uimm5`.
-Negative values are clamped to zero and values exceeding the maximum are clamped
-to 2^width^-1. When clamping occurs, the `vxsat` overflow flag is set. Elements
-already within range are passed through unchanged. Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-n = uimm5[4:0]
-maxval_w = ~(0xFFFFFFFF << n) & 0xFFFFFFFF
-
-for i = 0 .. (XLEN/32 - 1):
-    e = signed(s1[(32*i+31):(32*i)])
-    if e < 0:
-        d[(32*i+31):(32*i)] = 0x00000000
-        vxsat = 1
-    else if e > signed(maxval_w):
-        d[(32*i+31):(32*i)] = maxval_w
-        vxsat = 1
-    else:
-        d[(32*i+31):(32*i)] = s1[(32*i+31):(32*i)]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== SATI
-
-Mnemonic::
-
-sati _rd_, _rs1_, _width_
-
-Encoding::
-
-SATI is encoded in the OP-IMM-32 major opcode.
-
-RV32:
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x6, attr: ['SATI'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-RV64:
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x6, attr: ['SATI'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SATI instruction saturates `rs1` to the signed range
-[-(2^width-1^), 2^width-1^-1] where `width` is specified by `uimm5`+1(RV32) or
-`uimm6`+1(RV64). If the value exceeds the range, the result is clamped to the
-nearest bound and the `vxsat` overflow flag is set. Values within the range are
-passed through unchanged.
-
-Operation::
-
-RV32:
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-n  = uimm5[4:0]
-
-minval = 0xFFFF_FFFF << n
-maxval = ~minval
-
-if (s1 <_s minval):
-    vxsat = 1
-    X[rd] = minval
-else if (s1 >_s maxval):
-    vxsat = 1
-    X[rd] = maxval
-else:
-    X[rd] = s1
-----
-
-RV64:
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-n  = uimm6[5:0]
-
-minval = 0xFFFF_FFFF_FFFF_FFFF << n
-maxval = ~minval
-
-if (s1 <_s minval):
-    vxsat = 1
-    X[rd] = minval
-else if (s1 >_s maxval):
-    vxsat = 1
-    X[rd] = maxval
-else:
-    X[rd] = s1
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs.
-
-<<<
-==== USATI
-
-Mnemonic::
-
-usati _rd_, _rs1_, _uimm5_ (RV32) +
-usati _rd_, _rs1_, _uimm6_ (RV64)
-
-Encoding::
-
-USATI is encoded in the OP-IMM-32 major opcode.
-
-RV32:
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x2, attr: ['USATI'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-RV64:
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x2, attr: ['USATI'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The USATI instruction saturates `rs1` to the unsigned range [0, 2^width^-1]
-where `width` is specified by `uimm5`(RV32) or `uimm6`(RV64). Negative values
-are clamped to zero and values exceeding the maximum are clamped to 2^width^-1.
-When clamping occurs, the `vxsat` overflow flag is set. Values already within
-range are passed through unchanged.
-
-Operation::
-
-RV32:
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-n  = uimm5[4:0]
-
-maxval = ~(FFFF_FFFF << n)
-
-if (s1 <_s 0):
-    vxsat = 1
-    X[rd] = 0
-else if (s1 >_s maxval):
-    vxsat = 1
-    X[rd] = maxval
-else:
-    X[rd] = s1
-----
-
-RV64:
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-n  = uimm6[5:0]
-
-maxval = ~(0xFFFF_FFFF_FFFF_FFFF << n)
-
-if (s1 <_s 0):
-    vxsat = 1
-    X[rd] = 0
-else if (s1 >_s maxval):
-    vxsat = 1
-    X[rd] = maxval
-else:
-    X[rd] = s1
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs.
-
 
 <<<
 ==== PSATI.DH (RV32)
@@ -10970,6 +10750,227 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== USATI
+
+Mnemonic::
+
+usati _rd_, _rs1_, _uimm5_ (RV32) +
+usati _rd_, _rs1_, _uimm6_ (RV64)
+
+Encoding::
+
+USATI is encoded in the OP-IMM-32 major opcode.
+
+RV32:
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['USATI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+RV64:
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['USATI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The USATI instruction saturates `rs1` to the unsigned range [0, 2^width^-1]
+where `width` is specified by `uimm5`(RV32) or `uimm6`(RV64). Negative values
+are clamped to zero and values exceeding the maximum are clamped to 2^width^-1.
+When clamping occurs, the `vxsat` overflow flag is set. Values already within
+range are passed through unchanged.
+
+Operation::
+
+RV32:
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n  = uimm5[4:0]
+
+maxval = ~(FFFF_FFFF << n)
+
+if (s1 <_s 0):
+    vxsat = 1
+    X[rd] = 0
+else if (s1 >_s maxval):
+    vxsat = 1
+    X[rd] = maxval
+else:
+    X[rd] = s1
+----
+
+RV64:
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n  = uimm6[5:0]
+
+maxval = ~(0xFFFF_FFFF_FFFF_FFFF << n)
+
+if (s1 <_s 0):
+    vxsat = 1
+    X[rd] = 0
+else if (s1 >_s maxval):
+    vxsat = 1
+    X[rd] = maxval
+else:
+    X[rd] = s1
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs.
+
+
+<<<
+==== PUSATI.H
+
+Mnemonic::
+
+pusati.h _rd_, _rs1_, _uimm4_
+
+Encoding::
+
+PUSATI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format for
+packed halfword elements with a 4-bit unsigned immediate.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 4, name: 'uimm4' },
+    { bits: 3, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PUSATI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PUSATI.H performs unsigned saturation on each packed 16-bit halfword element of
+`rs1` to the range [0, 2^width^-1], where `width` is specified by `uimm4`.
+Negative values are clamped to zero and values exceeding the maximum are clamped
+to 2^width^-1. When clamping occurs, the `vxsat` overflow flag is set.
+Elements already within range are passed through unchanged.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n = uimm4[3:0]
+maxval_h = ~(0xFFFF << n) & 0xFFFF
+
+for i = 0 .. (XLEN/16 - 1):
+    e = signed(s1[(16*i+15):(16*i)])
+    if e < 0:
+        d[(16*i+15):(16*i)] = 0x0000
+        vxsat = 1
+    else if e > signed(maxval_h):
+        d[(16*i+15):(16*i)] = maxval_h
+        vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = s1[(16*i+15):(16*i)]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PUSATI.W (RV64)
+
+Mnemonic::
+
+pusati.w _rd_, _rs1_, _uimm5_
+
+Encoding::
+
+PUSATI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format for
+packed word elements with a 5-bit unsigned immediate. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PUSATI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PUSATI.W performs unsigned saturation on each packed 32-bit word element of `rs1`
+to the range [0, 2^width^-1], where `width` is specified by `uimm5`.
+Negative values are clamped to zero and values exceeding the maximum are clamped
+to 2^width^-1. When clamping occurs, the `vxsat` overflow flag is set. Elements
+already within range are passed through unchanged. Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+n = uimm5[4:0]
+maxval_w = ~(0xFFFFFFFF << n) & 0xFFFFFFFF
+
+for i = 0 .. (XLEN/32 - 1):
+    e = signed(s1[(32*i+31):(32*i)])
+    if e < 0:
+        d[(32*i+31):(32*i)] = 0x00000000
+        vxsat = 1
+    else if e > signed(maxval_w):
+        d[(32*i+31):(32*i)] = maxval_w
+        vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = s1[(32*i+31):(32*i)]
+
+X[rd] = d
 ----
 
 Notes::
@@ -11248,819 +11249,6 @@ X[rd] = d
 
 
 <<<
-==== PSRL.BS
-
-Mnemonic::
-
-psrl.bs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSRL.BS is encoded in the OP-IMM-32 major opcode.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x0, attr: ['PSRL.BS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSRL.BS instruction logically shifts each packed 8-bit element of `rs1`
-right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = X[rs2][4:0]
-for i = 0 .. (XLEN/8 - 1):
-    b = s1[(8*i+7):(8*i)]
-    d[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRL.HS
-
-Mnemonic::
-
-psrl.hs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSRL.HS is encoded in the OP-IMM-32 major opcode.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x0, attr: ['PSRL.HS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSRL.HS instruction logically shifts each packed 16-bit element of `rs1`
-right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = X[rs2][4:0]
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRL.WS (RV64)
-
-Mnemonic::
-
-psrl.ws _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSRL.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
-and word elements. Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x0, attr: ['PSRL.WS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSRL.WS logically shifts each packed 32-bit element of `rs1` right by the
-scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
-Bits shifted out are discarded and vacated bit positions are filled with zeros.
-Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = X[rs2][4:0]
-for i = 0 .. (XLEN/32 - 1):
-    w = s1[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = (zero_extend(64, w) >> shamt)[31:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRA.BS
-
-Mnemonic::
-
-psra.bs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSRA.BS is encoded in the OP-IMM-32 major opcode.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x4, attr: ['PSRA.BS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSRA.BS instruction arithmetically shifts each packed 8-bit element of `rs1`
-right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = X[rs2][4:0]
-for i = 0 .. (XLEN/8 - 1):
-    b = s1[(8*i+7):(8*i)]
-    d[(8*i+7):(8*i)] = (sign_extend(40, b) >> shamt)[7:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRA.HS
-
-Mnemonic::
-
-psra.hs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSRA.HS is encoded in the OP-IMM-32 major opcode.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x4, attr: ['PSRA.HS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSRA.HS instruction arithmetically shifts each packed 16-bit element of `rs1`
-right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = X[rs2][4:0]
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = (sign_extend(48, h) >> shamt)[15:0]
-X[rd] = d
-----
-
-
-
-<<<
-==== PSRA.WS (RV64)
-
-Mnemonic::
-
-psra.ws _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSRA.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
-and word elements. Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x4, attr: ['PSRA.WS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PSRA.WS arithmetically shifts each packed 32-bit element of `rs1` right by the
-scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
-Bits shifted out are discarded and vacated bit positions are filled with copies
-of the sign bit. Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = X[rs2][4:0]
-for i = 0 .. (XLEN/32 - 1):
-    w = s1[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = (sign_extend(64, w) >> shamt)[31:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSLLI.B
-
-Mnemonic::
-
-pslli.b _rd_, _rs1_, _uimm3_
-
-Encoding::
-
-PSLLI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
-and an immediate shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 3, name: 'uimm3' },
-    { bits: 4, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['PSLLI.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm3` field encodes the 3-bit shift amount for byte elements.
-
-Description::
-
-PSLLI.B shifts each packed 8-bit element of `rs1` left by the immediate shift
-amount encoded in `uimm3` and writes the packed byte result to `rd`. Bits
-shifted out are discarded and vacated bit positions are filled with zeros.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm3[2:0]
-for i = 0 .. (XLEN/8 - 1):
-    b = s1[(8*i+7):(8*i)]
-    d[(8*i+7):(8*i)] = (zero_extend(32, b) << shamt)[7:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSLLI.H
-
-Mnemonic::
-
-pslli.h _rd_, _rs1_, _uimm4_
-
-Encoding::
-
-PSLLI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
-and an immediate shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 4, name: 'uimm4' },
-    { bits: 3, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['PSLLI.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm4` field encodes the 4-bit shift amount for halfword elements.
-
-Description::
-
-PSLLI.H shifts each packed 16-bit element of `rs1` left by the immediate shift
-amount encoded in `uimm4` and writes the packed halfword result to `rd`.
-Bits shifted out are discarded and vacated bit positions are filled with zeros.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm4[3:0]
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSLLI.W (RV64)
-
-Mnemonic::
-
-pslli.w _rd_, _rs1_, _uimm5_
-
-Encoding::
-
-PSLLI.W is encoded in the OP-IMM-32 major opcode with packed word elements
-and an immediate shift amount. Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['PSLLI.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm5` field encodes the 5-bit shift amount for word elements.
-
-Description::
-
-PSLLI.W shifts each packed 32-bit element of `rs1` left by the immediate shift
-amount encoded in `uimm5` and writes the packed word result to `rd`. Bits
-shifted out are discarded and vacated bit positions are filled with zeros.
-Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm5[4:0]
-for i = 0 .. (XLEN/32 - 1):
-    w = s1[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = (zero_extend(64, w) << shamt)[31:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRLI.B
-
-Mnemonic::
-
-psrli.b _rd_, _rs1_, _uimm3_
-
-Encoding::
-
-PSRLI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
-and an immediate shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 3, name: 'uimm3' },
-    { bits: 4, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['PSRLI.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm3` field encodes the 3-bit shift amount for byte elements.
-
-Description::
-
-PSRLI.B logically shifts each packed 8-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm3` and writes the packed byte result
-to `rd`. Bits shifted out are discarded and vacated bit positions are filled
-with zeros.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm3[2:0]
-for i = 0 .. (XLEN/8 - 1):
-    b = s1[(8*i+7):(8*i)]
-    d[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRLI.H
-
-Mnemonic::
-
-psrli.h _rd_, _rs1_, _uimm4_
-
-Encoding::
-
-PSRLI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
-and an immediate shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 4, name: 'uimm4' },
-    { bits: 3, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['PSRLI.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm4` field encodes the 4-bit shift amount for halfword elements.
-
-Description::
-
-PSRLI.H logically shifts each packed 16-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm4` and writes the packed halfword
-result to `rd`. Bits shifted out are discarded and vacated bit positions are
-filled with zeros.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm4[3:0]
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRLI.W (RV64)
-
-Mnemonic::
-
-psrli.w _rd_, _rs1_, _uimm5_
-
-Encoding::
-
-PSRLI.W is encoded in the OP-IMM-32 major opcode with packed word elements
-and an immediate shift amount. Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['PSRLI.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm5` field encodes the 5-bit shift amount for word elements.
-
-Description::
-
-PSRLI.W logically shifts each packed 32-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm5` and writes the packed word result
-to `rd`. Bits shifted out are discarded and vacated bit positions are filled
-with zeros. Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm5[4:0]
-for i = 0 .. (XLEN/32 - 1):
-    w = s1[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = (zero_extend(64, w) >> shamt)[31:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRAI.B
-
-Mnemonic::
-
-psrai.b _rd_, _rs1_, _uimm3_
-
-Encoding::
-
-PSRAI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
-and an immediate shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 3, name: 'uimm3' },
-    { bits: 4, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x4, attr: ['PSRAI.B'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm3` field encodes the 3-bit shift amount for byte elements.
-
-Description::
-
-PSRAI.B arithmetically shifts each packed 8-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm3` and writes the packed byte result
-to `rd`. Bits shifted out are discarded and vacated bit positions are filled
-with copies of the sign bit.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm3[2:0]
-for i = 0 .. (XLEN/8 - 1):
-    b = s1[(8*i+7):(8*i)]
-    d[(8*i+7):(8*i)] = (sign_extend(40, b) >> shamt)[7:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRAI.H
-
-Mnemonic::
-
-psrai.h _rd_, _rs1_, _uimm4_
-
-Encoding::
-
-PSRAI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
-and an immediate shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 4, name: 'uimm4' },
-    { bits: 3, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x4, attr: ['PSRAI.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm4` field encodes the 4-bit shift amount for halfword elements.
-
-Description::
-
-PSRAI.H arithmetically shifts each packed 16-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm4` and writes the packed halfword
-result to `rd`. Bits shifted out are discarded and vacated bit positions are
-filled with copies of the sign bit.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm4[3:0]
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = (sign_extend(48, h) >> shamt)[15:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRAI.W (RV64)
-
-Mnemonic::
-
-psrai.w _rd_, _rs1_, _uimm5_
-
-Encoding::
-
-PSRAI.W is encoded in the OP-IMM-32 major opcode with packed word elements
-and an immediate shift amount. Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x4, attr: ['PSRAI.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm5` field encodes the 5-bit shift amount for word elements.
-
-Description::
-
-PSRAI.W arithmetically shifts each packed 32-bit element of `rs1` right by the
-immediate shift amount encoded in `uimm5` and writes the packed word result
-to `rd`. Bits shifted out are discarded and vacated bit positions are filled
-with copies of the sign bit. Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm5[4:0]
-for i = 0 .. (XLEN/32 - 1):
-    w = s1[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = (sign_extend(64, w) >> shamt)[31:0]
-X[rd] = d
-----
-
-
-<<<
-==== PSRARI.H
-
-Mnemonic::
-
-psrari.h _rd_, _rs1_, _uimm4_
-
-Encoding::
-
-PSRARI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
-and an immediate shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 4, name: 'uimm4' },
-    { bits: 3, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['PSRARI.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm4` field encodes the 4-bit shift amount for halfword elements.
-
-Description::
-
-PSRARI.H arithmetically shifts each packed 16-bit element of `rs1` right by
-the immediate shift amount encoded in `uimm4` with rounding and writes the
-packed halfword result to `rd`. A rounding bit is added before the shift so that
-the result is rounded to the nearest integer (round-to-nearest, ties round up).
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm4[3:0]
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15):(16*i)]
-    // Append rounding bit, shift, then extract rounded result
-    shx[(16+1):0] = ((sign_extend(48, h) @ 0b0) >> shamt)[(16+1):0]
-    d[(16*i+15):(16*i)] = (shx + 1)[16:1]
-X[rd] = d
-----
-
-
-<<<
-==== PSRARI.W (RV64)
-
-Mnemonic::
-
-psrari.w _rd_, _rs1_, _uimm5_
-
-Encoding::
-
-PSRARI.W is encoded in the OP-IMM-32 major opcode with packed word elements
-and an immediate shift amount. Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['PSRARI.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm5` field encodes the 5-bit shift amount for word elements.
-
-Description::
-
-PSRARI.W arithmetically shifts each packed 32-bit element of `rs1` right by
-the immediate shift amount encoded in `uimm5` with rounding and writes the
-packed word result to `rd`. A rounding bit is added before the shift so that the
-result is rounded to the nearest integer (round-to-nearest, ties round up).
-Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm5[4:0]
-for i = 0 .. (XLEN/32 - 1):
-    w = s1[(32*i+31):(32*i)]
-    // Append rounding bit, shift, then extract rounded result
-    shx[(32+1):0] = ((sign_extend(64, w) @ 0b0) >> shamt)[(32+1):0]
-    d[(32*i+31):(32*i)] = (shx + 1)[32:1]
-X[rd] = d
-----
-
-
-<<<
 ==== PSLL.DBS (RV32)
 
 Mnemonic::
@@ -12231,6 +11419,141 @@ if (rd_p != 0):
 
 
 <<<
+==== PSRL.BS
+
+Mnemonic::
+
+psrl.bs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSRL.BS is encoded in the OP-IMM-32 major opcode.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSRL.BS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSRL.BS instruction logically shifts each packed 8-bit element of `rs1`
+right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/8 - 1):
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSRL.HS
+
+Mnemonic::
+
+psrl.hs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSRL.HS is encoded in the OP-IMM-32 major opcode.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSRL.HS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSRL.HS instruction logically shifts each packed 16-bit element of `rs1`
+right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSRL.WS (RV64)
+
+Mnemonic::
+
+psrl.ws _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSRL.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
+and word elements. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PSRL.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSRL.WS logically shifts each packed 32-bit element of `rs1` right by the
+scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (zero_extend(64, w) >> shamt)[31:0]
+X[rd] = d
+----
+
+
+<<<
 ==== PSRL.DBS (RV32)
 
 Mnemonic::
@@ -12397,6 +11720,142 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PSRA.BS
+
+Mnemonic::
+
+psra.bs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSRA.BS is encoded in the OP-IMM-32 major opcode.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['PSRA.BS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSRA.BS instruction arithmetically shifts each packed 8-bit element of `rs1`
+right by the shift amount in `rs2[4:0]` and writes the packed byte result to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/8 - 1):
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (sign_extend(40, b) >> shamt)[7:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSRA.HS
+
+Mnemonic::
+
+psra.hs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSRA.HS is encoded in the OP-IMM-32 major opcode.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['PSRA.HS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSRA.HS instruction arithmetically shifts each packed 16-bit element of `rs1`
+right by the shift amount in `rs2[4:0]` and writes the packed halfword result to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (sign_extend(48, h) >> shamt)[15:0]
+X[rd] = d
+----
+
+
+
+<<<
+==== PSRA.WS (RV64)
+
+Mnemonic::
+
+psra.ws _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSRA.WS is encoded in the OP-IMM-32 major opcode with scalar shift amount
+and word elements. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['PSRA.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PSRA.WS arithmetically shifts each packed 32-bit element of `rs1` right by the
+scalar shift amount in `rs2[4:0]` and writes the packed word result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with copies
+of the sign bit. Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (sign_extend(64, w) >> shamt)[31:0]
+X[rd] = d
 ----
 
 
@@ -12574,6 +12033,151 @@ if (rd_p != 0):
 
 
 <<<
+==== PSLLI.B
+
+Mnemonic::
+
+pslli.b _rd_, _rs1_, _uimm3_
+
+Encoding::
+
+PSLLI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 3, name: 'uimm3' },
+    { bits: 4, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm3` field encodes the 3-bit shift amount for byte elements.
+
+Description::
+
+PSLLI.B shifts each packed 8-bit element of `rs1` left by the immediate shift
+amount encoded in `uimm3` and writes the packed byte result to `rd`. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm3[2:0]
+for i = 0 .. (XLEN/8 - 1):
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (zero_extend(32, b) << shamt)[7:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSLLI.H
+
+Mnemonic::
+
+pslli.h _rd_, _rs1_, _uimm4_
+
+Encoding::
+
+PSLLI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 4, name: 'uimm4' },
+    { bits: 3, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm4` field encodes the 4-bit shift amount for halfword elements.
+
+Description::
+
+PSLLI.H shifts each packed 16-bit element of `rs1` left by the immediate shift
+amount encoded in `uimm4` and writes the packed halfword result to `rd`.
+Bits shifted out are discarded and vacated bit positions are filled with zeros.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm4[3:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (zero_extend(32, h) << shamt)[15:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSLLI.W (RV64)
+
+Mnemonic::
+
+pslli.w _rd_, _rs1_, _uimm5_
+
+Encoding::
+
+PSLLI.W is encoded in the OP-IMM-32 major opcode with packed word elements
+and an immediate shift amount. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSLLI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm5` field encodes the 5-bit shift amount for word elements.
+
+Description::
+
+PSLLI.W shifts each packed 32-bit element of `rs1` left by the immediate shift
+amount encoded in `uimm5` and writes the packed word result to `rd`. Bits
+shifted out are discarded and vacated bit positions are filled with zeros.
+Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm5[4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (zero_extend(64, w) << shamt)[31:0]
+X[rd] = d
+----
+
+
+<<<
 ==== PSLLI.DB (RV32)
 
 Mnemonic::
@@ -12739,6 +12343,153 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PSRLI.B
+
+Mnemonic::
+
+psrli.b _rd_, _rs1_, _uimm3_
+
+Encoding::
+
+PSRLI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 3, name: 'uimm3' },
+    { bits: 4, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm3` field encodes the 3-bit shift amount for byte elements.
+
+Description::
+
+PSRLI.B logically shifts each packed 8-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm3` and writes the packed byte result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with zeros.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm3[2:0]
+for i = 0 .. (XLEN/8 - 1):
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (zero_extend(32, b) >> shamt)[7:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSRLI.H
+
+Mnemonic::
+
+psrli.h _rd_, _rs1_, _uimm4_
+
+Encoding::
+
+PSRLI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 4, name: 'uimm4' },
+    { bits: 3, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm4` field encodes the 4-bit shift amount for halfword elements.
+
+Description::
+
+PSRLI.H logically shifts each packed 16-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm4` and writes the packed halfword
+result to `rd`. Bits shifted out are discarded and vacated bit positions are
+filled with zeros.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm4[3:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (zero_extend(32, h) >> shamt)[15:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSRLI.W (RV64)
+
+Mnemonic::
+
+psrli.w _rd_, _rs1_, _uimm5_
+
+Encoding::
+
+PSRLI.W is encoded in the OP-IMM-32 major opcode with packed word elements
+and an immediate shift amount. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PSRLI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm5` field encodes the 5-bit shift amount for word elements.
+
+Description::
+
+PSRLI.W logically shifts each packed 32-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm5` and writes the packed word result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with zeros. Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm5[4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (zero_extend(64, w) >> shamt)[31:0]
+X[rd] = d
 ----
 
 
@@ -12914,6 +12665,153 @@ if (rd_p != 0):
 
 
 <<<
+==== PSRAI.B
+
+Mnemonic::
+
+psrai.b _rd_, _rs1_, _uimm3_
+
+Encoding::
+
+PSRAI.B is encoded in the OP-IMM-32 major opcode with packed byte elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 3, name: 'uimm3' },
+    { bits: 4, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.B'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm3` field encodes the 3-bit shift amount for byte elements.
+
+Description::
+
+PSRAI.B arithmetically shifts each packed 8-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm3` and writes the packed byte result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with copies of the sign bit.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm3[2:0]
+for i = 0 .. (XLEN/8 - 1):
+    b = s1[(8*i+7):(8*i)]
+    d[(8*i+7):(8*i)] = (sign_extend(40, b) >> shamt)[7:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSRAI.H
+
+Mnemonic::
+
+psrai.h _rd_, _rs1_, _uimm4_
+
+Encoding::
+
+PSRAI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 4, name: 'uimm4' },
+    { bits: 3, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm4` field encodes the 4-bit shift amount for halfword elements.
+
+Description::
+
+PSRAI.H arithmetically shifts each packed 16-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm4` and writes the packed halfword
+result to `rd`. Bits shifted out are discarded and vacated bit positions are
+filled with copies of the sign bit.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm4[3:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (sign_extend(48, h) >> shamt)[15:0]
+X[rd] = d
+----
+
+
+<<<
+==== PSRAI.W (RV64)
+
+Mnemonic::
+
+psrai.w _rd_, _rs1_, _uimm5_
+
+Encoding::
+
+PSRAI.W is encoded in the OP-IMM-32 major opcode with packed word elements
+and an immediate shift amount. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PSRAI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm5` field encodes the 5-bit shift amount for word elements.
+
+Description::
+
+PSRAI.W arithmetically shifts each packed 32-bit element of `rs1` right by the
+immediate shift amount encoded in `uimm5` and writes the packed word result
+to `rd`. Bits shifted out are discarded and vacated bit positions are filled
+with copies of the sign bit. Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm5[4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (sign_extend(64, w) >> shamt)[31:0]
+X[rd] = d
+----
+
+
+<<<
 ==== PSRAI.DB (RV32)
 
 Mnemonic::
@@ -13085,6 +12983,186 @@ if (rd_p != 0):
 
 
 <<<
+==== SRARI
+
+Mnemonic::
+
+srari _rd_, _rs1_, _uimm5_ (RV32) +
+srari _rd_, _rs1_, _uimm6_ (RV64)
+
+Encoding::
+
+SRARI is encoded in the OP-IMM-32 major opcode with the w-uimm format as
+a scalar XLEN-wide shift right arithmetic with rounding. In RV32 the shift
+amount is 5 bits; in RV64 the shift amount is 6 bits.
+
+RV32:
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 7, name: '01xxxxx' },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['SRARI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm5` field encodes the 5-bit shift amount for RV32.
+
+RV64:
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['SRARI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm6` field encodes the 6-bit shift amount for RV64.
+
+Description::
+
+SRARI arithmetically shifts the XLEN-wide value in `rs1` right by the
+immediate shift amount with rounding and writes the result to `rd`. A
+rounding bit is added before the final shift so that the result is rounded
+to the nearest integer (round-to-nearest, ties round up). When the shift
+amount is zero the source value is written unchanged.
+
+Operation::
+
+[source,pseudocode]
+----
+a = X[rs1]
+shamt = uimm6[log2(XLEN)-1:0]
+
+if shamt == 0:
+    d = a
+else:
+    // Append rounding bit, shift, then extract rounded result
+    shx[(XLEN+1):0] = ((sign_extend(2*XLEN, a) @ 0b0) >> shamt)[(XLEN+1):0]
+    d = (shx + 1)[XLEN:1]
+
+X[rd] = d
+----
+
+
+<<<
+==== PSRARI.H
+
+Mnemonic::
+
+psrari.h _rd_, _rs1_, _uimm4_
+
+Encoding::
+
+PSRARI.H is encoded in the OP-IMM-32 major opcode with packed halfword elements
+and an immediate shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 4, name: 'uimm4' },
+    { bits: 3, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSRARI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm4` field encodes the 4-bit shift amount for halfword elements.
+
+Description::
+
+PSRARI.H arithmetically shifts each packed 16-bit element of `rs1` right by
+the immediate shift amount encoded in `uimm4` with rounding and writes the
+packed halfword result to `rd`. A rounding bit is added before the shift so that
+the result is rounded to the nearest integer (round-to-nearest, ties round up).
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm4[3:0]
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]
+    // Append rounding bit, shift, then extract rounded result
+    shx[(16+1):0] = ((sign_extend(48, h) @ 0b0) >> shamt)[(16+1):0]
+    d[(16*i+15):(16*i)] = (shx + 1)[16:1]
+X[rd] = d
+----
+
+
+<<<
+==== PSRARI.W (RV64)
+
+Mnemonic::
+
+psrari.w _rd_, _rs1_, _uimm5_
+
+Encoding::
+
+PSRARI.W is encoded in the OP-IMM-32 major opcode with packed word elements
+and an immediate shift amount. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSRARI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm5` field encodes the 5-bit shift amount for word elements.
+
+Description::
+
+PSRARI.W arithmetically shifts each packed 32-bit element of `rs1` right by
+the immediate shift amount encoded in `uimm5` with rounding and writes the
+packed word result to `rd`. A rounding bit is added before the shift so that the
+result is rounded to the nearest integer (round-to-nearest, ties round up).
+Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm5[4:0]
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]
+    // Append rounding bit, shift, then extract rounded result
+    shx[(32+1):0] = ((sign_extend(64, w) @ 0b0) >> shamt)[(32+1):0]
+    d[(32*i+31):(32*i)] = (shx + 1)[32:1]
+X[rd] = d
+----
+
+
+<<<
 ==== PSRARI.DH (RV32)
 
 Mnemonic::
@@ -13213,6 +13291,123 @@ if (rd_p != 0):
 <<<
 === Saturating/Rounding Shift
 
+==== SHA (RV64)
+
+Mnemonic::
+
+sha _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SHA is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['SHA'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SHA instruction performs a signed variable shift of `rs1` using the signed
+shift amount in `rs2[7:0]`. Negative shift amounts shift right; non-negative
+shift amounts shift left.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+if (sshamt < 0):
+    xs1 = sign_extend(128, s1)
+    if (sshamt <= -64):
+        X[rd] = xs1[127:64]
+    else:
+        X[rd] = (xs1 >> (0 - shamt)[5:0])[63:0]
+else:
+    if (sshamt >= 64):
+        X[rd] = 0
+    else:
+        X[rd] = s1 << shamt[5:0]
+----
+
+
+<<<
+==== SSHA (RV32)
+
+Mnemonic::
+
+ssha _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SSHA is encoded in the OP-IMM-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['SSHA'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SSHA instruction performs a signed variable shift of `rs1` using the signed
+shift amount in `rs2[7:0]`. Left shifts saturate to the signed 32-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+xs1    = sign_extend(64, s1)
+
+if sshamt < 0:
+    if sshamt <= -32:
+        X[rd] = xs1[63:32]
+    else
+        X[rd] = (xs1 >> (0 - shamt)[4:0])[31:0]
+else:
+    shx = (sshamt >= 32) ? (s1 @ 0x00000000)
+                         : (xs1 << shamt[4:0])
+
+    if shx <_s 0xFFFFFFFF80000000:
+        vxsat = 1
+        X[rd] = 0x80000000
+    else if shx >_s 0x000000007FFFFFFF:
+        vxsat = 1
+        X[rd] = 0x7FFFFFFF
+    else
+        X[rd] = shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PSSHA.HS
 
 Mnemonic::
@@ -13356,1150 +13551,6 @@ for i = 0 .. (XLEN/32 - 1):
     d[(32*i+31):(32*i)] = r
 
 X[rd] = d
-----
-
-
-<<<
-==== PSSHAR.HS
-
-Mnemonic::
-
-psshar.hs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSHAR.HS is encoded in the OP-IMM-32 major opcode.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x7, attr: ['PSSHAR.HS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSSHAR.HS instruction performs a signed variable shift on each packed 16-bit
-element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
-rounded, and left shifts saturate to the signed 16-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15):(16*i)]    // signed 16-bit
-
-    if sshamt < 0:
-        // arithmetic right shift with rounding
-        x  = sign_extend(32, h) @ 0b0          // 33-bit
-        y  = (sshamt <= -16) ? x[32:16]
-                             : (x >> (0 - shamt)[3:0])[16:0]
-        r  = (y + 1)[16:1]
-    else:
-        // shift left with signed saturation to 16-bit range
-        shx = (sshamt >= 16) ? (h @ 0x0000)
-                             : (sign_extend(32, h) << shamt[3:0])
-
-        if shx <_s 0xFFFF8000:
-            vxsat = 1
-            r = 0x8000
-        else if shx >_s 0x00007FFF:
-            vxsat = 1
-            r = 0x7FFF
-        else
-            r = shx[15:0]
-
-    d[(16*i+15):(16*i)] = r
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PSSHAR.WS (RV64)
-
-Mnemonic::
-
-psshar.ws _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSHAR.WS is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x7, attr: ['PSSHAR.WS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSSHAR.WS instruction performs a signed variable shift on each packed 32-bit
-element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
-rounded, and left shifts saturate to the signed 32-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-for i = 0 .. (XLEN/32 - 1):
-    w = s1[(32*i+31):(32*i)]    // signed 32-bit
-
-    if sshamt < 0:
-        // arithmetic right shift with rounding
-        x  = sign_extend(64, w) @ 0b0          // 65-bit
-        y  = (sshamt <= -32) ? x[64:32]
-                             : (x >> (0 - shamt)[4:0])[32:0]
-        r  = (y + 1)[32:1]
-    else:
-        // shift left with signed saturation to 32-bit range
-        shx = (sshamt >= 32) ? (w @ 0x00000000)
-                             : (sign_extend(64, w) << shamt[4:0])
-
-        if shx <_s 0xFFFFFFFF80000000:
-            vxsat = 1
-            r = 0x80000000
-        else if shx >_s 0x000000007FFFFFFF:
-            vxsat = 1
-            r = 0x7FFFFFFF
-        else
-            r = shx[31:0]
-
-    d[(32*i+31):(32*i)] = r
-
-X[rd] = d
-----
-
-
-<<<
-==== PSSHL.HS
-
-Mnemonic::
-
-psshl.hs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSHL.HS is encoded in the OP-IMM-32 major opcode.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x2, attr: ['PSSHL.HS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSSHL.HS instruction performs an unsigned variable shift on each packed 16-bit
-element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts saturate
-to the signed 16-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = X[rs2][7:0]
-sshamt = signed(shamt)
-
-for i = 0 .. (XLEN/16 - 1):
-    h  = s1[(16*i+15):(16*i)]
-    xh = zero_extend(32, h)
-
-    if sshamt < 0:
-        // logical shift right by (-sshamt), saturating not required
-        if sshamt <= -16:
-            r = xh[31:16]
-        else
-            r = (xh >> (0 - shamt)[3:0])[15:0]
-    else:
-        // shift left with unsigned saturation to 16-bit range
-        if sshamt >= 16:
-            shx = (h @ 0x0000)
-        else
-            shx = xh << shamt[3:0]
-
-        if shx >_u 0x0000FFFF:
-            vxsat = 1
-            r = 0xFFFF
-        else
-            r = shx[15:0]
-
-    d[(16*i+15):(16*i)] = r
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PSSHL.WS (RV64)
-
-Mnemonic::
-
-psshl.ws _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSHL.WS is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x2, attr: ['PSSHL.WS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSSHL.WS instruction performs an unsigned variable shift on each packed 32-bit
-element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts
-saturate to the unsigned 32-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = X[rs2][7:0]
-sshamt = signed(shamt)
-
-for i = 0 .. (XLEN/32 - 1):
-    w  = s1[(32*i+32):(32*i)]
-    xw = zero_extend(64, w)
-
-    if sshamt < 0:
-        // logical shift right by (-sshamt), saturating not required
-        if sshamt <= -32:
-            r = xh[63:32]
-        else
-            r = (xh >> (0 - shamt)[4:0])[31:0]
-    else:
-        // shift left with unsigned saturation to 32-bit range
-        if sshamt >= 32:
-            shx = (w @ 0x00000000)
-        else
-            shx = xw << shamt[4:0]
-
-        if shx >_u 0xFFFFFFFF:
-            vxsat = 1
-            r = 0xFFFFFFFF
-        else
-            r = shx[31:0]
-
-    d[(32*i+31):(32*i)] = r
-
-X[rd] = d
-----
-
-
-<<<
-==== PSSHLR.HS
-
-Mnemonic::
-
-psshlr.hs _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSHLR.HS is encoded in the OP-IMM-32 major opcode.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x3, attr: ['PSSHLR.HS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSSHLR.HS instruction performs an unsigned variable shift on each packed
-16-bit element of `rs1` using the signed shift amount in `rs2[7:0]`. Right
-shifts are rounded, and left shifts saturate to the unsigned 16-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-for i = 0 .. (XLEN/16 - 1):
-    h = s1[(16*i+15):(16*i)]    // signed 16-bit
-
-    if sshamt < 0:
-        // logical right shift with rounding
-        x  = zero_extend(32, h) @ 0b0          // 33-bit
-        y  = (sshamt <= -16) ? x[32:16]
-                             : (x >> (0 - shamt)[3:0])[16:0]
-        r  = (y + 1)[16:1]
-    else:
-        // shift left with unsigned saturation to 16-bit range
-        shx = (sshamt >= 16) ? (h @ 0x0000)
-                             : (sign_extend(32, h) << shamt[3:0])
-
-        if shx >_u 0x0000FFFF:
-            vxsat = 1
-            r = 0xFFFF
-        else
-            r = shx[15:0]
-
-    d[(16*i+15):(16*i)] = r
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PSSHLR.WS (RV64)
-
-Mnemonic::
-
-psshlr.ws _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PSSHLR.WS is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x3, attr: ['PSSHLR.WS'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PSSHLR.WS instruction performs a unsigned variable shift on each packed
-32-bit element of `rs1` using the signed shift amount in `rs2[7:0]`. Right
-shifts are rounded, and left shifts saturate to the unsigned 32-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-for i = 0 .. (XLEN/32 - 1):
-    w = s1[(32*i+31):(32*i)]    // signed 32-bit
-
-    if sshamt < 0:
-        // logical right shift with rounding
-        x  = zero_extend(64, w) @ 0b0          // 65-bit
-        y  = (sshamt <= -32) ? x[64:32]
-                             : (x >> (0 - shamt)[4:0])[32:0]
-        r  = (y + 1)[32:1]
-    else:
-        // shift left with unsigned saturation to 32-bit range
-        shx = (sshamt >= 32) ? (h @ 0x00000000)
-                             : (zero_extend(32, w) << shamt[4:0])
-
-        if shx >_u 0x00000000FFFFFFFF:
-            vxsat = 1
-            r = 0xFFFF0000
-        else
-            r = shx[31:0]
-
-    d[(32*i+31):(32*i)] = r
-
-X[rd] = d
-----
-
-
-<<<
-==== PSSLAI.H
-
-Mnemonic::
-
-psslai.h _rd_, _rs1_, _uimm4_
-
-Encoding::
-
-PSSLAI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format
-and packed halfword elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 4, name: 'uimm4' },
-    { bits: 3, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['PSSLAI.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm4` field encodes the 4-bit shift amount for halfword elements.
-
-Description::
-
-PSSLAI.H (Packed Saturating Shift Left Arithmetic Immediate, Halfword) shifts
-each packed signed 16-bit element of `rs1` left by a 4-bit unsigned immediate.
-If the shifted result overflows the signed 16-bit range [-2^15^, 2^15^-1], the
-result is saturated to the nearest boundary and the `vxsat` flag is set. The
-packed halfword results are written to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
-
-for i = 0 .. (XLEN/16 - 1):
-    a = signed(s1[(16*i+15):(16*i)])
-    result = a << shamt
-    if result < -2^15:
-        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
-    else if result > 2^15 - 1:
-        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
-    else:
-        d[(16*i+15):(16*i)] = result[15:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PSSLAI.W (RV64)
-
-Mnemonic::
-
-psslai.w _rd_, _rs1_, _uimm5_
-
-Encoding::
-
-PSSLAI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format
-and word elements. Available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['PSSLAI.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm5` field encodes the 5-bit shift amount for word elements.
-
-Description::
-
-PSSLAI.W (Packed Saturating Shift Left Arithmetic Immediate, Word) shifts each
-packed signed 32-bit element of `rs1` left by a 5-bit unsigned immediate. If
-the shifted result overflows the signed 32-bit range [-2^31^, 2^31^-1], the
-result is saturated to the nearest boundary and the `vxsat` flag is set. The
-packed word results are written to `rd`. Available only in RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-shamt = uimm5[4:0]          // 5-bit shift amount for words
-
-for i = 0 .. (XLEN/32 - 1):
-    a = signed(s1[(32*i+31):(32*i)])
-    result = a << shamt
-    if result < -2^31:
-        d[(32*i+31):(32*i)] = 0x80000000; vxsat = 1
-    else if result > 2^31 - 1:
-        d[(32*i+31):(32*i)] = 0x7FFFFFFF; vxsat = 1
-    else:
-        d[(32*i+31):(32*i)] = result[31:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== SSHA (RV32)
-
-Mnemonic::
-
-ssha _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SSHA is encoded in the OP-IMM-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x6, attr: ['SSHA'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SSHA instruction performs a signed variable shift of `rs1` using the signed
-shift amount in `rs2[7:0]`. Left shifts saturate to the signed 32-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-xs1    = sign_extend(64, s1)
-
-if sshamt < 0:
-    if sshamt <= -32:
-        X[rd] = xs1[63:32]
-    else
-        X[rd] = (xs1 >> (0 - shamt)[4:0])[31:0]
-else:
-    shx = (sshamt >= 32) ? (s1 @ 0x00000000)
-                         : (xs1 << shamt[4:0])
-
-    if shx <_s 0xFFFFFFFF80000000:
-        vxsat = 1
-        X[rd] = 0x80000000
-    else if shx >_s 0x000000007FFFFFFF:
-        vxsat = 1
-        X[rd] = 0x7FFFFFFF
-    else
-        X[rd] = shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== SSHAR (RV32)
-
-Mnemonic::
-
-sshar _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SSHAR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x7, attr: ['SSHAR'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SSHAR instruction performs a signed variable shift of `rs1` using the signed
-shift amount in `rs2[7:0]`. Right shifts are rounded, and left shifts saturate
-to the signed 32-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-if sshamt < 0:
-    // arithmetic right shift with rounding
-    x  = sign_extend(64, s1) @ 0b0            // 65-bit
-    y  = (sshamt <= -32) ? x[64:32]
-                         : (x >> (0 - shamt)[4:0])[32:0]
-    X[rd] = (y + 1)[32:1]
-else:
-    // shift left with signed saturation to 32-bit range
-    shx = (sshamt >= 32) ? (s1 @ 0x00000000)
-                         : (sign_extend(64, s1) << shamt[4:0])
-
-    if shx <_s 0xFFFFFFFF80000000:
-        vxsat = 1
-        X[rd] = 0x80000000
-    else if shx >_s 0x000000007FFFFFFF:
-        vxsat = 1
-        X[rd] = 0x7FFFFFFF
-    else
-        X[rd] = shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs.
-
-<<<
-==== SSHL (RV32)
-
-Mnemonic::
-
-sshl _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SSHL is encoded in the OP-IMM-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x2, attr: ['SSHL'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SSHL instruction performs an unsigned variable shift of `rs1` using the signed
-shift amount in `rs2[7:0]`. Left shifts saturate to the unsigned 32-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-xs1    = zero_extend(64, s1)
-
-if sshamt < 0:
-    if sshamt <= -32:
-        X[rd] = xs1[63:32]
-    else
-        X[rd] = (xs1 >> (0 - shamt)[4:0])[31:0]
-else:
-    shx = (sshamt >= 32) ? (s1 @ 0x00000000)
-                         : (xs1 << shamt[4:0])
-
-    if shx >_u 0x00000000FFFFFFFF:
-        vxsat = 1
-        X[rd] = 0xFFFFFFFF
-    else
-        X[rd] = shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== SSHLR (RV32)
-
-Mnemonic::
-
-sshlr _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SSHLR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x3, attr: ['SSHLR'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SSHLR instruction performs an unsigned variable shift of `rs1` using the signed
-shift amount in `rs2[7:0]`. Right shifts are rounded, and left shifts saturate
-to the signed 32-bit range.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-if sshamt < 0:
-    // arithmetic right shift with rounding
-    x  = zero_extend(64, s1) @ 0b0            // 65-bit
-    y  = (sshamt <= -32) ? x[64:32]
-                         : (x >> (0 - shamt)[4:0])[32:0]
-    X[rd] = (y + 1)[32:1]
-else:
-    // shift left with unsigned saturation to 32-bit range
-    shx = (sshamt >= 32) ? (s1 @ 0x00000000)
-                         : (zero_extend(64, s1) << shamt[4:0])
-
-    if shx >_u 0x00000000FFFFFFFF:
-        vxsat = 1
-        X[rd] = 0xFFFFFFFF
-    else
-        X[rd] = shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs.
-
-<<<
-==== SSLAI (RV32)
-
-Mnemonic::
-
-sslai _rd_, _rs1_, _uimm5_
-
-Encoding::
-
-SSLAI is encoded in the OP-IMM-32 major opcode with the w-uimm format as
-a scalar XLEN-wide saturating shift left arithmetic immediate.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['SSLAI'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm5` field encodes the 5-bit shift amount.
-
-Description::
-
-SSLAI shifts the signed XLEN-wide value in `rs1` left by the immediate
-shift amount and writes the result to `rd` with signed saturation. If the
-shifted result overflows the signed XLEN-wide range, the result is clamped
-to the nearest boundary and the `vxsat` overflow flag is set.
-
-Operation::
-
-[source,pseudocode]
-----
-a = signed(X[rs1])
-shamt = uimm5[4:0]
-
-result = a << shamt
-
-if result < -(2^(XLEN-1)):
-    d = to_bits(XLEN, -(2^(XLEN-1))); vxsat = 1
-else if result > 2^(XLEN-1) - 1:
-    d = to_bits(XLEN, 2^(XLEN-1) - 1); vxsat = 1
-else:
-    d = to_bits(XLEN, result)
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== SRARI
-
-Mnemonic::
-
-srari _rd_, _rs1_, _uimm5_ (RV32) +
-srari _rd_, _rs1_, _uimm6_ (RV64)
-
-Encoding::
-
-SRARI is encoded in the OP-IMM-32 major opcode with the w-uimm format as
-a scalar XLEN-wide shift right arithmetic with rounding. In RV32 the shift
-amount is 5 bits; in RV64 the shift amount is 6 bits.
-
-RV32:
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 7, name: '01xxxxx' },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['SRARI'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm5` field encodes the 5-bit shift amount for RV32.
-
-RV64:
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 5, name: 'rs1' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['SRARI'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-The `uimm6` field encodes the 6-bit shift amount for RV64.
-
-Description::
-
-SRARI arithmetically shifts the XLEN-wide value in `rs1` right by the
-immediate shift amount with rounding and writes the result to `rd`. A
-rounding bit is added before the final shift so that the result is rounded
-to the nearest integer (round-to-nearest, ties round up). When the shift
-amount is zero the source value is written unchanged.
-
-Operation::
-
-[source,pseudocode]
-----
-a = X[rs1]
-shamt = uimm6[log2(XLEN)-1:0]
-
-if shamt == 0:
-    d = a
-else:
-    // Append rounding bit, shift, then extract rounded result
-    shx[(XLEN+1):0] = ((sign_extend(2*XLEN, a) @ 0b0) >> shamt)[(XLEN+1):0]
-    d = (shx + 1)[XLEN:1]
-
-X[rd] = d
-----
-
-
-<<<
-==== SHA (RV64)
-
-Mnemonic::
-
-sha _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SHA is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x6, attr: ['SHA'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SHA instruction performs a signed variable shift of `rs1` using the signed
-shift amount in `rs2[7:0]`. Negative shift amounts shift right; non-negative
-shift amounts shift left.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-if (sshamt < 0):
-    xs1 = sign_extend(128, s1)
-    if (sshamt <= -64):
-        X[rd] = xs1[127:64]
-    else:
-        X[rd] = (xs1 >> (0 - shamt)[5:0])[63:0]
-else:
-    if (sshamt >= 64):
-        X[rd] = 0
-    else:
-        X[rd] = s1 << shamt[5:0]
-----
-
-
-<<<
-==== SHAR (RV64)
-
-Mnemonic::
-
-shar _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SHAR is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x7, attr: ['SHAR'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SHAR instruction matches SHA for non-negative shift amounts. For negative
-shift amounts it performs a rounding arithmetic right shift as specified in the
-Sail code.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-if (sshamt < 0):
-    xs1 = sign_extend(128, s1) @ 0b0          // 129-bit
-    if (sshamt <= -64):
-        shx = xs1[128:64]
-    else:
-        shx = (xs1 >> (0 - shamt)[5:0])[64:0]
-    X[rd] = (shx + 1)[64:1]
-else:
-    if (sshamt >= 64):
-        X[rd] = 0
-    else:
-        X[rd] = s1 << shamt[5:0]
-----
-
-
-
-<<<
-==== SHL (RV64)
-
-Mnemonic::
-
-shl _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SHL is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x2, attr: ['SHL'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SHL instruction performs an unsigned variable shift of `rs1` using the
-signed shift amount in `rs2[7:0]`. Negative shift amounts shift right;
-non-negative shift amounts shift left.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-if (sshamt < 0):
-    xs1 = zero_extend(128, s1)
-    if (sshamt <= -64):
-        X[rd] = xs1[127:64]
-    else:
-        X[rd] = (xs1 >> (0 - shamt)[5:0])[63:0]
-else:
-    if (sshamt >= 64):
-        X[rd] = 0
-    else:
-        X[rd] = s1 << shamt[5:0]
-----
-
-
-<<<
-==== SHLR (RV64)
-
-Mnemonic::
-
-shlr _rd_, _rs1_, _rs2_
-
-Encoding::
-
-SHLR is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x3, attr: ['SHLR'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The SHLR instruction matches SHL for non-negative shift amounts. For negative
-shift amounts it performs a rounding logical right shift as specified in the
-Sail code.
-
-Operation::
-
-[source,pseudocode]
-----
-s1     = X[rs1]
-shamt  = X[rs2][7:0]
-sshamt = signed(shamt)
-
-if (sshamt < 0):
-    xs1 = zero_extend(128, s1) @ 0b0          // 129-bit
-    if (sshamt <= -64):
-        shx = xs1[128:64]
-    else:
-        shx = (xs1 >> (0 - shamt)[5:0])[64:0]
-    X[rd] = (shx + 1)[64:1]
-else:
-    if (sshamt >= 64):
-        X[rd] = 0
-    else:
-        X[rd] = s1 << shamt[5:0]
 ----
 
 
@@ -14652,6 +13703,268 @@ if (rd_p != 0):
 Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== SHAR (RV64)
+
+Mnemonic::
+
+shar _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SHAR is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['SHAR'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SHAR instruction matches SHA for non-negative shift amounts. For negative
+shift amounts it performs a rounding arithmetic right shift as specified in the
+Sail code.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+if (sshamt < 0):
+    xs1 = sign_extend(128, s1) @ 0b0          // 129-bit
+    if (sshamt <= -64):
+        shx = xs1[128:64]
+    else:
+        shx = (xs1 >> (0 - shamt)[5:0])[64:0]
+    X[rd] = (shx + 1)[64:1]
+else:
+    if (sshamt >= 64):
+        X[rd] = 0
+    else:
+        X[rd] = s1 << shamt[5:0]
+----
+
+
+
+<<<
+==== SSHAR (RV32)
+
+Mnemonic::
+
+sshar _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SSHAR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['SSHAR'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SSHAR instruction performs a signed variable shift of `rs1` using the signed
+shift amount in `rs2[7:0]`. Right shifts are rounded, and left shifts saturate
+to the signed 32-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+if sshamt < 0:
+    // arithmetic right shift with rounding
+    x  = sign_extend(64, s1) @ 0b0            // 65-bit
+    y  = (sshamt <= -32) ? x[64:32]
+                         : (x >> (0 - shamt)[4:0])[32:0]
+    X[rd] = (y + 1)[32:1]
+else:
+    // shift left with signed saturation to 32-bit range
+    shx = (sshamt >= 32) ? (s1 @ 0x00000000)
+                         : (sign_extend(64, s1) << shamt[4:0])
+
+    if shx <_s 0xFFFFFFFF80000000:
+        vxsat = 1
+        X[rd] = 0x80000000
+    else if shx >_s 0x000000007FFFFFFF:
+        vxsat = 1
+        X[rd] = 0x7FFFFFFF
+    else
+        X[rd] = shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs.
+
+<<<
+==== PSSHAR.HS
+
+Mnemonic::
+
+psshar.hs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSHAR.HS is encoded in the OP-IMM-32 major opcode.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['PSSHAR.HS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSSHAR.HS instruction performs a signed variable shift on each packed 16-bit
+element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
+rounded, and left shifts saturate to the signed 16-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]    // signed 16-bit
+
+    if sshamt < 0:
+        // arithmetic right shift with rounding
+        x  = sign_extend(32, h) @ 0b0          // 33-bit
+        y  = (sshamt <= -16) ? x[32:16]
+                             : (x >> (0 - shamt)[3:0])[16:0]
+        r  = (y + 1)[16:1]
+    else:
+        // shift left with signed saturation to 16-bit range
+        shx = (sshamt >= 16) ? (h @ 0x0000)
+                             : (sign_extend(32, h) << shamt[3:0])
+
+        if shx <_s 0xFFFF8000:
+            vxsat = 1
+            r = 0x8000
+        else if shx >_s 0x00007FFF:
+            vxsat = 1
+            r = 0x7FFF
+        else
+            r = shx[15:0]
+
+    d[(16*i+15):(16*i)] = r
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PSSHAR.WS (RV64)
+
+Mnemonic::
+
+psshar.ws _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSHAR.WS is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['PSSHAR.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSSHAR.WS instruction performs a signed variable shift on each packed 32-bit
+element of `rs1` using the signed shift amount in `rs2[7:0]`. Right shifts are
+rounded, and left shifts saturate to the signed 32-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]    // signed 32-bit
+
+    if sshamt < 0:
+        // arithmetic right shift with rounding
+        x  = sign_extend(64, w) @ 0b0          // 65-bit
+        y  = (sshamt <= -32) ? x[64:32]
+                             : (x >> (0 - shamt)[4:0])[32:0]
+        r  = (y + 1)[32:1]
+    else:
+        // shift left with signed saturation to 32-bit range
+        shx = (sshamt >= 32) ? (w @ 0x00000000)
+                             : (sign_extend(64, w) << shamt[4:0])
+
+        if shx <_s 0xFFFFFFFF80000000:
+            vxsat = 1
+            r = 0x80000000
+        else if shx >_s 0x000000007FFFFFFF:
+            vxsat = 1
+            r = 0x7FFFFFFF
+        else
+            r = shx[31:0]
+
+    d[(32*i+31):(32*i)] = r
+
+X[rd] = d
+----
+
 
 <<<
 ==== PSSHAR.DHS (RV32)
@@ -14810,6 +14123,261 @@ Notes::
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
+==== SHL (RV64)
+
+Mnemonic::
+
+shl _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SHL is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x2, attr: ['SHL'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SHL instruction performs an unsigned variable shift of `rs1` using the
+signed shift amount in `rs2[7:0]`. Negative shift amounts shift right;
+non-negative shift amounts shift left.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+if (sshamt < 0):
+    xs1 = zero_extend(128, s1)
+    if (sshamt <= -64):
+        X[rd] = xs1[127:64]
+    else:
+        X[rd] = (xs1 >> (0 - shamt)[5:0])[63:0]
+else:
+    if (sshamt >= 64):
+        X[rd] = 0
+    else:
+        X[rd] = s1 << shamt[5:0]
+----
+
+
+<<<
+==== SSHL (RV32)
+
+Mnemonic::
+
+sshl _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SSHL is encoded in the OP-IMM-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x2, attr: ['SSHL'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SSHL instruction performs an unsigned variable shift of `rs1` using the signed
+shift amount in `rs2[7:0]`. Left shifts saturate to the unsigned 32-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+xs1    = zero_extend(64, s1)
+
+if sshamt < 0:
+    if sshamt <= -32:
+        X[rd] = xs1[63:32]
+    else
+        X[rd] = (xs1 >> (0 - shamt)[4:0])[31:0]
+else:
+    shx = (sshamt >= 32) ? (s1 @ 0x00000000)
+                         : (xs1 << shamt[4:0])
+
+    if shx >_u 0x00000000FFFFFFFF:
+        vxsat = 1
+        X[rd] = 0xFFFFFFFF
+    else
+        X[rd] = shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PSSHL.HS
+
+Mnemonic::
+
+psshl.hs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSHL.HS is encoded in the OP-IMM-32 major opcode.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x2, attr: ['PSSHL.HS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSSHL.HS instruction performs an unsigned variable shift on each packed 16-bit
+element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts saturate
+to the signed 16-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][7:0]
+sshamt = signed(shamt)
+
+for i = 0 .. (XLEN/16 - 1):
+    h  = s1[(16*i+15):(16*i)]
+    xh = zero_extend(32, h)
+
+    if sshamt < 0:
+        // logical shift right by (-sshamt), saturating not required
+        if sshamt <= -16:
+            r = xh[31:16]
+        else
+            r = (xh >> (0 - shamt)[3:0])[15:0]
+    else:
+        // shift left with unsigned saturation to 16-bit range
+        if sshamt >= 16:
+            shx = (h @ 0x0000)
+        else
+            shx = xh << shamt[3:0]
+
+        if shx >_u 0x0000FFFF:
+            vxsat = 1
+            r = 0xFFFF
+        else
+            r = shx[15:0]
+
+    d[(16*i+15):(16*i)] = r
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PSSHL.WS (RV64)
+
+Mnemonic::
+
+psshl.ws _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSHL.WS is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x2, attr: ['PSSHL.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSSHL.WS instruction performs an unsigned variable shift on each packed 32-bit
+element of `rs1` using the signed shift amount in `rs2[7:0]`. Left shifts
+saturate to the unsigned 32-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = X[rs2][7:0]
+sshamt = signed(shamt)
+
+for i = 0 .. (XLEN/32 - 1):
+    w  = s1[(32*i+32):(32*i)]
+    xw = zero_extend(64, w)
+
+    if sshamt < 0:
+        // logical shift right by (-sshamt), saturating not required
+        if sshamt <= -32:
+            r = xh[63:32]
+        else
+            r = (xh >> (0 - shamt)[4:0])[31:0]
+    else:
+        // shift left with unsigned saturation to 32-bit range
+        if sshamt >= 32:
+            shx = (w @ 0x00000000)
+        else
+            shx = xw << shamt[4:0]
+
+        if shx >_u 0xFFFFFFFF:
+            vxsat = 1
+            r = 0xFFFFFFFF
+        else
+            r = shx[31:0]
+
+    d[(32*i+31):(32*i)] = r
+
+X[rd] = d
+----
+
+
+<<<
 ==== PSSHL.DHS (RV32)
 
 Mnemonic::
@@ -14952,6 +14520,258 @@ if (rd_p != 0):
 Notes::
 
 * `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== SHLR (RV64)
+
+Mnemonic::
+
+shlr _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SHLR is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['SHLR'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SHLR instruction matches SHL for non-negative shift amounts. For negative
+shift amounts it performs a rounding logical right shift as specified in the
+Sail code.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+if (sshamt < 0):
+    xs1 = zero_extend(128, s1) @ 0b0          // 129-bit
+    if (sshamt <= -64):
+        shx = xs1[128:64]
+    else:
+        shx = (xs1 >> (0 - shamt)[5:0])[64:0]
+    X[rd] = (shx + 1)[64:1]
+else:
+    if (sshamt >= 64):
+        X[rd] = 0
+    else:
+        X[rd] = s1 << shamt[5:0]
+----
+
+
+<<<
+==== SSHLR (RV32)
+
+Mnemonic::
+
+sshlr _rd_, _rs1_, _rs2_
+
+Encoding::
+
+SSHLR is encoded in the OP-IMM-32 major opcode and is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['SSHLR'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The SSHLR instruction performs an unsigned variable shift of `rs1` using the signed
+shift amount in `rs2[7:0]`. Right shifts are rounded, and left shifts saturate
+to the signed 32-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+if sshamt < 0:
+    // arithmetic right shift with rounding
+    x  = zero_extend(64, s1) @ 0b0            // 65-bit
+    y  = (sshamt <= -32) ? x[64:32]
+                         : (x >> (0 - shamt)[4:0])[32:0]
+    X[rd] = (y + 1)[32:1]
+else:
+    // shift left with unsigned saturation to 32-bit range
+    shx = (sshamt >= 32) ? (s1 @ 0x00000000)
+                         : (zero_extend(64, s1) << shamt[4:0])
+
+    if shx >_u 0x00000000FFFFFFFF:
+        vxsat = 1
+        X[rd] = 0xFFFFFFFF
+    else
+        X[rd] = shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs.
+
+<<<
+==== PSSHLR.HS
+
+Mnemonic::
+
+psshlr.hs _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSHLR.HS is encoded in the OP-IMM-32 major opcode.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['PSSHLR.HS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSSHLR.HS instruction performs an unsigned variable shift on each packed
+16-bit element of `rs1` using the signed shift amount in `rs2[7:0]`. Right
+shifts are rounded, and left shifts saturate to the unsigned 16-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+for i = 0 .. (XLEN/16 - 1):
+    h = s1[(16*i+15):(16*i)]    // signed 16-bit
+
+    if sshamt < 0:
+        // logical right shift with rounding
+        x  = zero_extend(32, h) @ 0b0          // 33-bit
+        y  = (sshamt <= -16) ? x[32:16]
+                             : (x >> (0 - shamt)[3:0])[16:0]
+        r  = (y + 1)[16:1]
+    else:
+        // shift left with unsigned saturation to 16-bit range
+        shx = (sshamt >= 16) ? (h @ 0x0000)
+                             : (sign_extend(32, h) << shamt[3:0])
+
+        if shx >_u 0x0000FFFF:
+            vxsat = 1
+            r = 0xFFFF
+        else
+            r = shx[15:0]
+
+    d[(16*i+15):(16*i)] = r
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PSSHLR.WS (RV64)
+
+Mnemonic::
+
+psshlr.ws _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PSSHLR.WS is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['PSSHLR.WS'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PSSHLR.WS instruction performs a unsigned variable shift on each packed
+32-bit element of `rs1` using the signed shift amount in `rs2[7:0]`. Right
+shifts are rounded, and left shifts saturate to the unsigned 32-bit range.
+
+Operation::
+
+[source,pseudocode]
+----
+s1     = X[rs1]
+shamt  = X[rs2][7:0]
+sshamt = signed(shamt)
+
+for i = 0 .. (XLEN/32 - 1):
+    w = s1[(32*i+31):(32*i)]    // signed 32-bit
+
+    if sshamt < 0:
+        // logical right shift with rounding
+        x  = zero_extend(64, w) @ 0b0          // 65-bit
+        y  = (sshamt <= -32) ? x[64:32]
+                             : (x >> (0 - shamt)[4:0])[32:0]
+        r  = (y + 1)[32:1]
+    else:
+        // shift left with unsigned saturation to 32-bit range
+        shx = (sshamt >= 32) ? (h @ 0x00000000)
+                             : (zero_extend(32, w) << shamt[4:0])
+
+        if shx >_u 0x00000000FFFFFFFF:
+            vxsat = 1
+            r = 0xFFFF0000
+        else
+            r = shx[31:0]
+
+    d[(32*i+31):(32*i)] = r
+
+X[rd] = d
+----
+
 
 <<<
 ==== PSSHLR.DHS (RV32)
@@ -15097,6 +14917,187 @@ for i = 0 .. 1:
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
     X[rd_p*2+1] = d[63:32]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== SSLAI (RV32)
+
+Mnemonic::
+
+sslai _rd_, _rs1_, _uimm5_
+
+Encoding::
+
+SSLAI is encoded in the OP-IMM-32 major opcode with the w-uimm format as
+a scalar XLEN-wide saturating shift left arithmetic immediate.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['SSLAI'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm5` field encodes the 5-bit shift amount.
+
+Description::
+
+SSLAI shifts the signed XLEN-wide value in `rs1` left by the immediate
+shift amount and writes the result to `rd` with signed saturation. If the
+shifted result overflows the signed XLEN-wide range, the result is clamped
+to the nearest boundary and the `vxsat` overflow flag is set.
+
+Operation::
+
+[source,pseudocode]
+----
+a = signed(X[rs1])
+shamt = uimm5[4:0]
+
+result = a << shamt
+
+if result < -(2^(XLEN-1)):
+    d = to_bits(XLEN, -(2^(XLEN-1))); vxsat = 1
+else if result > 2^(XLEN-1) - 1:
+    d = to_bits(XLEN, 2^(XLEN-1) - 1); vxsat = 1
+else:
+    d = to_bits(XLEN, result)
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PSSLAI.H
+
+Mnemonic::
+
+psslai.h _rd_, _rs1_, _uimm4_
+
+Encoding::
+
+PSSLAI.H is encoded in the OP-IMM-32 major opcode with the w-uimm format
+and packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 4, name: 'uimm4' },
+    { bits: 3, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSSLAI.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm4` field encodes the 4-bit shift amount for halfword elements.
+
+Description::
+
+PSSLAI.H (Packed Saturating Shift Left Arithmetic Immediate, Halfword) shifts
+each packed signed 16-bit element of `rs1` left by a 4-bit unsigned immediate.
+If the shifted result overflows the signed 16-bit range [-2^15^, 2^15^-1], the
+result is saturated to the nearest boundary and the `vxsat` flag is set. The
+packed halfword results are written to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+shamt = uimm4[3:0]          // 4-bit shift amount for halfwords
+
+for i = 0 .. (XLEN/16 - 1):
+    a = signed(s1[(16*i+15):(16*i)])
+    result = a << shamt
+    if result < -2^15:
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if result > 2^15 - 1:
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = result[15:0]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PSSLAI.W (RV64)
+
+Mnemonic::
+
+psslai.w _rd_, _rs1_, _uimm5_
+
+Encoding::
+
+PSSLAI.W is encoded in the OP-IMM-32 major opcode with the w-uimm format
+and word elements. Available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PSSLAI.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+The `uimm5` field encodes the 5-bit shift amount for word elements.
+
+Description::
+
+PSSLAI.W (Packed Saturating Shift Left Arithmetic Immediate, Word) shifts each
+packed signed 32-bit element of `rs1` left by a 5-bit unsigned immediate. If
+the shifted result overflows the signed 32-bit range [-2^31^, 2^31^-1], the
+result is saturated to the nearest boundary and the `vxsat` flag is set. The
+packed word results are written to `rd`. Available only in RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+shamt = uimm5[4:0]          // 5-bit shift amount for words
+
+for i = 0 .. (XLEN/32 - 1):
+    a = signed(s1[(32*i+31):(32*i)])
+    result = a << shamt
+    if result < -2^31:
+        d[(32*i+31):(32*i)] = 0x80000000; vxsat = 1
+    else if result > 2^31 - 1:
+        d[(32*i+31):(32*i)] = 0x7FFFFFFF; vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = result[31:0]
+
+X[rd] = d
 ----
 
 Notes::
@@ -15338,6 +15339,118 @@ X[rd] = d
 
 
 <<<
+==== PPAIRE.DB (RV32)
+
+Mnemonic::
+
+ppaire.db _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PPAIRE.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x0, attr: ['PPAIRE.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PPAIRE.DB performs packed byte even-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRE.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIRE.B operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 3:
+    s1_h = s1[(16*i+15):(16*i)]
+    s2_h = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[7:0]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PPAIRE.DH (RV32)
+
+Mnemonic::
+
+ppaire.dh _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PPAIRE.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PPAIRE.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PPAIRE.DH performs packed halfword even-element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIRE.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIRE.H operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[15:0]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
 ==== PPAIREO.B
 
 Mnemonic::
@@ -15477,6 +15590,118 @@ s2 = X[rs2]
 d = s2[63:32] @ s1[31:0]
 
 X[rd] = d
+----
+
+
+<<<
+==== PPAIREO.DB (RV32)
+
+Mnemonic::
+
+ppaireo.db _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PPAIREO.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PPAIREO.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PPAIREO.DB performs packed byte even-odd element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIREO.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIREO.B operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 3:
+    s1_h = s1[(16*i+15):(16*i)]
+    s2_h = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[7:0]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PPAIREO.DH (RV32)
+
+Mnemonic::
+
+ppaireo.dh _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PPAIREO.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PPAIREO.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PPAIREO.DH performs packed halfword even-odd element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIREO.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIREO.H operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[15:0]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -15624,6 +15849,118 @@ X[rd] = d
 
 
 <<<
+==== PPAIROE.DB (RV32)
+
+Mnemonic::
+
+ppairoe.db _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PPAIROE.DB is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed byte elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x4, attr: ['PPAIROE.DB'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PPAIROE.DB performs packed byte odd-even element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIROE.B operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIROE.B operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 3:
+    s1_h = s1[(16*i+15):(16*i)]
+    s2_h = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[15:8]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PPAIROE.DH (RV32)
+
+Mnemonic::
+
+ppairoe.dh _rd_p_, _rs1_p_, _rs2_p_
+
+Encoding::
+
+PPAIROE.DH is encoded in the OP-IMM-32 major opcode using the double-wide
+register-pair format with packed halfword elements. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x6 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs2_p' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['PPAIROE.DH'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PPAIROE.DH performs packed halfword odd-even element packing on double-wide
+(register-pair) operands. It is equivalent to two PPAIROE.H operations: one on
+the even registers and one on the odd registers of each pair. All three operands
+(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
+numbers. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Equivalent to two PPAIROE.H operations on even/odd register pairs
+s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
+s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    s2_w = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[31:16]
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
 ==== PPAIRO.B
 
 Mnemonic::
@@ -15764,342 +16101,6 @@ s2 = X[rs2]
 d = s2[63:32] @ s1[63:32]
 
 X[rd] = d
-----
-
-
-<<<
-==== PPAIRE.DB (RV32)
-
-Mnemonic::
-
-ppaire.db _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PPAIRE.DB is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format with packed byte elements. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x0, attr: ['PPAIRE.DB'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PPAIRE.DB performs packed byte even-element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIRE.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PPAIRE.B operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 3:
-    s1_h = s1[(16*i+15):(16*i)]
-    s2_h = s2[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[7:0]
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PPAIRE.DH (RV32)
-
-Mnemonic::
-
-ppaire.dh _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PPAIRE.DH is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format with packed halfword elements. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x0, attr: ['PPAIRE.DH'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PPAIRE.DH performs packed halfword even-element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIRE.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PPAIRE.H operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 1:
-    s1_w = s1[(32*i+31):(32*i)]
-    s2_w = s2[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[15:0]
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PPAIREO.DB (RV32)
-
-Mnemonic::
-
-ppaireo.db _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PPAIREO.DB is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format with packed byte elements. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x2, attr: ['PPAIREO.DB'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PPAIREO.DB performs packed byte even-odd element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIREO.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PPAIREO.B operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 3:
-    s1_h = s1[(16*i+15):(16*i)]
-    s2_h = s2[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = s2_h[15:8] @ s1_h[7:0]
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PPAIREO.DH (RV32)
-
-Mnemonic::
-
-ppaireo.dh _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PPAIREO.DH is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format with packed halfword elements. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['PPAIREO.DH'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PPAIREO.DH performs packed halfword even-odd element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIREO.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PPAIREO.H operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 1:
-    s1_w = s1[(32*i+31):(32*i)]
-    s2_w = s2[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = s2_w[31:16] @ s1_w[15:0]
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PPAIROE.DB (RV32)
-
-Mnemonic::
-
-ppairoe.db _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PPAIROE.DB is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format with packed byte elements. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x4, attr: ['PPAIROE.DB'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PPAIROE.DB performs packed byte odd-even element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIROE.B operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PPAIROE.B operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 3:
-    s1_h = s1[(16*i+15):(16*i)]
-    s2_h = s2[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = s2_h[7:0] @ s1_h[15:8]
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PPAIROE.DH (RV32)
-
-Mnemonic::
-
-ppairoe.dh _rd_p_, _rs1_p_, _rs2_p_
-
-Encoding::
-
-PPAIROE.DH is encoded in the OP-IMM-32 major opcode using the double-wide
-register-pair format with packed halfword elements. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x6 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs2_p' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x4, attr: ['PPAIROE.DH'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PPAIROE.DH performs packed halfword odd-even element packing on double-wide
-(register-pair) operands. It is equivalent to two PPAIROE.H operations: one on
-the even registers and one on the odd registers of each pair. All three operands
-(`rd_p`, `rs1_p`, `rs2_p`) are register pairs and must specify even register
-numbers. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Equivalent to two PPAIROE.H operations on even/odd register pairs
-s1 = (rs1_p == 0) ? 0 : X[rs1_p*2+1] @ X[rs1_p*2]
-s2 = (rs2_p == 0) ? 0 : X[rs2_p*2+1] @ X[rs2_p*2]
-
-for i = 0 .. 1:
-    s1_w = s1[(32*i+31):(32*i)]
-    s2_w = s2[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = s2_w[15:0] @ s1_w[31:16]
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
 ----
 
 
@@ -16306,6 +16307,90 @@ X[rd] =
 
 
 <<<
+==== ZIP16P (RV64)
+
+Mnemonic::
+
+zip16p _rd_, _rs1_, _rs2_
+
+Encoding::
+
+ZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x7, attr: ['ZIP16P'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The ZIP16P instruction interleaves 16-bit chunks from `rs2` and `rs1` to form a
+64-bit result.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+X[rd] = s2[31:16] @ s1[31:16] @ s2[15:0] @ s1[15:0]
+----
+
+
+<<<
+==== ZIP16HP (RV64)
+
+Mnemonic::
+
+zip16hp _rd_, _rs1_, _rs2_
+
+Encoding::
+
+ZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x7, attr: ['ZIP16HP'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The ZIP16HP instruction interleaves 16-bit chunks from the high 32-bit halves of
+`rs2` and `rs1` to form a 64-bit result.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+X[rd] = s2[63:48] @ s1[63:48] @ s2[47:32] @ s1[47:32]
+----
+
+
+<<<
 ==== UNZIP8P (RV64)
 
 Mnemonic::
@@ -16390,90 +16475,6 @@ s2 = X[rs2]
 X[rd] =
     s2[63:56] @ s2[47:40] @ s2[31:24] @ s2[15:8]
   @ s1[63:56] @ s1[47:40] @ s1[31:24] @ s1[15:8]
-----
-
-
-<<<
-==== ZIP16P (RV64)
-
-Mnemonic::
-
-zip16p _rd_, _rs1_, _rs2_
-
-Encoding::
-
-ZIP16P is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x7, attr: ['ZIP16P'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The ZIP16P instruction interleaves 16-bit chunks from `rs2` and `rs1` to form a
-64-bit result.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-X[rd] = s2[31:16] @ s1[31:16] @ s2[15:0] @ s1[15:0]
-----
-
-
-<<<
-==== ZIP16HP (RV64)
-
-Mnemonic::
-
-zip16hp _rd_, _rs1_, _rs2_
-
-Encoding::
-
-ZIP16HP is encoded in the OP-32 major opcode and is available only in RV64.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x7, attr: ['ZIP16HP'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The ZIP16HP instruction interleaves 16-bit chunks from the high 32-bit halves of
-`rs2` and `rs1` to form a 64-bit result.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-X[rd] = s2[63:48] @ s1[63:48] @ s2[47:32] @ s1[47:32]
 ----
 
 
@@ -17155,6 +17156,49 @@ X[rd_p * 2 + 1] = d[63:32]
 <<<
 === Widening Add/Subtract
 
+==== WADD (RV32)
+
+Mnemonic::
+
+wadd _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WADD is available only in RV32 and writes a 64-bit result to register pair `rd_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['WADD'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WADD adds `rs1` and `rs2` as signed XLEN values and writes the 64-bit sum to the
+destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+d = to_bits(64, signed(X[rs1]) + signed(X[rs2]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
 ==== PWADD.B (RV32)
 
 Mnemonic::
@@ -17206,6 +17250,97 @@ if (rd_p != 0):
 
 
 <<<
+==== PWADD.H (RV32)
+
+Mnemonic::
+
+pwadd.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWADD.H is available only in RV32. It writes results to an even-odd register
+pair specified by `rd_p`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x0, attr: ['PWADD.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWADD.H sign-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
+and writes two 32-bit results to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d0 = to_bits(32, signed(s1[15:0])  + signed(s2[15:0]))
+d1 = to_bits(32, signed(s1[31:16]) + signed(s2[31:16]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = d0
+    X[2*rd_p+1] = d1
+----
+
+
+<<<
+==== WADDA (RV32)
+
+Mnemonic::
+
+wadda _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WADDA is available only in RV32 and accumulates into the destination register pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x1, attr: ['WADDA'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WADDA performs WADD and accumulates the 64-bit result into the destination
+register pair.
+
+Operation::
+
+[source,pseudocode]
+----
+acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
+acc = acc + to_bits(64, signed(X[rs1]) + signed(X[rs2]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc[31:0]
+    X[2*rd_p+1] = acc[63:32]
+----
+
+
+<<<
 ==== PWADDA.B (RV32)
 
 Mnemonic::
@@ -17251,6 +17386,99 @@ for i = 0 .. 3:
     b = s2[(8*i+7):(8*i)]
     acc = d[(16*i+15):(16*i)]
     d[(16*i+15):(16*i)] = acc + to_bits(16, signed(a) + signed(b))
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
+==== PWADDA.H (RV32)
+
+Mnemonic::
+
+pwadda.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWADDA.H is available only in RV32 and accumulates into the destination register pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x1, attr: ['PWADDA.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWADDA.H performs PWADD.H and adds each 32-bit result into the corresponding
+32-bit element of the destination register pair.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+acc0 = X[2*rd_p]
+acc1 = (rd_p == 0) ? 0 : X[2*rd_p+1]
+
+acc0 = acc0 + to_bits(32, signed(s1[15:0])  + signed(s2[15:0]))
+acc1 = acc1 + to_bits(32, signed(s1[31:16]) + signed(s2[31:16]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc0
+    X[2*rd_p+1] = acc1
+----
+
+
+<<<
+==== WADDU (RV32)
+
+Mnemonic::
+
+waddu _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WADDU is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['WADDU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WADDU adds `rs1` and `rs2` as unsigned XLEN values and writes the 64-bit sum to
+the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+d = to_bits(64, unsigned(X[rs1]) + unsigned(X[rs2]))
 
 if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
@@ -17310,6 +17538,96 @@ if (rd_p != 0):
 
 
 <<<
+==== PWADDU.H (RV32)
+
+Mnemonic::
+
+pwaddu.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWADDU.H is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PWADDU.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWADDU.H zero-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
+and writes two 32-bit results to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d0 = to_bits(32, unsigned(s1[15:0])  + unsigned(s2[15:0]))
+d1 = to_bits(32, unsigned(s1[31:16]) + unsigned(s2[31:16]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = d0
+    X[2*rd_p+1] = d1
+----
+
+
+<<<
+==== WADDAU (RV32)
+
+Mnemonic::
+
+waddau _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WADDAU is available only in RV32 and accumulates into the destination register pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x3, attr: ['WADDAU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WADDAU performs WADDU and accumulates the 64-bit result into the destination
+register pair.
+
+Operation::
+
+[source,pseudocode]
+----
+acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
+acc = acc + to_bits(64, unsigned(X[rs1]) + unsigned(X[rs2]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc[31:0]
+    X[2*rd_p+1] = acc[63:32]
+----
+
+
+<<<
 ==== PWADDAU.B (RV32)
 
 Mnemonic::
@@ -17355,6 +17673,99 @@ for i = 0 .. 3:
     b = s2[(8*i+7):(8*i)]
     acc = d[(16*i+15):(16*i)]
     d[(16*i+15):(16*i)] = acc + to_bits(16, unsigned(a) + unsigned(b))
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
+==== PWADDAU.H (RV32)
+
+Mnemonic::
+
+pwaddau.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWADDAU.H is available only in RV32 and accumulates into the destination register pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x3, attr: ['PWADDAU.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWADDAU.H performs PWADDU.H and accumulates the two 32-bit results into the
+destination register pair.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+acc0 = X[2*rd_p]
+acc1 = (rd_p == 0) ? 0 : X[2*rd_p+1]
+
+acc0 = acc0 + to_bits(32, unsigned(s1[15:0])  + unsigned(s2[15:0]))
+acc1 = acc1 + to_bits(32, unsigned(s1[31:16]) + unsigned(s2[31:16]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc0
+    X[2*rd_p+1] = acc1
+----
+
+
+<<<
+==== WSUB (RV32)
+
+Mnemonic::
+
+wsub _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WSUB is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x8, attr: ['WSUB'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WSUB subtracts `rs2` from `rs1` as signed XLEN values and writes the 64-bit
+difference to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+d = to_bits(64, signed(X[rs1]) - signed(X[rs2]))
 
 if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
@@ -17415,6 +17826,96 @@ if (rd_p != 0):
 
 
 <<<
+==== PWSUB.H (RV32)
+
+Mnemonic::
+
+pwsub.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWSUB.H is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x8, attr: ['PWSUB.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWSUB.H sign-extends each 16-bit halfword element, subtracts element-wise, and
+writes two 32-bit results to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d0 = to_bits(32, signed(s1[15:0])  - signed(s2[15:0]))
+d1 = to_bits(32, signed(s1[31:16]) - signed(s2[31:16]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = d0
+    X[2*rd_p+1] = d1
+----
+
+
+<<<
+==== WSUBA (RV32)
+
+Mnemonic::
+
+wsuba _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WSUBA is available only in RV32 and accumulates into the destination register pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x9, attr: ['WSUBA'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WSUBA performs WSUB and accumulates the 64-bit result into the destination
+register pair.
+
+Operation::
+
+[source,pseudocode]
+----
+acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
+acc = acc + to_bits(64, signed(X[rs1]) - signed(X[rs2]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc[31:0]
+    X[2*rd_p+1] = acc[63:32]
+----
+
+
+<<<
 ==== PWSUBA.B (RV32)
 
 Mnemonic::
@@ -17461,6 +17962,99 @@ for i = 0 .. 3:
     b   = s2[(8*i+7):(8*i)]
     acc = d[(16*i+15):(16*i)]
     d[(16*i+15):(16*i)] = acc + to_bits(16, signed(a) - signed(b))
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
+==== PWSUBA.H (RV32)
+
+Mnemonic::
+
+pwsuba.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWSUBA.H is available only in RV32 and accumulates into the destination register pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x9, attr: ['PWSUBA.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWSUBA.H performs PWSUB.H and accumulates the two 32-bit results into the
+destination register pair.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+acc0 = X[2*rd_p]
+acc1 = (rd_p == 0) ? 0 : X[2*rd_p+1]
+
+acc0 = acc0 + to_bits(32, signed(s1[15:0])  - signed(s2[15:0]))
+acc1 = acc1 + to_bits(32, signed(s1[31:16]) - signed(s2[31:16]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc0
+    X[2*rd_p+1] = acc1
+----
+
+
+<<<
+==== WSUBU (RV32)
+
+Mnemonic::
+
+wsubu _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WSUBU is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['WSUBU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WSUBU subtracts `rs2` from `rs1` as unsigned XLEN values and writes the 64-bit
+difference to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+d = to_bits(64, unsigned(X[rs1]) - unsigned(X[rs2]))
 
 if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
@@ -17520,6 +18114,97 @@ if (rd_p != 0):
 
 
 <<<
+==== PWSUBU.H (RV32)
+
+Mnemonic::
+
+pwsubu.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWSUBU.H is available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xa, attr: ['PWSUBU.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWSUBU.H zero-extends each 16-bit halfword element, subtracts element-wise as
+unsigned values, and writes two 32-bit results to the destination register pair
+when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d0 = to_bits(32, unsigned(s1[15:0])  - unsigned(s2[15:0]))
+d1 = to_bits(32, unsigned(s1[31:16]) - unsigned(s2[31:16]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = d0
+    X[2*rd_p+1] = d1
+----
+
+
+<<<
+==== WSUBAU (RV32)
+
+Mnemonic::
+
+wsubau _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WSUBAU is available only in RV32 and accumulates into the destination register pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['WSUBAU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WSUBAU performs WSUBU and accumulates the 64-bit result into the destination
+register pair.
+
+Operation::
+
+[source,pseudocode]
+----
+acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
+acc = acc + to_bits(64, unsigned(X[rs1]) - unsigned(X[rs2]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc[31:0]
+    X[2*rd_p+1] = acc[63:32]
+----
+
+
+<<<
 ==== PWSUBAU.B (RV32)
 
 Mnemonic::
@@ -17574,342 +18259,6 @@ if (rd_p != 0):
 
 
 <<<
-==== PWADD.H (RV32)
-
-Mnemonic::
-
-pwadd.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWADD.H is available only in RV32. It writes results to an even-odd register
-pair specified by `rd_p`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x0, attr: ['PWADD.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWADD.H sign-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
-and writes two 32-bit results to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d0 = to_bits(32, signed(s1[15:0])  + signed(s2[15:0]))
-d1 = to_bits(32, signed(s1[31:16]) + signed(s2[31:16]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = d0
-    X[2*rd_p+1] = d1
-----
-
-
-<<<
-==== PWADDA.H (RV32)
-
-Mnemonic::
-
-pwadda.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWADDA.H is available only in RV32 and accumulates into the destination register pair.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x1, attr: ['PWADDA.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWADDA.H performs PWADD.H and adds each 32-bit result into the corresponding
-32-bit element of the destination register pair.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-acc0 = X[2*rd_p]
-acc1 = (rd_p == 0) ? 0 : X[2*rd_p+1]
-
-acc0 = acc0 + to_bits(32, signed(s1[15:0])  + signed(s2[15:0]))
-acc1 = acc1 + to_bits(32, signed(s1[31:16]) + signed(s2[31:16]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc0
-    X[2*rd_p+1] = acc1
-----
-
-
-<<<
-==== PWADDU.H (RV32)
-
-Mnemonic::
-
-pwaddu.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWADDU.H is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x2, attr: ['PWADDU.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWADDU.H zero-extends each 16-bit halfword element of `rs1` and `rs2`, adds them,
-and writes two 32-bit results to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d0 = to_bits(32, unsigned(s1[15:0])  + unsigned(s2[15:0]))
-d1 = to_bits(32, unsigned(s1[31:16]) + unsigned(s2[31:16]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = d0
-    X[2*rd_p+1] = d1
-----
-
-
-<<<
-==== PWADDAU.H (RV32)
-
-Mnemonic::
-
-pwaddau.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWADDAU.H is available only in RV32 and accumulates into the destination register pair.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x3, attr: ['PWADDAU.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWADDAU.H performs PWADDU.H and accumulates the two 32-bit results into the
-destination register pair.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-acc0 = X[2*rd_p]
-acc1 = (rd_p == 0) ? 0 : X[2*rd_p+1]
-
-acc0 = acc0 + to_bits(32, unsigned(s1[15:0])  + unsigned(s2[15:0]))
-acc1 = acc1 + to_bits(32, unsigned(s1[31:16]) + unsigned(s2[31:16]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc0
-    X[2*rd_p+1] = acc1
-----
-
-
-<<<
-==== PWSUB.H (RV32)
-
-Mnemonic::
-
-pwsub.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWSUB.H is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x8, attr: ['PWSUB.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWSUB.H sign-extends each 16-bit halfword element, subtracts element-wise, and
-writes two 32-bit results to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d0 = to_bits(32, signed(s1[15:0])  - signed(s2[15:0]))
-d1 = to_bits(32, signed(s1[31:16]) - signed(s2[31:16]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = d0
-    X[2*rd_p+1] = d1
-----
-
-
-<<<
-==== PWSUBA.H (RV32)
-
-Mnemonic::
-
-pwsuba.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWSUBA.H is available only in RV32 and accumulates into the destination register pair.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x9, attr: ['PWSUBA.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWSUBA.H performs PWSUB.H and accumulates the two 32-bit results into the
-destination register pair.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-acc0 = X[2*rd_p]
-acc1 = (rd_p == 0) ? 0 : X[2*rd_p+1]
-
-acc0 = acc0 + to_bits(32, signed(s1[15:0])  - signed(s2[15:0]))
-acc1 = acc1 + to_bits(32, signed(s1[31:16]) - signed(s2[31:16]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc0
-    X[2*rd_p+1] = acc1
-----
-
-
-<<<
-==== PWSUBU.H (RV32)
-
-Mnemonic::
-
-pwsubu.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWSUBU.H is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xa, attr: ['PWSUBU.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWSUBU.H zero-extends each 16-bit halfword element, subtracts element-wise as
-unsigned values, and writes two 32-bit results to the destination register pair
-when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d0 = to_bits(32, unsigned(s1[15:0])  - unsigned(s2[15:0]))
-d1 = to_bits(32, unsigned(s1[31:16]) - unsigned(s2[31:16]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = d0
-    X[2*rd_p+1] = d1
-----
-
-
-<<<
 ==== PWSUBAU.H (RV32)
 
 Mnemonic::
@@ -17959,358 +18308,55 @@ if (rd_p != 0):
 ----
 
 
-<<<
-==== WADD (RV32)
-
-Mnemonic::
-
-wadd _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WADD is available only in RV32 and writes a 64-bit result to register pair `rd_p`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x0, attr: ['WADD'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WADD adds `rs1` and `rs2` as signed XLEN values and writes the 64-bit sum to the
-destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-d = to_bits(64, signed(X[rs1]) + signed(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== WADDA (RV32)
-
-Mnemonic::
-
-wadda _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WADDA is available only in RV32 and accumulates into the destination register pair.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x1, attr: ['WADDA'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WADDA performs WADD and accumulates the 64-bit result into the destination
-register pair.
-
-Operation::
-
-[source,pseudocode]
-----
-acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
-acc = acc + to_bits(64, signed(X[rs1]) + signed(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc[31:0]
-    X[2*rd_p+1] = acc[63:32]
-----
-
-
-<<<
-==== WADDU (RV32)
-
-Mnemonic::
-
-waddu _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WADDU is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['WADDU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WADDU adds `rs1` and `rs2` as unsigned XLEN values and writes the 64-bit sum to
-the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-d = to_bits(64, unsigned(X[rs1]) + unsigned(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== WADDAU (RV32)
-
-Mnemonic::
-
-waddau _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WADDAU is available only in RV32 and accumulates into the destination register pair.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x3, attr: ['WADDAU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WADDAU performs WADDU and accumulates the 64-bit result into the destination
-register pair.
-
-Operation::
-
-[source,pseudocode]
-----
-acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
-acc = acc + to_bits(64, unsigned(X[rs1]) + unsigned(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc[31:0]
-    X[2*rd_p+1] = acc[63:32]
-----
-
-
-<<<
-==== WSUB (RV32)
-
-Mnemonic::
-
-wsub _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WSUB is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x8, attr: ['WSUB'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WSUB subtracts `rs2` from `rs1` as signed XLEN values and writes the 64-bit
-difference to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-d = to_bits(64, signed(X[rs1]) - signed(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== WSUBA (RV32)
-
-Mnemonic::
-
-wsuba _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WSUBA is available only in RV32 and accumulates into the destination register pair.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x9, attr: ['WSUBA'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WSUBA performs WSUB and accumulates the 64-bit result into the destination
-register pair.
-
-Operation::
-
-[source,pseudocode]
-----
-acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
-acc = acc + to_bits(64, signed(X[rs1]) - signed(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc[31:0]
-    X[2*rd_p+1] = acc[63:32]
-----
-
-
-<<<
-==== WSUBU (RV32)
-
-Mnemonic::
-
-wsubu _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WSUBU is available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xa, attr: ['WSUBU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WSUBU subtracts `rs2` from `rs1` as unsigned XLEN values and writes the 64-bit
-difference to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-d = to_bits(64, unsigned(X[rs1]) - unsigned(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== WSUBAU (RV32)
-
-Mnemonic::
-
-wsubau _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WSUBAU is available only in RV32 and accumulates into the destination register pair.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xb, attr: ['WSUBAU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WSUBAU performs WSUBU and accumulates the 64-bit result into the destination
-register pair.
-
-Operation::
-
-[source,pseudocode]
-----
-acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
-acc = acc + to_bits(64, unsigned(X[rs1]) - unsigned(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc[31:0]
-    X[2*rd_p+1] = acc[63:32]
-----
-
-
 
 <<<
 === Widening Shift
 
+==== WSLLI (RV32)
+
+Mnemonic::
+
+wslli _rd_p_, _rs1_, _uimm6_
+
+Encoding::
+
+WSLLI is available only in RV32. The shift amount is encoded in `uimm6`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['WSLLI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WSLLI zero-extends `rs1` to 64 bits, shifts left by an immediate amount, and
+writes the 64-bit result to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+shamt = uimm6[5:0]
+d = zero_extend(64, X[rs1]) << shamt
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
 ==== PWSLLI.B (RV32)
 
 Mnemonic::
@@ -18353,6 +18399,99 @@ shamt = uimm4[3:0]
 for i = 0 .. 3:
     a = s1[(8*i+7):(8*i)]
     d[(16*i+15):(16*i)] = zero_extend(16, a) << shamt
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
+==== PWSLLI.H (RV32)
+
+Mnemonic::
+
+pwslli.h _rd_p_, _rs1_, _uimm5_
+
+Encoding::
+
+PWSLLI.H is available only in RV32. The shift amount is encoded in `uimm5`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['PWSLLI.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWSLLI.H widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
+shifts left by an immediate amount, producing two 32-bit results.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm5[4:0]
+
+d0 = zero_extend(32, s1[15:0])  << shamt
+d1 = zero_extend(32, s1[31:16]) << shamt
+
+if (rd_p != 0):
+    X[2*rd_p]   = d0
+    X[2*rd_p+1] = d1
+----
+
+
+<<<
+==== WSLL (RV32)
+
+Mnemonic::
+
+wsll _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WSLL is available only in RV32. The shift amount is taken from `rs2`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['WSLL'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WSLL zero-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
+and writes the 64-bit result to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+shamt = X[rs2][5:0]
+d = zero_extend(64, X[rs1]) << shamt
 
 if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
@@ -18410,6 +18549,51 @@ if (rd_p != 0):
 
 
 <<<
+==== WSLAI (RV32)
+
+Mnemonic::
+
+wslai _rd_p_, _rs1_, _uimm6_
+
+Encoding::
+
+WSLAI is available only in RV32. The shift amount is encoded in `uimm6`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['WSLAI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WSLAI sign-extends `rs1` to 64 bits, shifts left by an immediate amount, and
+writes the 64-bit result to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+shamt = uimm6[5:0]
+d = sign_extend(64, X[rs1]) << shamt
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
 ==== PWSLAI.B (RV32)
 
 Mnemonic::
@@ -18451,6 +18635,99 @@ shamt = uimm4[3:0]
 for i = 0 .. 3:
     a = s1[(8*i+7):(8*i)]
     d[(16*i+15):(16*i)] = sign_extend(16, a) << shamt
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
+==== PWSLAI.H (RV32)
+
+Mnemonic::
+
+pwslai.h _rd_p_, _rs1_, _uimm5_
+
+Encoding::
+
+PWSLAI.H is available only in RV32. The shift amount is encoded in `uimm5`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PWSLAI.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWSLAI.H widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
+shifts left by an immediate amount.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = X[rs1]
+shamt = uimm5[4:0]
+
+d0 = sign_extend(32, s1[15:0])  << shamt
+d1 = sign_extend(32, s1[31:16]) << shamt
+
+if (rd_p != 0):
+    X[2*rd_p]   = d0
+    X[2*rd_p+1] = d1
+----
+
+
+<<<
+==== WSLA (RV32)
+
+Mnemonic::
+
+wsla _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WSLA is available only in RV32. The shift amount is taken from `rs2`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['WSLA'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WSLA sign-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
+and writes the 64-bit result to the destination register pair when `rd_p != 0`.
+
+Operation::
+
+[source,pseudocode]
+----
+shamt = X[rs2][5:0]
+d = sign_extend(64, X[rs1]) << shamt
 
 if (rd_p != 0):
     X[2*rd_p]   = d[31:0]
@@ -18508,54 +18785,6 @@ if (rd_p != 0):
 
 
 <<<
-==== PWSLLI.H (RV32)
-
-Mnemonic::
-
-pwslli.h _rd_p_, _rs1_, _uimm5_
-
-Encoding::
-
-PWSLLI.H is available only in RV32. The shift amount is encoded in `uimm5`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['PWSLLI.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWSLLI.H widens each 16-bit element of `rs1` to 32 bits by zero-extension, then
-shifts left by an immediate amount, producing two 32-bit results.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm5[4:0]
-
-d0 = zero_extend(32, s1[15:0])  << shamt
-d1 = zero_extend(32, s1[31:16]) << shamt
-
-if (rd_p != 0):
-    X[2*rd_p]   = d0
-    X[2*rd_p+1] = d1
-----
-
-
-<<<
 ==== PWSLL.HS (RV32)
 
 Mnemonic::
@@ -18596,54 +18825,6 @@ shamt = X[rs2][4:0]
 
 d0 = zero_extend(32, s1[15:0])  << shamt
 d1 = zero_extend(32, s1[31:16]) << shamt
-
-if (rd_p != 0):
-    X[2*rd_p]   = d0
-    X[2*rd_p+1] = d1
-----
-
-
-<<<
-==== PWSLAI.H (RV32)
-
-Mnemonic::
-
-pwslai.h _rd_p_, _rs1_, _uimm5_
-
-Encoding::
-
-PWSLAI.H is available only in RV32. The shift amount is encoded in `uimm5`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x4, attr: ['PWSLAI.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWSLAI.H widens each 16-bit element of `rs1` to 32 bits by sign-extension, then
-shifts left by an immediate amount.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = X[rs1]
-shamt = uimm5[4:0]
-
-d0 = sign_extend(32, s1[15:0])  << shamt
-d1 = sign_extend(32, s1[31:16]) << shamt
 
 if (rd_p != 0):
     X[2*rd_p]   = d0
@@ -18696,186 +18877,6 @@ d1 = sign_extend(32, s1[31:16]) << shamt
 if (rd_p != 0):
     X[2*rd_p]   = d0
     X[2*rd_p+1] = d1
-----
-
-
-<<<
-==== WSLL (RV32)
-
-Mnemonic::
-
-wsll _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WSLL is available only in RV32. The shift amount is taken from `rs2`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x0, attr: ['WSLL'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WSLL zero-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
-and writes the 64-bit result to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-shamt = X[rs2][5:0]
-d = zero_extend(64, X[rs1]) << shamt
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== WSLLI (RV32)
-
-Mnemonic::
-
-wslli _rd_p_, _rs1_, _uimm6_
-
-Encoding::
-
-WSLLI is available only in RV32. The shift amount is encoded in `uimm6`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['WSLLI'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WSLLI zero-extends `rs1` to 64 bits, shifts left by an immediate amount, and
-writes the 64-bit result to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-shamt = uimm6[5:0]
-d = zero_extend(64, X[rs1]) << shamt
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== WSLA (RV32)
-
-Mnemonic::
-
-wsla _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WSLA is available only in RV32. The shift amount is taken from `rs2`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x4, attr: ['WSLA'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WSLA sign-extends `rs1` to 64 bits, shifts left by the amount in `rs2` (low 6 bits),
-and writes the 64-bit result to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-shamt = X[rs2][5:0]
-d = sign_extend(64, X[rs1]) << shamt
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== WSLAI (RV32)
-
-Mnemonic::
-
-wslai _rd_p_, _rs1_, _uimm6_
-
-Encoding::
-
-WSLAI is available only in RV32. The shift amount is encoded in `uimm6`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x4, attr: ['WSLAI'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WSLAI sign-extends `rs1` to 64 bits, shifts left by an immediate amount, and
-writes the 64-bit result to the destination register pair when `rd_p != 0`.
-
-Operation::
-
-[source,pseudocode]
-----
-shamt = uimm6[5:0]
-d = sign_extend(64, X[rs1]) << shamt
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
 ----
 
 
@@ -19044,58 +19045,6 @@ X[rd] = to_bits(32, sum)
 
 
 <<<
-==== PREDSUMU.DBS (RV32)
-
-Mnemonic::
-
-predsumu.dbs _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-PREDSUMU.DBS is available only in RV32. It reads a 64-bit packed source from the
-even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
-in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x0 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x3, attr: ['PREDSUMU.DBS'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PREDSUMU.DBS adds the eight unsigned 8-bit elements contained in the 64-bit
-source register pair `rs1_p` to the unsigned scalar value in `rs2`, and writes
-the low 32 bits of the resulting sum to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 =
-  (rs1_p == 0) ? 0
-               : (X[2*rs1_p+1] @ X[2*rs1_p])      // 64-bit
-
-sum = unsigned(X[rs2])                            // scalar accumulator (int)
-
-for i = 0 .. 7:
-    sum += unsigned(s1[(8*i+7) : (8*i)])          // unsigned bytes
-
-X[rd] = to_bits(32, sum)
-----
-
-
-<<<
 ==== PREDSUM.DHS (RV32)
 
 Mnemonic::
@@ -19142,6 +19091,58 @@ sum = signed(X[rs2])                              // scalar accumulator (int)
 
 for i = 0 .. 3:
     sum += signed(s1[(16*i+15) : (16*i)])         // signed halfwords
+
+X[rd] = to_bits(32, sum)
+----
+
+
+<<<
+==== PREDSUMU.DBS (RV32)
+
+Mnemonic::
+
+predsumu.dbs _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+PREDSUMU.DBS is available only in RV32. It reads a 64-bit packed source from the
+even-odd register pair specified by `rs1_p` and produces a 32-bit scalar result
+in `rd`. If `rs1_p = 0`, the source pair is treated as zero.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x0 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['PREDSUMU.DBS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PREDSUMU.DBS adds the eight unsigned 8-bit elements contained in the 64-bit
+source register pair `rs1_p` to the unsigned scalar value in `rs2`, and writes
+the low 32 bits of the resulting sum to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 =
+  (rs1_p == 0) ? 0
+               : (X[2*rs1_p+1] @ X[2*rs1_p])      // 64-bit
+
+sum = unsigned(X[rs2])                            // scalar accumulator (int)
+
+for i = 0 .. 7:
+    sum += unsigned(s1[(8*i+7) : (8*i)])          // unsigned bytes
 
 X[rd] = to_bits(32, sum)
 ----
@@ -19203,6 +19204,52 @@ X[rd] = to_bits(32, sum)
 <<<
 === Narrowing Shift
 
+==== NSRLI (RV32)
+
+Mnemonic::
+
+nsrli _rd_, _rs1_p_, _uimm6_
+
+Encoding::
+
+NSRLI is encoded using the OP-IMM-32 major opcode. It reads a 64-bit register-pair
+source from `rs1_p`, performs a logical right shift by an immediate amount, and
+writes the low 32 bits to `rd`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x0, attr: ['NSRLI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+For NSRLI, `uimm6` is the shift amount.
+
+Description::
+
+NSRLI performs a 64-bit logical right shift of the register-pair source by an
+immediate amount and returns the low 32 bits.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = uimm6[5:0]
+X[rd] = (s1 >> shamt)[31:0]
+----
+
+
+<<<
 ==== PNSRLI.B (RV32)
 
 Mnemonic::
@@ -19249,259 +19296,6 @@ shamt = uimm4[3:0]
 for i = 0 .. 3:
     h = s1[(16*i+15):(16*i)]                 // 16-bit lane
     d[(8*i+7):(8*i)] = (zext_32(h) >> shamt)[7:0]
-
-X[rd] = d
-----
-
-
-<<<
-==== PNSRL.BS (RV32)
-
-Mnemonic::
-
-pnsrl.bs _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-PNSRL.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
-from `rs1_p` and uses `rs2[4:0]` as the shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x0, attr: ['PNSRL.BS'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNSRL.BS performs a per-lane logical right shift of four 16-bit lanes taken from
-a 64-bit register-pair source, using a shift amount from `rs2`. The low byte of
-each shifted lane is packed into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][4:0]
-
-for i = 0 .. 3:
-    h = s1[(16*i+15):(16*i)]
-    d[(8*i+7):(8*i)] = (zext_32(h) >> shamt)[7:0]
-
-X[rd] = d
-----
-
-
-<<<
-==== PNSRAI.B (RV32)
-
-Mnemonic::
-
-pnsrai.b _rd_, _rs1_p_, _uimm4_
-
-Encoding::
-
-PNSRAI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
-from the register pair selected by `rs1_p` and produces a packed byte result in
-`rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 4, name: 'uimm4' },
-    { bits: 3, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x4, attr: ['PNSRAI.B'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-`uimm4` is the shift amount.
-
-Description::
-
-PNSRAI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
-an arithmetic right shift by an immediate amount, and packs the low byte of each
-shifted lane into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = uimm4[3:0]
-
-for i = 0 .. 3:
-    h = s1[(16*i+15):(16*i)]
-    d[(8*i+7):(8*i)] = (sext_32(h) >> shamt)[7:0]
-
-X[rd] = d
-----
-
-
-<<<
-==== PNSRA.BS (RV32)
-
-Mnemonic::
-
-pnsra.bs _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-PNSRA.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
-from `rs1_p` and uses `rs2[4:0]` as the shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x4, attr: ['PNSRA.BS'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNSRA.BS performs a per-lane arithmetic right shift of four 16-bit lanes taken
-from a 64-bit register-pair source, using a shift amount from `rs2`. The low
-byte of each shifted lane is packed into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][4:0]
-
-for i = 0 .. 3:
-    h = s1[(16*i+15):(16*i)]
-    d[(8*i+7):(8*i)] = (sext_32(h) >> shamt)[7:0]
-
-X[rd] = d
-----
-
-
-<<<
-==== PNSRARI.B (RV32)
-
-Mnemonic::
-
-pnsrari.b _rd_, _rs1_p_, _uimm4_
-
-Encoding::
-
-PNSRARI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
-from `rs1_p` and performs a rounded arithmetic right shift by an immediate amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 4, name: 'uimm4' },
-    { bits: 3, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['PNSRARI.B'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-`uimm4` is the shift amount.
-
-Description::
-
-PNSRARI.B performs a per-lane rounded arithmetic right shift of four 16-bit lanes
-from a 64-bit register-pair source using an immediate shift amount, and packs
-the resulting bytes into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = uimm4[3:0]
-
-for i = 0 .. 3:
-    h  = s1[(16*i+15):(16*i)]
-    // Compute rounded arithmetic shift: ( (h << 1) >> shamt + 1 ) >> 1
-    shx = ((sext_32(h) @ 0b0) >> shamt)[8:0]
-    d[(8*i+7):(8*i)] = (shx + 1)[8:1]
-
-X[rd] = d
-----
-
-
-<<<
-==== PNSRAR.BS (RV32)
-
-Mnemonic::
-
-pnsrar.bs _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-PNSRAR.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
-from `rs1_p` and uses `rs2[4:0]` as the shift amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x5, attr: ['PNSRAR.BS'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNSRAR.BS performs a per-lane rounded arithmetic right shift of four 16-bit lanes
-from a 64-bit register-pair source using a shift amount from `rs2`, and packs
-the resulting bytes into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][4:0]
-
-for i = 0 .. 3:
-    h  = s1[(16*i+15):(16*i)]
-    shx = ((sext_32(h) @ 0b0) >> shamt)[8:0]
-    d[(8*i+7):(8*i)] = (shx + 1)[8:1]
 
 X[rd] = d
 ----
@@ -19559,6 +19353,98 @@ X[rd] = d
 
 
 <<<
+==== NSRL (RV32)
+
+Mnemonic::
+
+nsrl _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+NSRL is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
+amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['NSRL'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NSRL performs a 64-bit logical right shift of the register-pair source by a shift
+amount from `rs2` and returns the low 32 bits.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][5:0]
+X[rd] = (s1 >> shamt)[31:0]
+----
+
+
+<<<
+==== PNSRL.BS (RV32)
+
+Mnemonic::
+
+pnsrl.bs _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+PNSRL.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
+from `rs1_p` and uses `rs2[4:0]` as the shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x0, attr: ['PNSRL.BS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNSRL.BS performs a per-lane logical right shift of four 16-bit lanes taken from
+a 64-bit register-pair source, using a shift amount from `rs2`. The low byte of
+each shifted lane is packed into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][4:0]
+
+for i = 0 .. 3:
+    h = s1[(16*i+15):(16*i)]
+    d[(8*i+7):(8*i)] = (zext_32(h) >> shamt)[7:0]
+
+X[rd] = d
+----
+
+
+<<<
 ==== PNSRL.HS (RV32)
 
 Mnemonic::
@@ -19602,6 +19488,102 @@ shamt = X[rs2][4:0]
 
 d[15:0]  = (s1[31:0]  >> shamt)[15:0]
 d[31:16] = (s1[63:32] >> shamt)[15:0]
+
+X[rd] = d
+----
+
+
+<<<
+==== NSRAI (RV32)
+
+Mnemonic::
+
+nsrai _rd_, _rs1_p_, _uimm6_
+
+Encoding::
+
+NSRAI is encoded using the OP-IMM-32 major opcode. It performs an arithmetic
+right shift by an immediate amount on the 64-bit register-pair source and writes
+the low 32 bits to `rd`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['NSRAI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NSRAI performs a 64-bit arithmetic right shift of the register-pair source by an
+immediate amount and returns the low 32 bits.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = uimm6[5:0]
+X[rd] = (sext_96(s1) >> shamt)[31:0]
+----
+
+
+<<<
+==== PNSRAI.B (RV32)
+
+Mnemonic::
+
+pnsrai.b _rd_, _rs1_p_, _uimm4_
+
+Encoding::
+
+PNSRAI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
+from the register pair selected by `rs1_p` and produces a packed byte result in
+`rd`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 4, name: 'uimm4' },
+    { bits: 3, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x4, attr: ['PNSRAI.B'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+`uimm4` is the shift amount.
+
+Description::
+
+PNSRAI.B extracts four 16-bit lanes from a 64-bit register-pair source, performs
+an arithmetic right shift by an immediate amount, and packs the low byte of each
+shifted lane into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = uimm4[3:0]
+
+for i = 0 .. 3:
+    h = s1[(16*i+15):(16*i)]
+    d[(8*i+7):(8*i)] = (sext_32(h) >> shamt)[7:0]
 
 X[rd] = d
 ----
@@ -19659,6 +19641,98 @@ X[rd] = d
 
 
 <<<
+==== NSRA (RV32)
+
+Mnemonic::
+
+nsra _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+NSRA is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
+amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['NSRA'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NSRA performs a 64-bit arithmetic right shift of the register-pair source by a
+shift amount from `rs2` and returns the low 32 bits.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][5:0]
+X[rd] = (sext_96(s1) >> shamt)[31:0]
+----
+
+
+<<<
+==== PNSRA.BS (RV32)
+
+Mnemonic::
+
+pnsra.bs _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+PNSRA.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
+from `rs1_p` and uses `rs2[4:0]` as the shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x4, attr: ['PNSRA.BS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNSRA.BS performs a per-lane arithmetic right shift of four 16-bit lanes taken
+from a 64-bit register-pair source, using a shift amount from `rs2`. The low
+byte of each shifted lane is packed into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][4:0]
+
+for i = 0 .. 3:
+    h = s1[(16*i+15):(16*i)]
+    d[(8*i+7):(8*i)] = (sext_32(h) >> shamt)[7:0]
+
+X[rd] = d
+----
+
+
+<<<
 ==== PNSRA.HS (RV32)
 
 Mnemonic::
@@ -19702,6 +19776,104 @@ shamt = X[rs2][4:0]
 
 d[15:0]  = (sext_48(s1[31:0])  >> shamt)[15:0]
 d[31:16] = (sext_48(s1[63:32]) >> shamt)[15:0]
+
+X[rd] = d
+----
+
+
+<<<
+==== NSRARI (RV32)
+
+Mnemonic::
+
+nsrari _rd_, _rs1_p_, _uimm6_
+
+Encoding::
+
+NSRARI is encoded using the OP-IMM-32 major opcode. It performs a *rounded*
+arithmetic right shift by an immediate amount on the 64-bit register-pair source.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['NSRARI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NSRARI performs a 64-bit *rounded* arithmetic right shift of the register-pair
+source by an immediate amount and returns the rounded low 32-bit result.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = uimm6[5:0]
+
+shx = ((sext_96(s1) @ 0b0) >> shamt)[32:0]
+X[rd] = (shx + 1)[32:1]
+----
+
+
+<<<
+==== PNSRARI.B (RV32)
+
+Mnemonic::
+
+pnsrari.b _rd_, _rs1_p_, _uimm4_
+
+Encoding::
+
+PNSRARI.B is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
+from `rs1_p` and performs a rounded arithmetic right shift by an immediate amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 4, name: 'uimm4' },
+    { bits: 3, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x5, attr: ['PNSRARI.B'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+`uimm4` is the shift amount.
+
+Description::
+
+PNSRARI.B performs a per-lane rounded arithmetic right shift of four 16-bit lanes
+from a 64-bit register-pair source using an immediate shift amount, and packs
+the resulting bytes into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = uimm4[3:0]
+
+for i = 0 .. 3:
+    h  = s1[(16*i+15):(16*i)]
+    // Compute rounded arithmetic shift: ( (h << 1) >> shamt + 1 ) >> 1
+    shx = ((sext_32(h) @ 0b0) >> shamt)[8:0]
+    d[(8*i+7):(8*i)] = (shx + 1)[8:1]
 
 X[rd] = d
 ----
@@ -19759,6 +19931,101 @@ X[rd] = d
 
 
 <<<
+==== NSRAR (RV32)
+
+Mnemonic::
+
+nsrar _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+NSRAR is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
+amount for a *rounded* arithmetic right shift.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x5, attr: ['NSRAR'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NSRAR performs a 64-bit *rounded* arithmetic right shift of the register-pair
+source by a shift amount from `rs2` and returns the rounded low 32-bit result.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][5:0]
+
+shx = ((sext_96(s1) @ 0b0) >> shamt)[32:0]
+X[rd] = (shx + 1)[32:1]
+----
+
+
+<<<
+==== PNSRAR.BS (RV32)
+
+Mnemonic::
+
+pnsrar.bs _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+PNSRAR.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
+from `rs1_p` and uses `rs2[4:0]` as the shift amount.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x5, attr: ['PNSRAR.BS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNSRAR.BS performs a per-lane rounded arithmetic right shift of four 16-bit lanes
+from a 64-bit register-pair source using a shift amount from `rs2`, and packs
+the resulting bytes into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][4:0]
+
+for i = 0 .. 3:
+    h  = s1[(16*i+15):(16*i)]
+    shx = ((sext_32(h) @ 0b0) >> shamt)[8:0]
+    d[(8*i+7):(8*i)] = (shx + 1)[8:1]
+
+X[rd] = d
+----
+
+
+<<<
 ==== PNSRAR.HS (RV32)
 
 Mnemonic::
@@ -19808,276 +20075,68 @@ X[rd] = d
 ----
 
 
-<<<
-==== NSRLI (RV32)
-
-Mnemonic::
-
-nsrli _rd_, _rs1_p_, _uimm6_
-
-Encoding::
-
-NSRLI is encoded using the OP-IMM-32 major opcode. It reads a 64-bit register-pair
-source from `rs1_p`, performs a logical right shift by an immediate amount, and
-writes the low 32 bits to `rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x0, attr: ['NSRLI'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-For NSRLI, `uimm6` is the shift amount.
-
-Description::
-
-NSRLI performs a 64-bit logical right shift of the register-pair source by an
-immediate amount and returns the low 32 bits.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = uimm6[5:0]
-X[rd] = (s1 >> shamt)[31:0]
-----
-
-
-<<<
-==== NSRL (RV32)
-
-Mnemonic::
-
-nsrl _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-NSRL is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
-amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x0, attr: ['NSRL'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NSRL performs a 64-bit logical right shift of the register-pair source by a shift
-amount from `rs2` and returns the low 32 bits.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][5:0]
-X[rd] = (s1 >> shamt)[31:0]
-----
-
-
-<<<
-==== NSRAI (RV32)
-
-Mnemonic::
-
-nsrai _rd_, _rs1_p_, _uimm6_
-
-Encoding::
-
-NSRAI is encoded using the OP-IMM-32 major opcode. It performs an arithmetic
-right shift by an immediate amount on the 64-bit register-pair source and writes
-the low 32 bits to `rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x4, attr: ['NSRAI'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NSRAI performs a 64-bit arithmetic right shift of the register-pair source by an
-immediate amount and returns the low 32 bits.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = uimm6[5:0]
-X[rd] = (sext_96(s1) >> shamt)[31:0]
-----
-
-
-<<<
-==== NSRA (RV32)
-
-Mnemonic::
-
-nsra _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-NSRA is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
-amount.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x4, attr: ['NSRA'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NSRA performs a 64-bit arithmetic right shift of the register-pair source by a
-shift amount from `rs2` and returns the low 32 bits.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][5:0]
-X[rd] = (sext_96(s1) >> shamt)[31:0]
-----
-
-
-<<<
-==== NSRARI (RV32)
-
-Mnemonic::
-
-nsrari _rd_, _rs1_p_, _uimm6_
-
-Encoding::
-
-NSRARI is encoded using the OP-IMM-32 major opcode. It performs a *rounded*
-arithmetic right shift by an immediate amount on the 64-bit register-pair source.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x5, attr: ['NSRARI'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NSRARI performs a 64-bit *rounded* arithmetic right shift of the register-pair
-source by an immediate amount and returns the rounded low 32-bit result.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = uimm6[5:0]
-
-shx = ((sext_96(s1) @ 0b0) >> shamt)[32:0]
-X[rd] = (shx + 1)[32:1]
-----
-
-
-<<<
-==== NSRAR (RV32)
-
-Mnemonic::
-
-nsrar _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-NSRAR is encoded using the OP-IMM-32 major opcode and uses `rs2[5:0]` as the shift
-amount for a *rounded* arithmetic right shift.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x5, attr: ['NSRAR'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NSRAR performs a 64-bit *rounded* arithmetic right shift of the register-pair
-source by a shift amount from `rs2` and returns the rounded low 32-bit result.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][5:0]
-
-shx = ((sext_96(s1) @ 0b0) >> shamt)[32:0]
-X[rd] = (shx + 1)[32:1]
-----
-
-
 
 <<<
 === Narrowing Clip
 
+==== NCLIPI (RV32)
+
+Mnemonic::
+
+nclipi _rd_, _rs1_p_, _uimm6_
+
+Encoding::
+
+NCLIPI is encoded in the OP-IMM-32 major opcode with an immediate shift amount
+and XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['NCLIPI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NCLIPI performs an XLEN-wide narrowing signed clip with an immediate shift
+amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is arithmetically right-shifted by the 6-bit immediate, then
+clamped to the signed 32-bit range [-2^31^, 2^31^-1]. The 32-bit result is
+written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = uimm6[5:0]
+
+shx = sign_extend(128, s1) >> shamt    // arithmetic shift, take low 64 bits
+
+if (shx <s 0xFFFFFFFF80000000):
+    X[rd] = 0x80000000; vxsat = 1
+else if (shx >s 0x000000007FFFFFFF):
+    X[rd] = 0x7FFFFFFF; vxsat = 1
+else:
+    X[rd] = shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PNCLIPI.B (RV32)
 
 Mnemonic::
@@ -20146,6 +20205,126 @@ Notes::
 * `vxsat` is set if any lane saturates; it is not cleared by this instruction.
 
 <<<
+==== PNCLIPI.H (RV32)
+
+Mnemonic::
+
+pnclipi.h _rd_, _rs1_p_, _uimm5_
+
+Encoding::
+
+PNCLIPI.H is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount and packed halfword narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x6, attr: ['PNCLIPI.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNCLIPI.H performs a packed narrowing signed clip from 32-bit word elements
+to 16-bit halfword elements with an immediate shift amount. The 64-bit source
+is read from the register pair designated by `rs1_p`. Each 32-bit element is
+arithmetically right-shifted by the 5-bit immediate, then clamped to the signed
+16-bit range [-32768, 32767]. Two halfword results are packed into `rd`. If any
+element saturates, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = uimm5[4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    shx  = sign_extend(64, s1_w) >> shamt    // arithmetic shift, take low 32 bits
+    if (shx <s 0xFFFF8000):
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if (shx >s 0x00007FFF):
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = shx[15:0]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== NCLIP (RV32)
+
+Mnemonic::
+
+nclip _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+NCLIP is encoded in the OP-IMM-32 major opcode with a scalar shift amount and
+XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['NCLIP'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NCLIP performs an XLEN-wide narrowing signed clip with a scalar shift amount.
+The 64-bit source is read from the register pair designated by `rs1_p`. The
+value is arithmetically right-shifted by the amount in `rs2[5:0]`, then clamped
+to the signed 32-bit range [-2^31^, 2^31^-1]. The 32-bit result is written to
+`rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][5:0]
+
+shx = sign_extend(128, s1) >> shamt    // arithmetic shift, take low 64 bits
+
+if (shx <s 0xFFFFFFFF80000000):
+    X[rd] = 0x80000000; vxsat = 1
+else if (shx >s 0x000000007FFFFFFF):
+    X[rd] = 0x7FFFFFFF; vxsat = 1
+else:
+    X[rd] = shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PNCLIP.BS (RV32)
 
 Mnemonic::
@@ -20201,6 +20380,129 @@ for i = 0 .. 3:
         d[(8*i+7):(8*i)] = shx[7:0]
 
 X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PNCLIP.HS (RV32)
+
+Mnemonic::
+
+pnclip.hs _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+PNCLIP.HS is encoded in the OP-IMM-32 major opcode with a scalar shift amount
+and packed halfword narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x6, attr: ['PNCLIP.HS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNCLIP.HS performs a packed narrowing signed clip from 32-bit word elements
+to 16-bit halfword elements with a scalar shift amount. The 64-bit source is
+read from the register pair designated by `rs1_p`. Each 32-bit element is
+arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
+signed 16-bit range [-32768, 32767]. Two halfword results are packed into `rd`.
+If any element saturates, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    shx  = sign_extend(64, s1_w) >> shamt    // arithmetic shift, take low 32 bits
+    if (shx <s 0xFFFF8000):
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if (shx >s 0x00007FFF):
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = shx[15:0]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== NCLIPRI (RV32)
+
+Mnemonic::
+
+nclipri _rd_, _rs1_p_, _uimm6_
+
+Encoding::
+
+NCLIPRI is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount, rounding, and XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x7, attr: ['NCLIPRI'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NCLIPRI performs an XLEN-wide narrowing signed clip with rounding using an
+immediate shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is arithmetically right-shifted with
+round-to-nearest-up by the 6-bit immediate, then clamped to the signed 32-bit
+range [-2^31^, 2^31^-1]. The 32-bit result is written to `rd`. If saturation
+occurs, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = uimm6[5:0]
+
+// Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
+shx       = (sign_extend(128, s1) @ 0b0) >> shamt   // 65-bit result
+round_shx = (shx + 1)[64:1]                          // round to nearest, ties up
+
+if (round_shx <s 0xFFFFFFFF80000000):
+    X[rd] = 0x80000000; vxsat = 1
+else if (round_shx >s 0x000000007FFFFFFF):
+    X[rd] = 0x7FFFFFFF; vxsat = 1
+else:
+    X[rd] = round_shx[31:0]
 ----
 
 Notes::
@@ -20282,6 +20584,131 @@ Notes::
 * `vxsat` is set if any lane saturates; it is not cleared by this instruction.
 
 <<<
+==== PNCLIPRI.H (RV32)
+
+Mnemonic::
+
+pnclipri.h _rd_, _rs1_p_, _uimm5_
+
+Encoding::
+
+PNCLIPRI.H is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount, rounding, and packed halfword narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x7, attr: ['PNCLIPRI.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNCLIPRI.H performs a packed narrowing signed clip with rounding from 32-bit
+word elements to 16-bit halfword elements using an immediate shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is arithmetically right-shifted with round-to-nearest-up, then clamped
+to the signed 16-bit range [-32768, 32767]. Two halfword results are packed
+into `rd`. If any element saturates, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = uimm5[4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    // Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
+    shx       = (sign_extend(64, s1_w) @ 0b0) >> shamt   // 33-bit result
+    round_shx = (shx + 1)[32:1]                           // round to nearest, ties up
+    if (round_shx <s 0xFFFF8000):
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if (round_shx >s 0x00007FFF):
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = round_shx[15:0]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== NCLIPR (RV32)
+
+Mnemonic::
+
+nclipr _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+NCLIPR is encoded in the OP-IMM-32 major opcode with a scalar shift amount,
+rounding, and XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['NCLIPR'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NCLIPR performs an XLEN-wide narrowing signed clip with rounding using a scalar
+shift amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is arithmetically right-shifted with round-to-nearest-up by
+the amount in `rs2[5:0]`, then clamped to the signed 32-bit range
+[-2^31^, 2^31^-1]. The 32-bit result is written to `rd`. If saturation occurs,
+`vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][5:0]
+
+// Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
+shx       = (sign_extend(128, s1) @ 0b0) >> shamt   // 65-bit result
+round_shx = (shx + 1)[64:1]                          // round to nearest, ties up
+
+if (round_shx <s 0xFFFFFFFF80000000):
+    X[rd] = 0x80000000; vxsat = 1
+else if (round_shx >s 0x000000007FFFFFFF):
+    X[rd] = 0x7FFFFFFF; vxsat = 1
+else:
+    X[rd] = round_shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PNCLIPR.BS (RV32)
 
 Mnemonic::
@@ -20354,6 +20781,127 @@ Notes::
 * `vxsat` is set if any lane saturates; it is not cleared by this instruction.
 
 <<<
+==== PNCLIPR.HS (RV32)
+
+Mnemonic::
+
+pnclipr.hs _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+PNCLIPR.HS is encoded in the OP-IMM-32 major opcode with a scalar shift
+amount, rounding, and packed halfword narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x7, attr: ['PNCLIPR.HS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNCLIPR.HS performs a packed narrowing signed clip with rounding from 32-bit
+word elements to 16-bit halfword elements using a scalar shift amount. The
+64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
+element is arithmetically right-shifted with round-to-nearest-up by the amount
+in `rs2[4:0]`, then clamped to the signed 16-bit range [-32768, 32767]. Two
+halfword results are packed into `rd`. If any element saturates, `vxsat` is
+set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][4:0]
+
+for i = 0 .. 1:
+    s1_w = s1[(32*i+31):(32*i)]
+    // Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
+    shx       = (sign_extend(64, s1_w) @ 0b0) >> shamt   // 33-bit result
+    round_shx = (shx + 1)[32:1]                           // round to nearest, ties up
+    if (round_shx <s 0xFFFF8000):
+        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
+    else if (round_shx >s 0x00007FFF):
+        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
+    else:
+        d[(16*i+15):(16*i)] = round_shx[15:0]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== NCLIPIU (RV32)
+
+Mnemonic::
+
+nclipiu _rd_, _rs1_p_, _uimm6_
+
+Encoding::
+
+NCLIPIU is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount and unsigned XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['NCLIPIU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NCLIPIU performs an XLEN-wide narrowing unsigned clip with an immediate shift
+amount. The 64-bit source is read from the register pair designated by
+`rs1_p`. The value is logically right-shifted by the 6-bit immediate, then
+clamped to the unsigned 32-bit range [0, 2^32^-1]. The 32-bit result is
+written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = uimm6[5:0]
+
+shx = s1 >> shamt                      // logical shift
+
+if (shx >u 0x00000000FFFFFFFF):
+    X[rd] = 0xFFFFFFFF; vxsat = 1
+else:
+    X[rd] = shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PNCLIPIU.B (RV32)
 
 Mnemonic::
@@ -20419,6 +20967,120 @@ Notes::
 * `vxsat` is set if any lane saturates; it is not cleared by this instruction.
 
 <<<
+==== PNCLIPIU.H (RV32)
+
+Mnemonic::
+
+pnclipiu.h _rd_, _rs1_p_, _uimm5_
+
+Encoding::
+
+PNCLIPIU.H is encoded using the OP-IMM-32 major opcode. It performs a per-word
+logical right shift by an immediate amount and clips each result to the unsigned
+16-bit range [0, 65535], setting `vxsat` on saturation.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'uimm5' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x2, attr: ['PNCLIPIU.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNCLIPIU.H shifts each 32-bit word lane of the 64-bit register-pair source right
+logically by an immediate amount, then clips each shifted value to unsigned
+16-bit and packs the two halfwords into `rd`. The `vxsat` sticky flag is set if
+any lane saturates.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = uimm5[4:0]
+
+for i = 0 .. 1:
+    w   = s1[(32*i+31):(32*i)]
+    shx = zext_64(w) >> shamt
+
+    if (shx >_u 0x0000FFFF):
+        vxsat = 1
+        d[(16*i+15):(16*i)] = 0xFFFF
+    else:
+        d[(16*i+15):(16*i)] = shx[15:0]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== NCLIPU (RV32)
+
+Mnemonic::
+
+nclipu _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+NCLIPU is encoded using the OP-IMM-32 major opcode. It shifts a 64-bit register-pair
+source right logically by a shift amount from `rs2` and clips the result to the
+unsigned 32-bit range, setting `vxsat` on saturation.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x2, attr: ['NCLIPU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NCLIPU performs a 64-bit logical right shift of the register-pair source and clips
+the result to 32-bit unsigned. The `vxsat` sticky flag is set if clipping occurs.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][5:0]
+
+shx = s1 >> shamt
+
+if (shx >_u 0x00000000FFFFFFFF):
+    vxsat = 1
+    X[rd] = 0xFFFFFFFF
+else:
+    X[rd] = shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PNCLIPU.BS (RV32)
 
 Mnemonic::
@@ -20472,6 +21134,123 @@ for i = 0 .. 3:
         d[(8*i+7):(8*i)] = shx[7:0]
 
 X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PNCLIPU.HS (RV32)
+
+Mnemonic::
+
+pnclipu.hs _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+PNCLIPU.HS is encoded using the OP-IMM-32 major opcode. It uses `rs2[4:0]` as the
+shift amount and clips to unsigned 16-bit.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x2, attr: ['PNCLIPU.HS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNCLIPU.HS performs a per-word logical right shift of a 64-bit register-pair
+source using `rs2` as the shift amount, clips each lane to unsigned 16-bit, and
+packs the results into `rd`. The `vxsat` sticky flag is set on saturation.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][4:0]
+
+for i = 0 .. 1:
+    w   = s1[(32*i+31):(32*i)]
+    shx = zext_64(w) >> shamt
+
+    if (shx >_u 0x0000FFFF):
+        vxsat = 1
+        d[(16*i+15):(16*i)] = 0xFFFF
+    else:
+        d[(16*i+15):(16*i)] = shx[15:0]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== NCLIPRIU (RV32)
+
+Mnemonic::
+
+nclipriu _rd_, _rs1_p_, _uimm6_
+
+Encoding::
+
+NCLIPRIU is encoded in the OP-IMM-32 major opcode with an immediate shift
+amount, rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 6, name: 'uimm6' },
+    { bits: 1, name: 0x1 },
+    { bits: 1, name: 0x0 },
+    { bits: 3, name: 0x3, attr: ['NCLIPRIU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NCLIPRIU performs an XLEN-wide narrowing unsigned clip with rounding using an
+immediate shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is logically right-shifted with
+round-to-nearest-up by the 6-bit immediate, then clamped to the unsigned
+32-bit range [0, 2^32^-1]. The 32-bit result is written to `rd`. If
+saturation occurs, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = uimm6[5:0]
+
+// Unsigned shift right with rounding: append guard bit, shift, add 1, drop LSB
+shx       = (s1 @ 0b0) >> shamt              // 65-bit logical shift
+round_shx = (shx + 1)[64:1]                  // round to nearest, ties up
+
+if (round_shx >u 0x00000000FFFFFFFF):
+    X[rd] = 0xFFFFFFFF; vxsat = 1
+else:
+    X[rd] = round_shx[31:0]
 ----
 
 Notes::
@@ -20544,439 +21323,6 @@ Notes::
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
-==== PNCLIPRU.BS (RV32)
-
-Mnemonic::
-
-pnclipru.bs _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-PNCLIPRU.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
-from the register pair selected by `rs1_p`, uses `rs2[4:0]` as the shift amount,
-and writes packed *rounded unsigned-clipped* bytes to `rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x3, attr: ['PNCLIPRU.BS'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNCLIPRU.BS performs a per-lane *rounded* logical right shift of four 16-bit lanes
-from a 64-bit register-pair source using a shift amount from `rs2`. Each rounded
-shifted value is clipped to [0, 255] and packed into `rd`. The `vxsat` sticky
-flag is set if any lane saturates.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][4:0]
-
-for i = 0 .. 3:
-    h = s1[(16*i+15):(16*i)]
-
-    shx = ((zext_32(h) @ 0b0) >> shamt)[16:0]
-    r   = (shx + 1)[16:1]
-
-    if (r >_u 0x00FF):
-        vxsat = 1
-        d[(8*i+7):(8*i)] = 0xFF
-    else:
-        d[(8*i+7):(8*i)] = r[7:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PNCLIPI.H (RV32)
-
-Mnemonic::
-
-pnclipi.h _rd_, _rs1_p_, _uimm5_
-
-Encoding::
-
-PNCLIPI.H is encoded in the OP-IMM-32 major opcode with an immediate shift
-amount and packed halfword narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x6, attr: ['PNCLIPI.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNCLIPI.H performs a packed narrowing signed clip from 32-bit word elements
-to 16-bit halfword elements with an immediate shift amount. The 64-bit source
-is read from the register pair designated by `rs1_p`. Each 32-bit element is
-arithmetically right-shifted by the 5-bit immediate, then clamped to the signed
-16-bit range [-32768, 32767]. Two halfword results are packed into `rd`. If any
-element saturates, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = uimm5[4:0]
-
-for i = 0 .. 1:
-    s1_w = s1[(32*i+31):(32*i)]
-    shx  = sign_extend(64, s1_w) >> shamt    // arithmetic shift, take low 32 bits
-    if (shx <s 0xFFFF8000):
-        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
-    else if (shx >s 0x00007FFF):
-        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
-    else:
-        d[(16*i+15):(16*i)] = shx[15:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PNCLIP.HS (RV32)
-
-Mnemonic::
-
-pnclip.hs _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-PNCLIP.HS is encoded in the OP-IMM-32 major opcode with a scalar shift amount
-and packed halfword narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x6, attr: ['PNCLIP.HS'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNCLIP.HS performs a packed narrowing signed clip from 32-bit word elements
-to 16-bit halfword elements with a scalar shift amount. The 64-bit source is
-read from the register pair designated by `rs1_p`. Each 32-bit element is
-arithmetically right-shifted by the amount in `rs2[4:0]`, then clamped to the
-signed 16-bit range [-32768, 32767]. Two halfword results are packed into `rd`.
-If any element saturates, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = X[rs2][4:0]
-
-for i = 0 .. 1:
-    s1_w = s1[(32*i+31):(32*i)]
-    shx  = sign_extend(64, s1_w) >> shamt    // arithmetic shift, take low 32 bits
-    if (shx <s 0xFFFF8000):
-        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
-    else if (shx >s 0x00007FFF):
-        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
-    else:
-        d[(16*i+15):(16*i)] = shx[15:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PNCLIPRI.H (RV32)
-
-Mnemonic::
-
-pnclipri.h _rd_, _rs1_p_, _uimm5_
-
-Encoding::
-
-PNCLIPRI.H is encoded in the OP-IMM-32 major opcode with an immediate shift
-amount, rounding, and packed halfword narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x7, attr: ['PNCLIPRI.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNCLIPRI.H performs a packed narrowing signed clip with rounding from 32-bit
-word elements to 16-bit halfword elements using an immediate shift amount. The
-64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
-element is arithmetically right-shifted with round-to-nearest-up, then clamped
-to the signed 16-bit range [-32768, 32767]. Two halfword results are packed
-into `rd`. If any element saturates, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = uimm5[4:0]
-
-for i = 0 .. 1:
-    s1_w = s1[(32*i+31):(32*i)]
-    // Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
-    shx       = (sign_extend(64, s1_w) @ 0b0) >> shamt   // 33-bit result
-    round_shx = (shx + 1)[32:1]                           // round to nearest, ties up
-    if (round_shx <s 0xFFFF8000):
-        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
-    else if (round_shx >s 0x00007FFF):
-        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
-    else:
-        d[(16*i+15):(16*i)] = round_shx[15:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PNCLIPR.HS (RV32)
-
-Mnemonic::
-
-pnclipr.hs _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-PNCLIPR.HS is encoded in the OP-IMM-32 major opcode with a scalar shift
-amount, rounding, and packed halfword narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x7, attr: ['PNCLIPR.HS'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNCLIPR.HS performs a packed narrowing signed clip with rounding from 32-bit
-word elements to 16-bit halfword elements using a scalar shift amount. The
-64-bit source is read from the register pair designated by `rs1_p`. Each 32-bit
-element is arithmetically right-shifted with round-to-nearest-up by the amount
-in `rs2[4:0]`, then clamped to the signed 16-bit range [-32768, 32767]. Two
-halfword results are packed into `rd`. If any element saturates, `vxsat` is
-set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = X[rs2][4:0]
-
-for i = 0 .. 1:
-    s1_w = s1[(32*i+31):(32*i)]
-    // Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
-    shx       = (sign_extend(64, s1_w) @ 0b0) >> shamt   // 33-bit result
-    round_shx = (shx + 1)[32:1]                           // round to nearest, ties up
-    if (round_shx <s 0xFFFF8000):
-        d[(16*i+15):(16*i)] = 0x8000; vxsat = 1
-    else if (round_shx >s 0x00007FFF):
-        d[(16*i+15):(16*i)] = 0x7FFF; vxsat = 1
-    else:
-        d[(16*i+15):(16*i)] = round_shx[15:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PNCLIPIU.H (RV32)
-
-Mnemonic::
-
-pnclipiu.h _rd_, _rs1_p_, _uimm5_
-
-Encoding::
-
-PNCLIPIU.H is encoded using the OP-IMM-32 major opcode. It performs a per-word
-logical right shift by an immediate amount and clips each result to the unsigned
-16-bit range [0, 65535], setting `vxsat` on saturation.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'uimm5' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x2, attr: ['PNCLIPIU.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNCLIPIU.H shifts each 32-bit word lane of the 64-bit register-pair source right
-logically by an immediate amount, then clips each shifted value to unsigned
-16-bit and packs the two halfwords into `rd`. The `vxsat` sticky flag is set if
-any lane saturates.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = uimm5[4:0]
-
-for i = 0 .. 1:
-    w   = s1[(32*i+31):(32*i)]
-    shx = zext_64(w) >> shamt
-
-    if (shx >_u 0x0000FFFF):
-        vxsat = 1
-        d[(16*i+15):(16*i)] = 0xFFFF
-    else:
-        d[(16*i+15):(16*i)] = shx[15:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== PNCLIPU.HS (RV32)
-
-Mnemonic::
-
-pnclipu.hs _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-PNCLIPU.HS is encoded using the OP-IMM-32 major opcode. It uses `rs2[4:0]` as the
-shift amount and clips to unsigned 16-bit.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x2, attr: ['PNCLIPU.HS'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PNCLIPU.HS performs a per-word logical right shift of a 64-bit register-pair
-source using `rs2` as the shift amount, clips each lane to unsigned 16-bit, and
-packs the results into `rd`. The `vxsat` sticky flag is set on saturation.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][4:0]
-
-for i = 0 .. 1:
-    w   = s1[(32*i+31):(32*i)]
-    shx = zext_64(w) >> shamt
-
-    if (shx >_u 0x0000FFFF):
-        vxsat = 1
-        d[(16*i+15):(16*i)] = 0xFFFF
-    else:
-        d[(16*i+15):(16*i)] = shx[15:0]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
 ==== PNCLIPRIU.H (RV32)
 
 Mnemonic::
@@ -21031,6 +21377,127 @@ for i = 0 .. 1:
         d[(16*i+15):(16*i)] = 0xFFFF; vxsat = 1
     else:
         d[(16*i+15):(16*i)] = round_shx[15:0]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== NCLIPRU (RV32)
+
+Mnemonic::
+
+nclipru _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+NCLIPRU is encoded in the OP-IMM-32 major opcode with a scalar shift amount,
+rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['NCLIPRU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+NCLIPRU performs an XLEN-wide narrowing unsigned clip with rounding using a
+scalar shift amount. The 64-bit source is read from the register pair
+designated by `rs1_p`. The value is logically right-shifted with
+round-to-nearest-up by the amount in `rs2[5:0]`, then clamped to the unsigned
+32-bit range [0, 2^32^-1]. The 32-bit result is written to `rd`. If
+saturation occurs, `vxsat` is set. Available only in RV32.
+
+Operation::
+
+[source,pseudocode]
+----
+// Read 64-bit source from register pair
+s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
+shamt = X[rs2][5:0]
+
+// Unsigned shift right with rounding: append guard bit, shift, add 1, drop LSB
+shx       = (s1 @ 0b0) >> shamt              // 65-bit logical shift
+round_shx = (shx + 1)[64:1]                  // round to nearest, ties up
+
+if (round_shx >u 0x00000000FFFFFFFF):
+    X[rd] = 0xFFFFFFFF; vxsat = 1
+else:
+    X[rd] = round_shx[31:0]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PNCLIPRU.BS (RV32)
+
+Mnemonic::
+
+pnclipru.bs _rd_, _rs1_p_, _rs2_
+
+Encoding::
+
+PNCLIPRU.BS is encoded using the OP-IMM-32 major opcode. It reads a 64-bit source
+from the register pair selected by `rs1_p`, uses `rs2[4:0]` as the shift amount,
+and writes packed *rounded unsigned-clipped* bytes to `rd`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x4 },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rs1_p' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 1, name: 0x1 },
+    { bits: 3, name: 0x3, attr: ['PNCLIPRU.BS'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PNCLIPRU.BS performs a per-lane *rounded* logical right shift of four 16-bit lanes
+from a 64-bit register-pair source using a shift amount from `rs2`. Each rounded
+shifted value is clipped to [0, 255] and packed into `rd`. The `vxsat` sticky
+flag is set if any lane saturates.
+
+Operation::
+
+[source,pseudocode]
+----
+s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
+shamt = X[rs2][4:0]
+
+for i = 0 .. 3:
+    h = s1[(16*i+15):(16*i)]
+
+    shx = ((zext_32(h) @ 0b0) >> shamt)[16:0]
+    r   = (shx + 1)[16:1]
+
+    if (r >_u 0x00FF):
+        vxsat = 1
+        d[(8*i+7):(8*i)] = 0xFF
+    else:
+        d[(8*i+7):(8*i)] = r[7:0]
 
 X[rd] = d
 ----
@@ -21097,472 +21564,6 @@ for i = 0 .. 1:
         d[(16*i+15):(16*i)] = round_shx[15:0]
 
 X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== NCLIPI (RV32)
-
-Mnemonic::
-
-nclipi _rd_, _rs1_p_, _uimm6_
-
-Encoding::
-
-NCLIPI is encoded in the OP-IMM-32 major opcode with an immediate shift amount
-and XLEN-wide narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x6, attr: ['NCLIPI'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NCLIPI performs an XLEN-wide narrowing signed clip with an immediate shift
-amount. The 64-bit source is read from the register pair designated by
-`rs1_p`. The value is arithmetically right-shifted by the 6-bit immediate, then
-clamped to the signed 32-bit range [-2^31^, 2^31^-1]. The 32-bit result is
-written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = uimm6[5:0]
-
-shx = sign_extend(128, s1) >> shamt    // arithmetic shift, take low 64 bits
-
-if (shx <s 0xFFFFFFFF80000000):
-    X[rd] = 0x80000000; vxsat = 1
-else if (shx >s 0x000000007FFFFFFF):
-    X[rd] = 0x7FFFFFFF; vxsat = 1
-else:
-    X[rd] = shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== NCLIP (RV32)
-
-Mnemonic::
-
-nclip _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-NCLIP is encoded in the OP-IMM-32 major opcode with a scalar shift amount and
-XLEN-wide narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x6, attr: ['NCLIP'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NCLIP performs an XLEN-wide narrowing signed clip with a scalar shift amount.
-The 64-bit source is read from the register pair designated by `rs1_p`. The
-value is arithmetically right-shifted by the amount in `rs2[5:0]`, then clamped
-to the signed 32-bit range [-2^31^, 2^31^-1]. The 32-bit result is written to
-`rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = X[rs2][5:0]
-
-shx = sign_extend(128, s1) >> shamt    // arithmetic shift, take low 64 bits
-
-if (shx <s 0xFFFFFFFF80000000):
-    X[rd] = 0x80000000; vxsat = 1
-else if (shx >s 0x000000007FFFFFFF):
-    X[rd] = 0x7FFFFFFF; vxsat = 1
-else:
-    X[rd] = shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== NCLIPRI (RV32)
-
-Mnemonic::
-
-nclipri _rd_, _rs1_p_, _uimm6_
-
-Encoding::
-
-NCLIPRI is encoded in the OP-IMM-32 major opcode with an immediate shift
-amount, rounding, and XLEN-wide narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x7, attr: ['NCLIPRI'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NCLIPRI performs an XLEN-wide narrowing signed clip with rounding using an
-immediate shift amount. The 64-bit source is read from the register pair
-designated by `rs1_p`. The value is arithmetically right-shifted with
-round-to-nearest-up by the 6-bit immediate, then clamped to the signed 32-bit
-range [-2^31^, 2^31^-1]. The 32-bit result is written to `rd`. If saturation
-occurs, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = uimm6[5:0]
-
-// Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
-shx       = (sign_extend(128, s1) @ 0b0) >> shamt   // 65-bit result
-round_shx = (shx + 1)[64:1]                          // round to nearest, ties up
-
-if (round_shx <s 0xFFFFFFFF80000000):
-    X[rd] = 0x80000000; vxsat = 1
-else if (round_shx >s 0x000000007FFFFFFF):
-    X[rd] = 0x7FFFFFFF; vxsat = 1
-else:
-    X[rd] = round_shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== NCLIPR (RV32)
-
-Mnemonic::
-
-nclipr _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-NCLIPR is encoded in the OP-IMM-32 major opcode with a scalar shift amount,
-rounding, and XLEN-wide narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x7, attr: ['NCLIPR'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NCLIPR performs an XLEN-wide narrowing signed clip with rounding using a scalar
-shift amount. The 64-bit source is read from the register pair designated by
-`rs1_p`. The value is arithmetically right-shifted with round-to-nearest-up by
-the amount in `rs2[5:0]`, then clamped to the signed 32-bit range
-[-2^31^, 2^31^-1]. The 32-bit result is written to `rd`. If saturation occurs,
-`vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = X[rs2][5:0]
-
-// Shift right with rounding: append guard bit, shift, then add 1 and drop LSB
-shx       = (sign_extend(128, s1) @ 0b0) >> shamt   // 65-bit result
-round_shx = (shx + 1)[64:1]                          // round to nearest, ties up
-
-if (round_shx <s 0xFFFFFFFF80000000):
-    X[rd] = 0x80000000; vxsat = 1
-else if (round_shx >s 0x000000007FFFFFFF):
-    X[rd] = 0x7FFFFFFF; vxsat = 1
-else:
-    X[rd] = round_shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== NCLIPIU (RV32)
-
-Mnemonic::
-
-nclipiu _rd_, _rs1_p_, _uimm6_
-
-Encoding::
-
-NCLIPIU is encoded in the OP-IMM-32 major opcode with an immediate shift
-amount and unsigned XLEN-wide narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x2, attr: ['NCLIPIU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NCLIPIU performs an XLEN-wide narrowing unsigned clip with an immediate shift
-amount. The 64-bit source is read from the register pair designated by
-`rs1_p`. The value is logically right-shifted by the 6-bit immediate, then
-clamped to the unsigned 32-bit range [0, 2^32^-1]. The 32-bit result is
-written to `rd`. If saturation occurs, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = uimm6[5:0]
-
-shx = s1 >> shamt                      // logical shift
-
-if (shx >u 0x00000000FFFFFFFF):
-    X[rd] = 0xFFFFFFFF; vxsat = 1
-else:
-    X[rd] = shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== NCLIPU (RV32)
-
-Mnemonic::
-
-nclipu _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-NCLIPU is encoded using the OP-IMM-32 major opcode. It shifts a 64-bit register-pair
-source right logically by a shift amount from `rs2` and clips the result to the
-unsigned 32-bit range, setting `vxsat` on saturation.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x2, attr: ['NCLIPU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NCLIPU performs a 64-bit logical right shift of the register-pair source and clips
-the result to 32-bit unsigned. The `vxsat` sticky flag is set if clipping occurs.
-
-Operation::
-
-[source,pseudocode]
-----
-s1    = (rs1_p == 0) ? 0 : (X[2*rs1_p+1] @ X[2*rs1_p])
-shamt = X[rs2][5:0]
-
-shx = s1 >> shamt
-
-if (shx >_u 0x00000000FFFFFFFF):
-    vxsat = 1
-    X[rd] = 0xFFFFFFFF
-else:
-    X[rd] = shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== NCLIPRIU (RV32)
-
-Mnemonic::
-
-nclipriu _rd_, _rs1_p_, _uimm6_
-
-Encoding::
-
-NCLIPRIU is encoded in the OP-IMM-32 major opcode with an immediate shift
-amount, rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 6, name: 'uimm6' },
-    { bits: 1, name: 0x1 },
-    { bits: 1, name: 0x0 },
-    { bits: 3, name: 0x3, attr: ['NCLIPRIU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NCLIPRIU performs an XLEN-wide narrowing unsigned clip with rounding using an
-immediate shift amount. The 64-bit source is read from the register pair
-designated by `rs1_p`. The value is logically right-shifted with
-round-to-nearest-up by the 6-bit immediate, then clamped to the unsigned
-32-bit range [0, 2^32^-1]. The 32-bit result is written to `rd`. If
-saturation occurs, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = uimm6[5:0]
-
-// Unsigned shift right with rounding: append guard bit, shift, add 1, drop LSB
-shx       = (s1 @ 0b0) >> shamt              // 65-bit logical shift
-round_shx = (shx + 1)[64:1]                  // round to nearest, ties up
-
-if (round_shx >u 0x00000000FFFFFFFF):
-    X[rd] = 0xFFFFFFFF; vxsat = 1
-else:
-    X[rd] = round_shx[31:0]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-==== NCLIPRU (RV32)
-
-Mnemonic::
-
-nclipru _rd_, _rs1_p_, _rs2_
-
-Encoding::
-
-NCLIPRU is encoded in the OP-IMM-32 major opcode with a scalar shift amount,
-rounding, and unsigned XLEN-wide narrowing. Available only in RV32.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x4 },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rs1_p' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 1, name: 0x1 },
-    { bits: 3, name: 0x3, attr: ['NCLIPRU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-NCLIPRU performs an XLEN-wide narrowing unsigned clip with rounding using a
-scalar shift amount. The 64-bit source is read from the register pair
-designated by `rs1_p`. The value is logically right-shifted with
-round-to-nearest-up by the amount in `rs2[5:0]`, then clamped to the unsigned
-32-bit range [0, 2^32^-1]. The 32-bit result is written to `rd`. If
-saturation occurs, `vxsat` is set. Available only in RV32.
-
-Operation::
-
-[source,pseudocode]
-----
-// Read 64-bit source from register pair
-s1 = if (rs1_p == 0) then 0 else X[rs1_p * 2 + 1] @ X[rs1_p * 2]
-shamt = X[rs2][5:0]
-
-// Unsigned shift right with rounding: append guard bit, shift, add 1, drop LSB
-shx       = (s1 @ 0b0) >> shamt              // 65-bit logical shift
-round_shx = (shx + 1)[64:1]                  // round to nearest, ties up
-
-if (round_shx >u 0x00000000FFFFFFFF):
-    X[rd] = 0xFFFFFFFF; vxsat = 1
-else:
-    X[rd] = round_shx[31:0]
 ----
 
 Notes::
@@ -21968,16 +21969,15 @@ Notes::
   product, keeping the upper half.
 
 <<<
-==== PMULHR.H
+==== PMULH.W (RV64)
 
 Mnemonic::
 
-pmulhr.h _rd_, _rs1_, _rs2_
+pmulh.w _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PMULHR.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
-elements and returns the rounded high half of each signed 16×16 multiplication.
+PMULH.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
 
 [wavedrom, ,svg]
 ....
@@ -21987,41 +21987,35 @@ elements and returns the rounded high half of each signed 16×16 multiplication.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x0, attr: ['PMULHR.H'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PMULH.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-PMULHR.H performs lane-wise signed multiplication of packed 16-bit elements from
-`rs1` and `rs2`. For each lane, it adds 2^15^ to the 32-bit product and then
-writes the upper 16 bits of the adjusted value to the corresponding 16-bit
-element of `rd`, implementing rounding when extracting the high half.
+PMULH.W multiplies corresponding signed packed 32-bit word elements of `rs1`
+and `rs2`, producing 64-bit intermediate products, and writes the upper 32 bits
+of each product to the corresponding word element of `rd`. This instruction is
+available only on RV64.
 
 Operation::
 
 [source,pseudocode]
 ----
+# RV64 only
 s1 = X[rs1]
 s2 = X[rs2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1[(16*i+15):(16*i)]
-    b = s2[(16*i+15):(16*i)]
-    // add 2^15 before taking high 16 bits (rounding)
-    d[(16*i+15):(16*i)] =
-        to_bits(32, signed(a) * signed(b) + 2^15)[31:16]
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (signed(a) * signed(b))[63:32]
 
 X[rd] = d
 ----
 
-Notes::
-
-* This instruction does not set `vxsat`.
-* The per-lane result corresponds to rounding the 32-bit product before
-  extracting bits [31:16].
 
 <<<
 ==== PMULHSU.H
@@ -22078,6 +22072,336 @@ Notes::
 * This instruction does not set `vxsat`.
 * The result is equivalent to extracting bits [31:16] of the full 32-bit
   mixed signed×unsigned product.
+
+<<<
+==== PMULHSU.W (RV64)
+
+Mnemonic::
+
+pmulhsu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULHSU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x8, attr: ['PMULHSU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMULHSU.W instruction multiplies corresponding 32-bit elements of `rs1`
+(signed) and `rs2` (unsigned), and writes the upper 32 bits of each product
+to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 1:
+    a = sext_64(s1[(32*i+31):(32*i)])
+    b = zext_64(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a * b)[63:32]
+
+X[rd] = d
+----
+
+
+<<<
+==== PMULHU.H
+
+Mnemonic::
+
+pmulhu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULHU.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PMULHU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULHU.H multiplies corresponding unsigned packed 16-bit halfword elements of
+`rs1` and `rs2`, producing 32-bit intermediate products, and writes the upper
+16 bits of each product to the corresponding halfword element of `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    d[(16*i+15):(16*i)] = (unsigned(a) * unsigned(b))[31:16]
+
+X[rd] = d
+----
+
+
+<<<
+==== PMULHU.W (RV64)
+
+Mnemonic::
+
+pmulhu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULHU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PMULHU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMULHU.W instruction multiplies corresponding unsigned 32-bit elements of
+`rs1` and `rs2`, writing the upper 32 bits of each product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 1:
+    a = zext_64(s1[(32*i+31):(32*i)])
+    b = zext_64(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a * b)[63:32]
+
+X[rd] = d
+----
+
+
+<<<
+==== MULHR (RV32)
+
+Mnemonic::
+
+mulhr _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULHR is encoded in the OP-32 major opcode as an XLEN-wide operation.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['MULHR'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULHR multiplies the full signed XLEN-bit values of `rs1` and `rs2`, producing
+a 2*XLEN-bit intermediate product, adds a rounding constant of 2^(XLEN-1),
+and writes the upper XLEN bits of the rounded product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^31)[63:32]
+----
+
+
+<<<
+==== PMULHR.H
+
+Mnemonic::
+
+pmulhr.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULHR.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
+elements and returns the rounded high half of each signed 16×16 multiplication.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x0, attr: ['PMULHR.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULHR.H performs lane-wise signed multiplication of packed 16-bit elements from
+`rs1` and `rs2`. For each lane, it adds 2^15^ to the 32-bit product and then
+writes the upper 16 bits of the adjusted value to the corresponding 16-bit
+element of `rd`, implementing rounding when extracting the high half.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/16 - 1):
+    a = s1[(16*i+15):(16*i)]
+    b = s2[(16*i+15):(16*i)]
+    // add 2^15 before taking high 16 bits (rounding)
+    d[(16*i+15):(16*i)] =
+        to_bits(32, signed(a) * signed(b) + 2^15)[31:16]
+
+X[rd] = d
+----
+
+Notes::
+
+* This instruction does not set `vxsat`.
+* The per-lane result corresponds to rounding the 32-bit product before
+  extracting bits [31:16].
+
+<<<
+==== PMULHR.W (RV64)
+
+Mnemonic::
+
+pmulhr.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULHR.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['PMULHR.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULHR.W multiplies corresponding signed packed 32-bit word elements of `rs1`
+and `rs2`, producing 64-bit intermediate products, adds a rounding constant
+of 2^31^, and writes the upper 32 bits of each rounded product to the
+corresponding word element of `rd`. This instruction is available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    d[(32*i+31):(32*i)] = (signed(a) * signed(b) + 2^31)[63:32]
+
+X[rd] = d
+----
+
+
+<<<
+==== MULHRSU (RV32)
+
+Mnemonic::
+
+mulhrsu _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULHRSU is encoded in the OP-32 major opcode using the scalar
+multiply-high rounded sub-encoding.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x8, attr: ['MULHRSU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MULHRSU instruction multiplies `rs1` as a signed value by `rs2` as an
+unsigned value, adds 2^31^ for rounding, and writes the upper 32 bits of the
+result to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a64 = sext_64(X[rs1])
+b64 = zext_64(X[rs2])
+prod = a64 * b64
+X[rd] = (prod + 2^31)[63:32]
+----
+
+Notes::
+
+* Rounding is performed by adding 2^31^ before extracting bits [63:32].
 
 <<<
 ==== PMULHRSU.H
@@ -22138,15 +22462,16 @@ Notes::
   before extracting bits [31:16].
 
 <<<
-==== PMULHU.H
+==== PMULHRSU.W (RV64)
 
 Mnemonic::
 
-pmulhu.h _rd_, _rs1_, _rs2_
+pmulhrsu.w _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PMULHU.H is encoded in the OP-32 major opcode with packed halfword elements.
+PMULHRSU.W is encoded in the OP-32 major opcode using packed 32-bit elements
+with rounding.
 
 [wavedrom, ,svg]
 ....
@@ -22156,17 +22481,17 @@ PMULHU.H is encoded in the OP-32 major opcode with packed halfword elements.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x2, attr: ['PMULHU.H'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x8, attr: ['PMULHRSU.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-PMULHU.H multiplies corresponding unsigned packed 16-bit halfword elements of
-`rs1` and `rs2`, producing 32-bit intermediate products, and writes the upper
-16 bits of each product to the corresponding halfword element of `rd`.
+The PMULHRSU.W instruction performs signed×unsigned packed multiplication on
+32-bit elements, applies rounding, and writes the upper 32 bits of each result
+to `rd`.
 
 Operation::
 
@@ -22175,12 +22500,56 @@ Operation::
 s1 = X[rs1]
 s2 = X[rs2]
 
-for i = 0 .. (XLEN/16 - 1):
-    a = s1[(16*i+15):(16*i)]
-    b = s2[(16*i+15):(16*i)]
-    d[(16*i+15):(16*i)] = (unsigned(a) * unsigned(b))[31:16]
+for i = 0 .. 1:
+    a = sext_64(s1[(32*i+31):(32*i)])
+    b = zext_64(s2[(32*i+31):(32*i)])
+    d[(32*i+31):(32*i)] = (a * b + 2^31)[63:32]
 
 X[rd] = d
+----
+
+Notes::
+
+* Rounding is performed by adding 2^31^ before extracting bits [63:32].
+
+<<<
+==== MULHRU (RV32)
+
+Mnemonic::
+
+mulhru _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULHRU is encoded in the OP-32 major opcode using the scalar
+multiply-high rounded sub-encoding.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x2, attr: ['MULHRU'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MULHRU instruction multiplie
+
+Operation::
+
+[source,pseudocode]
+----
+a64 = zext_64(X[rs1])
+b64 = zext_64(X[rs2])
+prod = a64 * b64
+X[rd] = (prod + 2^31)[63:32]
 ----
 
 
@@ -22241,248 +22610,6 @@ Notes::
   extracting bits [31:16].
 
 <<<
-==== PMULH.W (RV64)
-
-Mnemonic::
-
-pmulh.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULH.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x0, attr: ['PMULH.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULH.W multiplies corresponding signed packed 32-bit word elements of `rs1`
-and `rs2`, producing 64-bit intermediate products, and writes the upper 32 bits
-of each product to the corresponding word element of `rd`. This instruction is
-available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. 1:
-    a = s1[(32*i+31):(32*i)]
-    b = s2[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = (signed(a) * signed(b))[63:32]
-
-X[rd] = d
-----
-
-
-<<<
-==== PMULHR.W (RV64)
-
-Mnemonic::
-
-pmulhr.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULHR.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x0, attr: ['PMULHR.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULHR.W multiplies corresponding signed packed 32-bit word elements of `rs1`
-and `rs2`, producing 64-bit intermediate products, adds a rounding constant
-of 2^31^, and writes the upper 32 bits of each rounded product to the
-corresponding word element of `rd`. This instruction is available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. 1:
-    a = s1[(32*i+31):(32*i)]
-    b = s2[(32*i+31):(32*i)]
-    d[(32*i+31):(32*i)] = (signed(a) * signed(b) + 2^31)[63:32]
-
-X[rd] = d
-----
-
-
-<<<
-==== PMULHSU.W (RV64)
-
-Mnemonic::
-
-pmulhsu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULHSU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x8, attr: ['PMULHSU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMULHSU.W instruction multiplies corresponding 32-bit elements of `rs1`
-(signed) and `rs2` (unsigned), and writes the upper 32 bits of each product
-to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. 1:
-    a = sext_64(s1[(32*i+31):(32*i)])
-    b = zext_64(s2[(32*i+31):(32*i)])
-    d[(32*i+31):(32*i)] = (a * b)[63:32]
-
-X[rd] = d
-----
-
-
-<<<
-==== PMULHRSU.W (RV64)
-
-Mnemonic::
-
-pmulhrsu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULHRSU.W is encoded in the OP-32 major opcode using packed 32-bit elements
-with rounding.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x8, attr: ['PMULHRSU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMULHRSU.W instruction performs signed×unsigned packed multiplication on
-32-bit elements, applies rounding, and writes the upper 32 bits of each result
-to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. 1:
-    a = sext_64(s1[(32*i+31):(32*i)])
-    b = zext_64(s2[(32*i+31):(32*i)])
-    d[(32*i+31):(32*i)] = (a * b + 2^31)[63:32]
-
-X[rd] = d
-----
-
-Notes::
-
-* Rounding is performed by adding 2^31^ before extracting bits [63:32].
-
-<<<
-==== PMULHU.W (RV64)
-
-Mnemonic::
-
-pmulhu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULHU.W is encoded in the OP-32 major opcode using packed 32-bit elements.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['PMULHU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMULHU.W instruction multiplies corresponding unsigned 32-bit elements of
-`rs1` and `rs2`, writing the upper 32 bits of each product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. 1:
-    a = zext_64(s1[(32*i+31):(32*i)])
-    b = zext_64(s2[(32*i+31):(32*i)])
-    d[(32*i+31):(32*i)] = (a * b)[63:32]
-
-X[rd] = d
-----
-
-
-<<<
 ==== PMULHRU.W (RV64)
 
 Mnemonic::
@@ -22532,136 +22659,60 @@ Notes::
 
 * Rounding is performed by adding 2^31^.
 
-<<<
-==== MULHR (RV32)
-
-Mnemonic::
-
-mulhr _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULHR is encoded in the OP-32 major opcode as an XLEN-wide operation.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x0, attr: ['MULHR'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULHR multiplies the full signed XLEN-bit values of `rs1` and `rs2`, producing
-a 2*XLEN-bit intermediate product, adds a rounding constant of 2^(XLEN-1),
-and writes the upper XLEN bits of the rounded product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-X[rd] = (signed(X[rs1]) * signed(X[rs2]) + 2^31)[63:32]
-----
-
-
-<<<
-==== MULHRSU (RV32)
-
-Mnemonic::
-
-mulhrsu _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULHRSU is encoded in the OP-32 major opcode using the scalar
-multiply-high rounded sub-encoding.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x8, attr: ['MULHRSU'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MULHRSU instruction multiplies `rs1` as a signed value by `rs2` as an
-unsigned value, adds 2^31^ for rounding, and writes the upper 32 bits of the
-result to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a64 = sext_64(X[rs1])
-b64 = zext_64(X[rs2])
-prod = a64 * b64
-X[rd] = (prod + 2^31)[63:32]
-----
-
-Notes::
-
-* Rounding is performed by adding 2^31^ before extracting bits [63:32].
-
-<<<
-==== MULHRU (RV32)
-
-Mnemonic::
-
-mulhru _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULHRU is encoded in the OP-32 major opcode using the scalar
-multiply-high rounded sub-encoding.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x2, attr: ['MULHRU'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MULHRU instruction multiplie
-
-Operation::
-
-[source,pseudocode]
-----
-a64 = zext_64(X[rs1])
-b64 = zext_64(X[rs2])
-prod = a64 * b64
-X[rd] = (prod + 2^31)[63:32]
-----
-
 
 
 <<<
 === Q-format Multiply
 
+==== MULQ (RV32)
+
+Mnemonic::
+
+mulq _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULQ is encoded in the OP-32 major opcode as an XLEN-wide operation.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['MULQ'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULQ performs a Q-format multiply on the full signed XLEN-bit values of `rs1`
+and `rs2`. It computes `(a * b) << 1` and keeps the upper XLEN bits. When both
+inputs are the most negative value, the result saturates to the most positive
+value and the `vxsat` overflow flag is set.
+
+Operation::
+
+[source,pseudocode]
+----
+a = X[rs1]
+b = X[rs2]
+if (a == 0x80000000) & (b == 0x80000000):
+    X[rd] = 0x7FFFFFFF
+    vxsat = 1
+else:
+    X[rd] = (signed(a) * signed(b))[62:31]
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
 ==== PMULQ.H
 
 Mnemonic::
@@ -22710,6 +22761,113 @@ for i = 0 .. (XLEN/16 - 1):
         d[(16*i+15):(16*i)] = (signed(a) * signed(b))[30:15]
 
 X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== PMULQ.W (RV64)
+
+Mnemonic::
+
+pmulq.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULQ.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['PMULQ.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULQ.W performs a Q-format multiply on corresponding signed packed 32-bit
+word elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
+upper 32 bits. When both inputs are the most negative value (0x80000000), the
+result saturates to 0x7FFFFFFF and the `vxsat` overflow flag is set. This
+instruction is available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 1:
+    a = s1[(32*i+31):(32*i)]
+    b = s2[(32*i+31):(32*i)]
+    if (a == 0x80000000) & (b == 0x80000000):
+        d[(32*i+31):(32*i)] = 0x7FFFFFFF
+        vxsat = 1
+    else:
+        d[(32*i+31):(32*i)] = (signed(a) * signed(b))[62:31]
+
+X[rd] = d
+----
+
+Notes::
+
+* `vxsat` is set to 1 if saturation occurs in any element.
+
+<<<
+==== MULQR (RV32)
+
+Mnemonic::
+
+mulqr _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULQR is encoded in the OP-32 major opcode as an XLEN-wide operation.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xa, attr: ['MULQR'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULQR performs a rounding Q-format multiply on the full signed XLEN-bit values
+of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a rounding constant of
+2^(XLEN-2) before the shift, and keeps the upper XLEN bits. When both inputs
+are the most negative value, the result saturates to the most positive value
+and the `vxsat` overflow flag is set.
+
+Operation::
+
+[source,pseudocode]
+----
+a = X[rs1]
+b = X[rs2]
+if (a == 0x80000000) & (b == 0x80000000):
+    X[rd] = 0x7FFFFFFF
+    vxsat = 1
+else:
+    X[rd] = (signed(a) * signed(b) + 2^30)[62:31]
 ----
 
 Notes::
@@ -22780,63 +22938,6 @@ Notes::
 
 
 <<<
-==== PMULQ.W (RV64)
-
-Mnemonic::
-
-pmulq.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULQ.W is encoded in the OP-32 major opcode with packed word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xa, attr: ['PMULQ.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULQ.W performs a Q-format multiply on corresponding signed packed 32-bit
-word elements of `rs1` and `rs2`. It computes `(a * b) << 1` and keeps the
-upper 32 bits. When both inputs are the most negative value (0x80000000), the
-result saturates to 0x7FFFFFFF and the `vxsat` overflow flag is set. This
-instruction is available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. 1:
-    a = s1[(32*i+31):(32*i)]
-    b = s2[(32*i+31):(32*i)]
-    if (a == 0x80000000) & (b == 0x80000000):
-        d[(32*i+31):(32*i)] = 0x7FFFFFFF
-        vxsat = 1
-    else:
-        d[(32*i+31):(32*i)] = (signed(a) * signed(b))[62:31]
-
-X[rd] = d
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
 ==== PMULQR.W (RV64)
 
 Mnemonic::
@@ -22895,15 +22996,18 @@ Notes::
 * `vxsat` is set to 1 if saturation occurs in any element.
 
 <<<
-==== MULQ (RV32)
+=== Multiply-High Accumulate
+
+==== MHACC (RV32)
 
 Mnemonic::
 
-mulq _rd_, _rs1_, _rs2_
+mhacc _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MULQ is encoded in the OP-32 major opcode as an XLEN-wide operation.
+MHACC is encoded in the OP-32 major opcode as a scalar
+multiply-high accumulate instruction.
 
 [wavedrom, ,svg]
 ....
@@ -22914,88 +23018,31 @@ MULQ is encoded in the OP-32 major opcode as an XLEN-wide operation.
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xa, attr: ['MULQ'] },
+    { bits: 4, name: 0x1, attr: ['MHACC'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-MULQ performs a Q-format multiply on the full signed XLEN-bit values of `rs1`
-and `rs2`. It computes `(a * b) << 1` and keeps the upper XLEN bits. When both
-inputs are the most negative value, the result saturates to the most positive
-value and the `vxsat` overflow flag is set.
+The MHACC instruction multiplies `rs1` and `rs2` as signed values, extracts
+the upper 32 bits of the product, and accumulates the result into `rd`.
 
 Operation::
 
 [source,pseudocode]
 ----
-a = X[rs1]
-b = X[rs2]
-if (a == 0x80000000) & (b == 0x80000000):
-    X[rd] = 0x7FFFFFFF
-    vxsat = 1
-else:
-    X[rd] = (signed(a) * signed(b))[62:31]
+a64 = sext_64(X[rs1])
+b64 = sext_64(X[rs2])
+hi  = (a64 * b64)[63:32]
+X[rd] = X[rd] + hi
 ----
 
 Notes::
 
-* `vxsat` is set to 1 if saturation occurs in any element.
+* This instruction reads and writes `rd`.
 
 <<<
-==== MULQR (RV32)
-
-Mnemonic::
-
-mulqr _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULQR is encoded in the OP-32 major opcode as an XLEN-wide operation.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xa, attr: ['MULQR'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULQR performs a rounding Q-format multiply on the full signed XLEN-bit values
-of `rs1` and `rs2`. It computes `(a * b) << 1`, adds a rounding constant of
-2^(XLEN-2) before the shift, and keeps the upper XLEN bits. When both inputs
-are the most negative value, the result saturates to the most positive value
-and the `vxsat` overflow flag is set.
-
-Operation::
-
-[source,pseudocode]
-----
-a = X[rs1]
-b = X[rs2]
-if (a == 0x80000000) & (b == 0x80000000):
-    X[rd] = 0x7FFFFFFF
-    vxsat = 1
-else:
-    X[rd] = (signed(a) * signed(b) + 2^30)[62:31]
-----
-
-Notes::
-
-* `vxsat` is set to 1 if saturation occurs in any element.
-
-<<<
-=== Multiply-High Accumulate
-
 ==== PMHACC.H
 
 Mnemonic::
@@ -23044,301 +23091,6 @@ for i = 0 .. (XLEN/16 - 1):
 
     d[(16*i+15):(16*i)] =
         acc + to_bits(32, signed(a) * signed(b))[31:16]
-
-X[rd] = d
-----
-
-Notes::
-
-* This instruction does not set `vxsat`.
-* The per-lane add wraps modulo 2^16^.
-
-<<<
-==== PMHRACC.H
-
-Mnemonic::
-
-pmhracc.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMHRACC.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
-elements and accumulates the rounded high half of each signed 16×16
-multiplication into `rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x1, attr: ['PMHRACC.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMHRACC.H performs lane-wise signed multiplication of packed 16-bit elements from
-`rs1` and `rs2`. For each lane, it adds 2^15^ to the 32-bit product, extracts the
-upper 16 bits of the adjusted value, and accumulates that into the corresponding
-16-bit element of `rd`. The packed accumulated result is written back to `rd`,
-implementing rounding when extracting the high half.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d  = X[rd]
-
-for i = 0 .. (XLEN/16 - 1):
-    a   = s1[(16*i+15):(16*i)]
-    b   = s2[(16*i+15):(16*i)]
-    acc = d[(16*i+15):(16*i)]
-
-    d[(16*i+15):(16*i)] =
-        acc + to_bits(32, signed(a) * signed(b) + 2^15)[31:16]
-
-X[rd] = d
-----
-
-Notes::
-
-* This instruction does not set `vxsat`.
-* The per-lane add wraps modulo 2^16^.
-
-<<<
-==== PMHACCSU.H
-
-Mnemonic::
-
-pmhaccsu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMHACCSU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
-elements and accumulates the high half of each mixed signed×unsigned 16×16
-multiplication into `rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x9, attr: ['PMHACCSU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMHACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
-and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
-each lane, it extracts the upper 16 bits of the 32-bit product and accumulates
-that value into the corresponding 16-bit element of `rd`. The packed accumulated
-result is written back to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d  = X[rd]
-
-for i = 0 .. (XLEN/16 - 1):
-    a   = s1[(16*i+15):(16*i)]
-    b   = s2[(16*i+15):(16*i)]
-    acc = d[(16*i+15):(16*i)]
-
-    d[(16*i+15):(16*i)] =
-        acc + to_bits(32, signed(a) * unsigned(b))[31:16]
-
-X[rd] = d
-----
-
-Notes::
-
-* This instruction does not set `vxsat`.
-* The per-lane add wraps modulo 2^16^.
-
-<<<
-==== PMHRACCSU.H
-
-Mnemonic::
-
-pmhraccsu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMHRACCSU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
-elements and accumulates the rounded high half of each mixed signed×unsigned
-16×16 multiplication into `rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x9, attr: ['PMHRACCSU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMHRACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
-and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
-each lane, it adds 2^15^ to the 32-bit product, extracts the upper 16 bits of the
-adjusted value, and accumulates that into the corresponding 16-bit element of
-`rd`. The packed accumulated result is written back to `rd`, implementing
-rounding when extracting the high half.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d  = X[rd]
-
-for i = 0 .. (XLEN/16 - 1):
-    a   = s1[(16*i+15):(16*i)]
-    b   = s2[(16*i+15):(16*i)]
-    acc = d[(16*i+15):(16*i)]
-
-    d[(16*i+15):(16*i)] =
-        acc + to_bits(32, signed(a) * unsigned(b) + 2^15)[31:16]
-
-X[rd] = d
-----
-
-Notes::
-
-* This instruction does not set `vxsat`.
-* The per-lane add wraps modulo 2^16^.
-
-<<<
-==== PMHACCU.H
-
-Mnemonic::
-
-pmhaccu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMHACCU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
-elements and accumulates the high half of each unsigned 16×16 multiplication
-into `rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x3, attr: ['PMHACCU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMHACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
-from `rs1` and `rs2`. For each lane, it extracts the upper 16 bits of the 32-bit
-product and accumulates that value into the corresponding 16-bit element of
-`rd`. The packed accumulated result is written back to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d  = X[rd]
-
-for i = 0 .. (XLEN/16 - 1):
-    a   = s1[(16*i+15):(16*i)]
-    b   = s2[(16*i+15):(16*i)]
-    acc = d[(16*i+15):(16*i)]
-
-    d[(16*i+15):(16*i)] =
-        acc + to_bits(32, unsigned(a) * unsigned(b))[31:16]
-
-X[rd] = d
-----
-
-Notes::
-
-* This instruction does not set `vxsat`.
-* The per-lane add wraps modulo 2^16^.
-
-<<<
-==== PMHRACCU.H
-
-Mnemonic::
-
-pmhraccu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMHRACCU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
-elements and accumulates the rounded high half of each unsigned 16×16
-multiplication into `rd`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x3, attr: ['PMHRACCU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMHRACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
-from `rs1` and `rs2`. For each lane, it adds 2^15^ to the 32-bit product, extracts
-the upper 16 bits of the adjusted value, and accumulates that into the
-corresponding 16-bit element of `rd`. The packed accumulated result is written
-back to `rd`, implementing rounding when extracting the high half.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d  = X[rd]
-
-for i = 0 .. (XLEN/16 - 1):
-    a   = s1[(16*i+15):(16*i)]
-    b   = s2[(16*i+15):(16*i)]
-    acc = d[(16*i+15):(16*i)]
-
-    d[(16*i+15):(16*i)] =
-        acc + to_bits(32, unsigned(a) * unsigned(b) + 2^15)[31:16]
 
 X[rd] = d
 ----
@@ -23401,16 +23153,16 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== PMHRACC.W (RV64)
+==== MHACCSU (RV32)
 
 Mnemonic::
 
-pmhracc.w _rd_, _rs1_, _rs2_
+mhaccsu _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PMHRACC.W is encoded in the OP-32 major opcode as a packed multiply-high
-rounded accumulate instruction.
+MHACCSU is encoded in the OP-32 major opcode as a scalar
+signed×unsigned multiply-high accumulate instruction.
 
 [wavedrom, ,svg]
 ....
@@ -23420,16 +23172,62 @@ rounded accumulate instruction.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x1, attr: ['PMHRACC.W'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x9, attr: ['MHACCSU'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The PMHRACC.W instruction performs signed packed multiplication with rounding
-and accumulates the upper 32 bits of each product into `rd`.
+The MHACCSU instruction multiplies `rs1` as signed by `rs2` as unsigned,
+extracts the upper 32 bits of the product, and accumulates the result.
+
+Operation::
+
+[source,pseudocode]
+----
+a64 = sext_64(X[rs1])
+b64 = zext_64(X[rs2])
+hi  = (a64 * b64)[63:32]
+X[rd] = X[rd] + hi
+----
+
+
+<<<
+==== PMHACCSU.H
+
+Mnemonic::
+
+pmhaccsu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMHACCSU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
+elements and accumulates the high half of each mixed signed×unsigned 16×16
+multiplication into `rd`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x9, attr: ['PMHACCSU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMHACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
+and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
+each lane, it extracts the upper 16 bits of the 32-bit product and accumulates
+that value into the corresponding 16-bit element of `rd`. The packed accumulated
+result is written back to `rd`.
 
 Operation::
 
@@ -23439,14 +23237,21 @@ s1 = X[rs1]
 s2 = X[rs2]
 d  = X[rd]
 
-for i = 0 .. 1:
-    a = sext_64(s1[(32*i+31):(32*i)])
-    b = sext_64(s2[(32*i+31):(32*i)])
-    hi = (a * b + 2^31)[63:32]
-    d[(32*i+31):(32*i)] = d[(32*i+31):(32*i)] + hi
+for i = 0 .. (XLEN/16 - 1):
+    a   = s1[(16*i+15):(16*i)]
+    b   = s2[(16*i+15):(16*i)]
+    acc = d[(16*i+15):(16*i)]
+
+    d[(16*i+15):(16*i)] =
+        acc + to_bits(32, signed(a) * unsigned(b))[31:16]
 
 X[rd] = d
 ----
+
+Notes::
+
+* This instruction does not set `vxsat`.
+* The per-lane add wraps modulo 2^16^.
 
 
 <<<
@@ -23499,16 +23304,16 @@ X[rd] = d
 
 
 <<<
-==== PMHRACCSU.W (RV64)
+==== MHACCU (RV32)
 
 Mnemonic::
 
-pmhraccsu.w _rd_, _rs1_, _rs2_
+mhaccu _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PMHRACCSU.W is encoded in the OP-32 major opcode as a packed signed×unsigned
-multiply-high rounded accumulate instruction.
+MHACCU is encoded in the OP-32 major opcode as a scalar
+unsigned×unsigned multiply-high accumulate instruction.
 
 [wavedrom, ,svg]
 ....
@@ -23518,16 +23323,61 @@ multiply-high rounded accumulate instruction.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x9, attr: ['PMHRACCSU.W'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x3, attr: ['MHACCU'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The PMHRACCSU.W instruction performs signed×unsigned packed multiplication with
-rounding and accumulates the upper 32 bits into `rd`.
+The MHACCU instruction multiplies `rs1` and `rs2` as unsigned values and
+accumulates the upper 32 bits of the product into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a64 = zext_64(X[rs1])
+b64 = zext_64(X[rs2])
+hi  = (a64 * b64)[63:32]
+X[rd] = X[rd] + hi
+----
+
+
+<<<
+==== PMHACCU.H
+
+Mnemonic::
+
+pmhaccu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMHACCU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
+elements and accumulates the high half of each unsigned 16×16 multiplication
+into `rd`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x3, attr: ['PMHACCU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMHACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
+from `rs1` and `rs2`. For each lane, it extracts the upper 16 bits of the 32-bit
+product and accumulates that value into the corresponding 16-bit element of
+`rd`. The packed accumulated result is written back to `rd`.
 
 Operation::
 
@@ -23537,15 +23387,21 @@ s1 = X[rs1]
 s2 = X[rs2]
 d  = X[rd]
 
-for i = 0 .. 1:
-    a = sext_64(s1[(32*i+31):(32*i)])
-    b = zext_64(s2[(32*i+31):(32*i)])
-    hi = (a * b + 2^31)[63:32]
-    d[(32*i+31):(32*i)] = d[(32*i+31):(32*i)] + hi
+for i = 0 .. (XLEN/16 - 1):
+    a   = s1[(16*i+15):(16*i)]
+    b   = s2[(16*i+15):(16*i)]
+    acc = d[(16*i+15):(16*i)]
+
+    d[(16*i+15):(16*i)] =
+        acc + to_bits(32, unsigned(a) * unsigned(b))[31:16]
 
 X[rd] = d
 ----
 
+Notes::
+
+* This instruction does not set `vxsat`.
+* The per-lane add wraps modulo 2^16^.
 
 <<<
 ==== PMHACCU.W (RV64)
@@ -23597,100 +23453,6 @@ X[rd] = d
 
 
 <<<
-==== PMHRACCU.W (RV64)
-
-Mnemonic::
-
-pmhraccu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMHRACCU.W is encoded in the OP-32 major opcode as a packed unsigned×unsigned
-multiply-high rounded accumulate instruction.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x3, attr: ['PMHRACCU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMHRACCU.W instruction multiplies unsigned packed 32-bit elements with
-rounding and accumulates the upper 32 bits of each product into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d  = X[rd]
-
-for i = 0 .. 1:
-    a = zext_64(s1[(32*i+31):(32*i)])
-    b = zext_64(s2[(32*i+31):(32*i)])
-    hi = (a * b + 2^31)[63:32]
-    d[(32*i+31):(32*i)] = d[(32*i+31):(32*i)] + hi
-
-X[rd] = d
-----
-
-
-<<<
-==== MHACC (RV32)
-
-Mnemonic::
-
-mhacc _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MHACC is encoded in the OP-32 major opcode as a scalar
-multiply-high accumulate instruction.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x1, attr: ['MHACC'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MHACC instruction multiplies `rs1` and `rs2` as signed values, extracts
-the upper 32 bits of the product, and accumulates the result into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a64 = sext_64(X[rs1])
-b64 = sext_64(X[rs2])
-hi  = (a64 * b64)[63:32]
-X[rd] = X[rd] + hi
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
 ==== MHRACC (RV32)
 
 Mnemonic::
@@ -23737,16 +23499,17 @@ Notes::
 * Rounding is performed by adding 2^31^.
 
 <<<
-==== MHACCSU (RV32)
+==== PMHRACC.H
 
 Mnemonic::
 
-mhaccsu _rd_, _rs1_, _rs2_
+pmhracc.h _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MHACCSU is encoded in the OP-32 major opcode as a scalar
-signed×unsigned multiply-high accumulate instruction.
+PMHRACC.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
+elements and accumulates the rounded high half of each signed 16×16
+multiplication into `rd`.
 
 [wavedrom, ,svg]
 ....
@@ -23756,25 +23519,90 @@ signed×unsigned multiply-high accumulate instruction.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x9, attr: ['MHACCSU'] },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x1, attr: ['PMHRACC.H'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The MHACCSU instruction multiplies `rs1` as signed by `rs2` as unsigned,
-extracts the upper 32 bits of the product, and accumulates the result.
+PMHRACC.H performs lane-wise signed multiplication of packed 16-bit elements from
+`rs1` and `rs2`. For each lane, it adds 2^15^ to the 32-bit product, extracts the
+upper 16 bits of the adjusted value, and accumulates that into the corresponding
+16-bit element of `rd`. The packed accumulated result is written back to `rd`,
+implementing rounding when extracting the high half.
 
 Operation::
 
 [source,pseudocode]
 ----
-a64 = sext_64(X[rs1])
-b64 = zext_64(X[rs2])
-hi  = (a64 * b64)[63:32]
-X[rd] = X[rd] + hi
+s1 = X[rs1]
+s2 = X[rs2]
+d  = X[rd]
+
+for i = 0 .. (XLEN/16 - 1):
+    a   = s1[(16*i+15):(16*i)]
+    b   = s2[(16*i+15):(16*i)]
+    acc = d[(16*i+15):(16*i)]
+
+    d[(16*i+15):(16*i)] =
+        acc + to_bits(32, signed(a) * signed(b) + 2^15)[31:16]
+
+X[rd] = d
+----
+
+Notes::
+
+* This instruction does not set `vxsat`.
+* The per-lane add wraps modulo 2^16^.
+
+<<<
+==== PMHRACC.W (RV64)
+
+Mnemonic::
+
+pmhracc.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMHRACC.W is encoded in the OP-32 major opcode as a packed multiply-high
+rounded accumulate instruction.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x1, attr: ['PMHRACC.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMHRACC.W instruction performs signed packed multiplication with rounding
+and accumulates the upper 32 bits of each product into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d  = X[rd]
+
+for i = 0 .. 1:
+    a = sext_64(s1[(32*i+31):(32*i)])
+    b = sext_64(s2[(32*i+31):(32*i)])
+    hi = (a * b + 2^31)[63:32]
+    d[(32*i+31):(32*i)] = d[(32*i+31):(32*i)] + hi
+
+X[rd] = d
 ----
 
 
@@ -23821,16 +23649,17 @@ X[rd] = X[rd] + hi_rnd
 
 
 <<<
-==== MHACCU (RV32)
+==== PMHRACCSU.H
 
 Mnemonic::
 
-mhaccu _rd_, _rs1_, _rs2_
+pmhraccsu.h _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MHACCU is encoded in the OP-32 major opcode as a scalar
-unsigned×unsigned multiply-high accumulate instruction.
+PMHRACCSU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
+elements and accumulates the rounded high half of each mixed signed×unsigned
+16×16 multiplication into `rd`.
 
 [wavedrom, ,svg]
 ....
@@ -23840,25 +23669,92 @@ unsigned×unsigned multiply-high accumulate instruction.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x3, attr: ['MHACCU'] },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x9, attr: ['PMHRACCSU.H'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The MHACCU instruction multiplies `rs1` and `rs2` as unsigned values and
-accumulates the upper 32 bits of the product into `rd`.
+PMHRACCSU.H performs lane-wise multiplication of packed 16-bit elements from `rs1`
+and `rs2`, treating `rs1` elements as signed and `rs2` elements as unsigned. For
+each lane, it adds 2^15^ to the 32-bit product, extracts the upper 16 bits of the
+adjusted value, and accumulates that into the corresponding 16-bit element of
+`rd`. The packed accumulated result is written back to `rd`, implementing
+rounding when extracting the high half.
 
 Operation::
 
 [source,pseudocode]
 ----
-a64 = zext_64(X[rs1])
-b64 = zext_64(X[rs2])
-hi  = (a64 * b64)[63:32]
-X[rd] = X[rd] + hi
+s1 = X[rs1]
+s2 = X[rs2]
+d  = X[rd]
+
+for i = 0 .. (XLEN/16 - 1):
+    a   = s1[(16*i+15):(16*i)]
+    b   = s2[(16*i+15):(16*i)]
+    acc = d[(16*i+15):(16*i)]
+
+    d[(16*i+15):(16*i)] =
+        acc + to_bits(32, signed(a) * unsigned(b) + 2^15)[31:16]
+
+X[rd] = d
+----
+
+Notes::
+
+* This instruction does not set `vxsat`.
+* The per-lane add wraps modulo 2^16^.
+
+
+<<<
+==== PMHRACCSU.W (RV64)
+
+Mnemonic::
+
+pmhraccsu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMHRACCSU.W is encoded in the OP-32 major opcode as a packed signed×unsigned
+multiply-high rounded accumulate instruction.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x9, attr: ['PMHRACCSU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMHRACCSU.W instruction performs signed×unsigned packed multiplication with
+rounding and accumulates the upper 32 bits into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d  = X[rd]
+
+for i = 0 .. 1:
+    a = sext_64(s1[(32*i+31):(32*i)])
+    b = zext_64(s2[(32*i+31):(32*i)])
+    hi = (a * b + 2^31)[63:32]
+    d[(32*i+31):(32*i)] = d[(32*i+31):(32*i)] + hi
+
+X[rd] = d
 ----
 
 
@@ -23901,6 +23797,114 @@ a64 = zext_64(X[rs1])
 b64 = zext_64(X[rs2])
 hi_rnd = (a64 * b64 + 2^31)[63:32]
 X[rd] = X[rd] + hi_rnd
+----
+
+
+<<<
+==== PMHRACCU.H
+
+Mnemonic::
+
+pmhraccu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMHRACCU.H is encoded using the OP-32 major opcode. It operates on packed 16-bit
+elements and accumulates the rounded high half of each unsigned 16×16
+multiplication into `rd`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x3, attr: ['PMHRACCU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMHRACCU.H performs lane-wise unsigned multiplication of packed 16-bit elements
+from `rs1` and `rs2`. For each lane, it adds 2^15^ to the 32-bit product, extracts
+the upper 16 bits of the adjusted value, and accumulates that into the
+corresponding 16-bit element of `rd`. The packed accumulated result is written
+back to `rd`, implementing rounding when extracting the high half.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d  = X[rd]
+
+for i = 0 .. (XLEN/16 - 1):
+    a   = s1[(16*i+15):(16*i)]
+    b   = s2[(16*i+15):(16*i)]
+    acc = d[(16*i+15):(16*i)]
+
+    d[(16*i+15):(16*i)] =
+        acc + to_bits(32, unsigned(a) * unsigned(b) + 2^15)[31:16]
+
+X[rd] = d
+----
+
+Notes::
+
+* This instruction does not set `vxsat`.
+* The per-lane add wraps modulo 2^16^.
+
+<<<
+==== PMHRACCU.W (RV64)
+
+Mnemonic::
+
+pmhraccu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMHRACCU.W is encoded in the OP-32 major opcode as a packed unsigned×unsigned
+multiply-high rounded accumulate instruction.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x3, attr: ['PMHRACCU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMHRACCU.W instruction multiplies unsigned packed 32-bit elements with
+rounding and accumulates the upper 32 bits of each product into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d  = X[rd]
+
+for i = 0 .. 1:
+    a = zext_64(s1[(32*i+31):(32*i)])
+    b = zext_64(s2[(32*i+31):(32*i)])
+    hi = (a * b + 2^31)[63:32]
+    d[(32*i+31):(32*i)] = d[(32*i+31):(32*i)] + hi
+
+X[rd] = d
 ----
 
 
@@ -24047,16 +24051,16 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== MQRACC.H00 (RV32)
+==== MQACC.W00 (RV64)
 
 Mnemonic::
 
-mqracc.h00 _rd_, _rs1_, _rs2_
+mqacc.w00 _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MQRACC.H00 is encoded in the OP-32 major opcode as a scalar Q-format rounded
-accumulate instruction operating on the low halfwords of `rs1` and `rs2`.
+MQACC.W00 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
+instruction operating on the low words of `rs1` and `rs2`.
 
 [wavedrom, ,svg]
 ....
@@ -24066,43 +24070,43 @@ accumulate instruction operating on the low halfwords of `rs1` and `rs2`.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xd, attr: ['MQRACC.H00'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xd, attr: ['MQACC.W00'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The MQRACC.H00 instruction is like MQACC.H00 but applies rounding by adding
-2^14^ before extracting bits [46:15], and then accumulates into `rd`.
+The MQACC.W00 instruction multiplies `rs1[31:0]` and `rs2[31:0]` as signed
+32-bit values, extracts bits [94:31] of the 95-bit product, and accumulates the
+extracted value into `rd`.
 
 Operation::
 
 [source,pseudocode]
 ----
-a = sext_47(X[rs1][15:0])
-b = sext_47(X[rs2][15:0])
-q = (a * b + 2^14)[46:15]
+a = sext_95(X[rs1][31:0])
+b = sext_95(X[rs2][31:0])
+q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
 Notes::
 
 * This instruction reads and writes `rd`.
-* Rounding is performed by adding 2^14^.
 
 <<<
-==== MQRACC.H01 (RV32)
+==== MQACC.W01 (RV64)
 
 Mnemonic::
 
-mqracc.h01 _rd_, _rs1_, _rs2_
+mqacc.w01 _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MQRACC.H01 is encoded in the OP-32 major opcode as a scalar Q-format rounded
-accumulate instruction operating on `rs1[15:0]` and `rs2[31:16]`.
+MQACC.W01 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
+instruction operating on the low word of `rs1` and the high word of `rs2`.
 
 [wavedrom, ,svg]
 ....
@@ -24112,43 +24116,43 @@ accumulate instruction operating on `rs1[15:0]` and `rs2[31:16]`.
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xf, attr: ['MQRACC.H01'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['MQACC.W01'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The MQRACC.H01 instruction is like MQACC.H01 but applies rounding by adding
-2^14^ before extracting bits [46:15], and then accumulates into `rd`.
+The MQACC.W01 instruction multiplies `rs1[31:0]` by `rs2[63:32]` as signed
+32-bit values, extracts bits [94:31] of the product, and accumulates the result
+into `rd`.
 
 Operation::
 
 [source,pseudocode]
 ----
-a = sext_47(X[rs1][15:0])
-b = sext_47(X[rs2][31:16])
-q = (a * b + 2^14)[46:15]
+a = sext_95(X[rs1][31:0])
+b = sext_95(X[rs2][63:32])
+q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
 Notes::
 
 * This instruction reads and writes `rd`.
-* Rounding is performed by adding 2^14^.
 
 <<<
-==== MQRACC.H11 (RV32)
+==== MQACC.W11 (RV64)
 
 Mnemonic::
 
-mqracc.h11 _rd_, _rs1_, _rs2_
+mqacc.w11 _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MQRACC.H11 is encoded in the OP-32 major opcode as a scalar Q-format rounded
-accumulate instruction operating on the high halfwords of `rs1` and `rs2`.
+MQACC.W11 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
+instruction operating on the high words of `rs1` and `rs2`.
 
 [wavedrom, ,svg]
 ....
@@ -24158,31 +24162,31 @@ accumulate instruction operating on the high halfwords of `rs1` and `rs2`.
     { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xf, attr: ['MQRACC.H11'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['MQACC.W11'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The MQRACC.H11 instruction is like MQACC.H11 but applies rounding by adding
-2^14^ before extracting bits [46:15], and then accumulates into `rd`.
+The MQACC.W11 instruction multiplies `rs1[63:32]` and `rs2[63:32]` as signed
+32-bit values, extracts bits [94:31] of the product, and accumulates the result
+into `rd`.
 
 Operation::
 
 [source,pseudocode]
 ----
-a = sext_47(X[rs1][31:16])
-b = sext_47(X[rs2][31:16])
-q = (a * b + 2^14)[46:15]
+a = sext_95(X[rs1][63:32])
+b = sext_95(X[rs2][63:32])
+q = (a * b)[94:31]
 X[rd] = X[rd] + q
 ----
 
 Notes::
 
 * This instruction reads and writes `rd`.
-* Rounding is performed by adding 2^14^.
 
 <<<
 ==== PMQACC.W.H00 (RV64)
@@ -24336,6 +24340,283 @@ for i = 0 .. 1:
 X[rd] = d
 ----
 
+
+<<<
+==== MQRACC.H00 (RV32)
+
+Mnemonic::
+
+mqracc.h00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MQRACC.H00 is encoded in the OP-32 major opcode as a scalar Q-format rounded
+accumulate instruction operating on the low halfwords of `rs1` and `rs2`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xd, attr: ['MQRACC.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MQRACC.H00 instruction is like MQACC.H00 but applies rounding by adding
+2^14^ before extracting bits [46:15], and then accumulates into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_47(X[rs1][15:0])
+b = sext_47(X[rs2][15:0])
+q = (a * b + 2^14)[46:15]
+X[rd] = X[rd] + q
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+* Rounding is performed by adding 2^14^.
+
+<<<
+==== MQRACC.H01 (RV32)
+
+Mnemonic::
+
+mqracc.h01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MQRACC.H01 is encoded in the OP-32 major opcode as a scalar Q-format rounded
+accumulate instruction operating on `rs1[15:0]` and `rs2[31:16]`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xf, attr: ['MQRACC.H01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MQRACC.H01 instruction is like MQACC.H01 but applies rounding by adding
+2^14^ before extracting bits [46:15], and then accumulates into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_47(X[rs1][15:0])
+b = sext_47(X[rs2][31:16])
+q = (a * b + 2^14)[46:15]
+X[rd] = X[rd] + q
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+* Rounding is performed by adding 2^14^.
+
+<<<
+==== MQRACC.H11 (RV32)
+
+Mnemonic::
+
+mqracc.h11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MQRACC.H11 is encoded in the OP-32 major opcode as a scalar Q-format rounded
+accumulate instruction operating on the high halfwords of `rs1` and `rs2`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xf, attr: ['MQRACC.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MQRACC.H11 instruction is like MQACC.H11 but applies rounding by adding
+2^14^ before extracting bits [46:15], and then accumulates into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_47(X[rs1][31:16])
+b = sext_47(X[rs2][31:16])
+q = (a * b + 2^14)[46:15]
+X[rd] = X[rd] + q
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+* Rounding is performed by adding 2^14^.
+
+<<<
+==== MQRACC.W00 (RV64)
+
+Mnemonic::
+
+mqracc.w00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MQRACC.W00 is encoded in the OP-32 major opcode as a scalar Q-format rounded
+accumulate instruction operating on the low words of `rs1` and `rs2`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xd, attr: ['MQRACC.W00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MQRACC.W00 instruction is like MQACC.W00 but applies rounding by adding 2^30^
+before extracting bits [94:31], and then accumulates the extracted value into
+`rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_95(X[rs1][31:0])
+b = sext_95(X[rs2][31:0])
+q = (a * b + 2^30)[94:31]
+X[rd] = X[rd] + q
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+* Rounding is performed by adding 2^30^.
+
+<<<
+==== MQRACC.W01 (RV64)
+
+Mnemonic::
+
+mqracc.w01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MQRACC.W01 is encoded in the OP-32 major opcode as a scalar Q-format rounded
+accumulate instruction operating on `rs1[31:0]` and `rs2[63:32]`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xf, attr: ['MQRACC.W01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MQRACC.W01 instruction is like MQACC.W01 but applies rounding by adding 2^30^
+before extracting bits [94:31], and then accumulates into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_95(X[rs1][31:0])
+b = sext_95(X[rs2][63:32])
+q = (a * b + 2^30)[94:31]
+X[rd] = X[rd] + q
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+* Rounding is performed by adding 2^30^.
+
+<<<
+==== MQRACC.W11 (RV64)
+
+Mnemonic::
+
+mqracc.w11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MQRACC.W11 is encoded in the OP-32 major opcode as a scalar Q-format rounded
+accumulate instruction operating on the high words of `rs1` and `rs2`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xf, attr: ['MQRACC.W11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The MQRACC.W11 instruction is like MQACC.W11 but applies rounding by adding 2^30^
+before extracting bits [94:31], and then accumulates into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_95(X[rs1][63:32])
+b = sext_95(X[rs2][63:32])
+q = (a * b + 2^30)[94:31]
+X[rd] = X[rd] + q
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+* Rounding is performed by adding 2^30^.
 
 <<<
 ==== PMQRACC.W.H00 (RV64)
@@ -24497,6 +24778,8 @@ Notes::
 * Rounding is performed by adding 2^14^.
 
 <<<
+=== Q-format Horizontal Multiply-Add
+
 ==== PMQ2ADD.H
 
 Mnemonic::
@@ -24550,6 +24833,54 @@ X[rd] = d
 
 
 <<<
+==== PMQ2ADD.W (RV64)
+
+Mnemonic::
+
+pmq2add.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMQ2ADD.W is encoded in the OP-32 major opcode as a packed Q-format instruction
+that sums two word products to produce a scalar XLEN result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PMQ2ADD.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMQ2ADD.W instruction multiplies the low words and the high words of `rs1`
+and `rs2` as signed 32-bit values, extracts bits [94:31] from each product, and
+adds the two extracted values to produce the result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = sext_95(X[rs1][31:0])
+b0 = sext_95(X[rs2][31:0])
+a1 = sext_95(X[rs1][63:32])
+b1 = sext_95(X[rs2][63:32])
+
+q0 = (a0 * b0)[94:31]
+q1 = (a1 * b1)[94:31]
+
+X[rd] = q0 + q1
+----
+
+
+<<<
 ==== PMQ2ADDA.H
 
 Mnemonic::
@@ -24599,6 +24930,55 @@ for i = 0 .. (XLEN/32 - 1):
     d[(32*i+31):(32*i)] = d[(32*i+31):(32*i)] + q0 + q1
 
 X[rd] = d
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== PMQ2ADDA.W (RV64)
+
+Mnemonic::
+
+pmq2adda.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMQ2ADDA.W is encoded in the OP-32 major opcode as an accumulating form of
+PMQ2ADD.W.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['PMQ2ADDA.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMQ2ADDA.W instruction adds the PMQ2ADD.W result into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = sext_95(X[rs1][31:0])
+b0 = sext_95(X[rs2][31:0])
+a1 = sext_95(X[rs1][63:32])
+b1 = sext_95(X[rs2][63:32])
+
+q0 = (a0 * b0)[94:31]
+q1 = (a1 * b1)[94:31]
+
+X[rd] = X[rd] + q0 + q1
 ----
 
 Notes::
@@ -24662,6 +25042,56 @@ Notes::
 * Rounding is performed by adding 2^14^.
 
 <<<
+==== PMQR2ADD.W (RV64)
+
+Mnemonic::
+
+pmqr2add.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMQR2ADD.W is encoded in the OP-32 major opcode as a rounded form of PMQ2ADD.W.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['PMQR2ADD.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMQR2ADD.W instruction is like PMQ2ADD.W but applies rounding by adding 2^30^
+to each product before extracting bits [94:31], and then sums the two extracted
+values.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = sext_95(X[rs1][31:0])
+b0 = sext_95(X[rs2][31:0])
+a1 = sext_95(X[rs1][63:32])
+b1 = sext_95(X[rs2][63:32])
+
+q0 = (a0 * b0 + 2^30)[94:31]
+q1 = (a1 * b1 + 2^30)[94:31]
+
+X[rd] = q0 + q1
+----
+
+Notes::
+
+* Rounding is performed by adding 2^30^.
+
+<<<
 ==== PMQR2ADDA.H
 
 Mnemonic::
@@ -24719,430 +25149,6 @@ Notes::
 * Rounding is performed by adding 2^14^.
 
 <<<
-==== MQACC.W00 (RV64)
-
-Mnemonic::
-
-mqacc.w00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MQACC.W00 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
-instruction operating on the low words of `rs1` and `rs2`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xd, attr: ['MQACC.W00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MQACC.W00 instruction multiplies `rs1[31:0]` and `rs2[31:0]` as signed
-32-bit values, extracts bits [94:31] of the 95-bit product, and accumulates the
-extracted value into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_95(X[rs1][31:0])
-b = sext_95(X[rs2][31:0])
-q = (a * b)[94:31]
-X[rd] = X[rd] + q
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MQACC.W01 (RV64)
-
-Mnemonic::
-
-mqacc.w01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MQACC.W01 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
-instruction operating on the low word of `rs1` and the high word of `rs2`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xf, attr: ['MQACC.W01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MQACC.W01 instruction multiplies `rs1[31:0]` by `rs2[63:32]` as signed
-32-bit values, extracts bits [94:31] of the product, and accumulates the result
-into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_95(X[rs1][31:0])
-b = sext_95(X[rs2][63:32])
-q = (a * b)[94:31]
-X[rd] = X[rd] + q
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MQACC.W11 (RV64)
-
-Mnemonic::
-
-mqacc.w11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MQACC.W11 is encoded in the OP-32 major opcode as a scalar Q-format accumulate
-instruction operating on the high words of `rs1` and `rs2`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xf, attr: ['MQACC.W11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MQACC.W11 instruction multiplies `rs1[63:32]` and `rs2[63:32]` as signed
-32-bit values, extracts bits [94:31] of the product, and accumulates the result
-into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_95(X[rs1][63:32])
-b = sext_95(X[rs2][63:32])
-q = (a * b)[94:31]
-X[rd] = X[rd] + q
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MQRACC.W00 (RV64)
-
-Mnemonic::
-
-mqracc.w00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MQRACC.W00 is encoded in the OP-32 major opcode as a scalar Q-format rounded
-accumulate instruction operating on the low words of `rs1` and `rs2`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xd, attr: ['MQRACC.W00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MQRACC.W00 instruction is like MQACC.W00 but applies rounding by adding 2^30^
-before extracting bits [94:31], and then accumulates the extracted value into
-`rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_95(X[rs1][31:0])
-b = sext_95(X[rs2][31:0])
-q = (a * b + 2^30)[94:31]
-X[rd] = X[rd] + q
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-* Rounding is performed by adding 2^30^.
-
-<<<
-==== MQRACC.W01 (RV64)
-
-Mnemonic::
-
-mqracc.w01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MQRACC.W01 is encoded in the OP-32 major opcode as a scalar Q-format rounded
-accumulate instruction operating on `rs1[31:0]` and `rs2[63:32]`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xf, attr: ['MQRACC.W01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MQRACC.W01 instruction is like MQACC.W01 but applies rounding by adding 2^30^
-before extracting bits [94:31], and then accumulates into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_95(X[rs1][31:0])
-b = sext_95(X[rs2][63:32])
-q = (a * b + 2^30)[94:31]
-X[rd] = X[rd] + q
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-* Rounding is performed by adding 2^30^.
-
-<<<
-==== MQRACC.W11 (RV64)
-
-Mnemonic::
-
-mqracc.w11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MQRACC.W11 is encoded in the OP-32 major opcode as a scalar Q-format rounded
-accumulate instruction operating on the high words of `rs1` and `rs2`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xf, attr: ['MQRACC.W11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The MQRACC.W11 instruction is like MQACC.W11 but applies rounding by adding 2^30^
-before extracting bits [94:31], and then accumulates into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_95(X[rs1][63:32])
-b = sext_95(X[rs2][63:32])
-q = (a * b + 2^30)[94:31]
-X[rd] = X[rd] + q
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-* Rounding is performed by adding 2^30^.
-
-<<<
-==== PMQ2ADD.W (RV64)
-
-Mnemonic::
-
-pmq2add.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMQ2ADD.W is encoded in the OP-32 major opcode as a packed Q-format instruction
-that sums two word products to produce a scalar XLEN result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x6, attr: ['PMQ2ADD.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMQ2ADD.W instruction multiplies the low words and the high words of `rs1`
-and `rs2` as signed 32-bit values, extracts bits [94:31] from each product, and
-adds the two extracted values to produce the result in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_95(X[rs1][31:0])
-b0 = sext_95(X[rs2][31:0])
-a1 = sext_95(X[rs1][63:32])
-b1 = sext_95(X[rs2][63:32])
-
-q0 = (a0 * b0)[94:31]
-q1 = (a1 * b1)[94:31]
-
-X[rd] = q0 + q1
-----
-
-
-<<<
-==== PMQ2ADDA.W (RV64)
-
-Mnemonic::
-
-pmq2adda.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMQ2ADDA.W is encoded in the OP-32 major opcode as an accumulating form of
-PMQ2ADD.W.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x7, attr: ['PMQ2ADDA.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMQ2ADDA.W instruction adds the PMQ2ADD.W result into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_95(X[rs1][31:0])
-b0 = sext_95(X[rs2][31:0])
-a1 = sext_95(X[rs1][63:32])
-b1 = sext_95(X[rs2][63:32])
-
-q0 = (a0 * b0)[94:31]
-q1 = (a1 * b1)[94:31]
-
-X[rd] = X[rd] + q0 + q1
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== PMQR2ADD.W (RV64)
-
-Mnemonic::
-
-pmqr2add.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMQR2ADD.W is encoded in the OP-32 major opcode as a rounded form of PMQ2ADD.W.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x6, attr: ['PMQR2ADD.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMQR2ADD.W instruction is like PMQ2ADD.W but applies rounding by adding 2^30^
-to each product before extracting bits [94:31], and then sums the two extracted
-values.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_95(X[rs1][31:0])
-b0 = sext_95(X[rs2][31:0])
-a1 = sext_95(X[rs1][63:32])
-b1 = sext_95(X[rs2][63:32])
-
-q0 = (a0 * b0 + 2^30)[94:31]
-q1 = (a1 * b1 + 2^30)[94:31]
-
-X[rd] = q0 + q1
-----
-
-Notes::
-
-* Rounding is performed by adding 2^30^.
-
-<<<
 ==== PMQR2ADDA.W (RV64)
 
 Mnemonic::
@@ -25196,6 +25202,258 @@ Notes::
 <<<
 === Cross-element Multiply
 
+==== MUL.H00 (RV32)
+
+Mnemonic::
+
+mul.h00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MUL.H00 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['MUL.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MUL.H00 multiplies the low 16-bit halfword (h0) of `rs1` by the low 16-bit
+halfword (h0) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV32
+s1_h0 = X[rs1][15:0]
+s2_h0 = X[rs2][15:0]
+X[rd] = signed(s1_h0) * signed(s2_h0)
+----
+
+
+<<<
+==== MUL.H01 (RV32)
+
+Mnemonic::
+
+mul.h01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MUL.H01 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['MUL.H01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MUL.H01 multiplies the low 16-bit halfword (h0) of `rs1` by the high 16-bit
+halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV32
+s1_h0 = X[rs1][15:0]
+s2_h1 = X[rs2][31:16]
+X[rd] = signed(s1_h0) * signed(s2_h1)
+----
+
+
+<<<
+==== MUL.H11 (RV32)
+
+Mnemonic::
+
+mul.h11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MUL.H11 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['MUL.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MUL.H11 multiplies the high 16-bit halfword (h1) of `rs1` by the high 16-bit
+halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
+product that is written to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV32
+s1_h1 = X[rs1][31:16]
+s2_h1 = X[rs2][31:16]
+X[rd] = signed(s1_h1) * signed(s2_h1)
+----
+
+
+<<<
+==== MUL.W00 (RV64)
+
+Mnemonic::
+
+mul.w00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MUL.W00 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['MUL.W00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MUL.W00 multiplies the low 32-bit word (w0) of `rs1` by the low 32-bit word
+(w0) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1_w0 = X[rs1][31:0]
+s2_w0 = X[rs2][31:0]
+X[rd] = signed(s1_w0) * signed(s2_w0)
+----
+
+
+<<<
+==== MUL.W01 (RV64)
+
+Mnemonic::
+
+mul.w01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MUL.W01 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x2, attr: ['MUL.W01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MUL.W01 multiplies the low 32-bit word (w0) of `rs1` by the high 32-bit word
+(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1_w0 = X[rs1][31:0]
+s2_w1 = X[rs2][63:32]
+X[rd] = signed(s1_w0) * signed(s2_w1)
+----
+
+
+<<<
+==== MUL.W11 (RV64)
+
+Mnemonic::
+
+mul.w11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MUL.W11 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x2, attr: ['MUL.W11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MUL.W11 multiplies the high 32-bit word (w1) of `rs1` by the high 32-bit word
+(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
+that is written to `rd`. This instruction is available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1_w1 = X[rs1][63:32]
+s2_w1 = X[rs2][63:32]
+X[rd] = signed(s1_w1) * signed(s2_w1)
+----
+
+
+<<<
 ==== PMUL.H.B00
 
 Mnemonic::
@@ -25335,6 +25593,306 @@ X[rd] = d
 
 
 <<<
+==== PMUL.W.H00 (RV64)
+
+Mnemonic::
+
+pmul.w.h00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMUL.W.H00 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PMUL.W.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMUL.W.H00 multiplies the low halfword (h0) of each packed 32-bit word element
+in `rs1` by the low halfword (h0) of the corresponding word element in `rs2`,
+both treated as signed, producing a 32-bit product per element that is written
+to the corresponding word of `rd`. This instruction is available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = signed(s1[15:0])  * signed(s2[15:0])
+d_w1 = signed(s1[47:32]) * signed(s2[47:32])
+X[rd] = d_w1 @ d_w0
+----
+
+
+<<<
+==== PMUL.W.H01 (RV64)
+
+Mnemonic::
+
+pmul.w.h01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMUL.W.H01 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PMUL.W.H01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMUL.W.H01 multiplies the low halfword (h0) of each packed 32-bit word element
+in `rs1` by the high halfword (h1) of the corresponding word element in `rs2`,
+both treated as signed, producing a 32-bit product per element that is written
+to the corresponding word of `rd`. This instruction is available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = signed(s1[15:0])  * signed(s2[31:16])
+d_w1 = signed(s1[47:32]) * signed(s2[63:48])
+X[rd] = d_w1 @ d_w0
+----
+
+
+<<<
+==== PMUL.W.H11 (RV64)
+
+Mnemonic::
+
+pmul.w.h11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMUL.W.H11 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PMUL.W.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMUL.W.H11 multiplies the high halfword (h1) of each packed 32-bit word
+element in `rs1` by the high halfword (h1) of the corresponding word element in
+`rs2`, both treated as signed, producing a 32-bit product per element that is
+written to the corresponding word of `rd`. This instruction is available only
+on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = signed(s1[31:16]) * signed(s2[31:16])
+d_w1 = signed(s1[63:48]) * signed(s2[63:48])
+X[rd] = d_w1 @ d_w0
+----
+
+
+<<<
+==== MULSU.H00 (RV32)
+
+Mnemonic::
+
+mulsu.h00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULSU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
+(signed×unsigned) producing a 32-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xc, attr: ['MULSU.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and writes
+the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_32(X[rs1][15:0])
+b = zext_32(X[rs2][15:0])
+X[rd] = to_bits(32, a * b)
+----
+
+
+<<<
+==== MULSU.H11 (RV32)
+
+Mnemonic::
+
+mulsu.h11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULSU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
+(signed×unsigned) producing a 32-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['MULSU.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and writes
+the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_32(X[rs1][31:16])
+b = zext_32(X[rs2][31:16])
+X[rd] = to_bits(32, a * b)
+----
+
+
+<<<
+==== MULSU.W00 (RV64)
+
+Mnemonic::
+
+mulsu.w00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
+(signed×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xc, attr: ['MULSU.W00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and writes
+the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_64(X[rs1][31:0])
+b = zext_64(X[rs2][31:0])
+X[rd] = to_bits(64, a * b)
+----
+
+
+<<<
+==== MULSU.W11 (RV64)
+
+Mnemonic::
+
+mulsu.w11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
+(signed×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xe, attr: ['MULSU.W11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and writes
+the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_64(X[rs1][63:32])
+b = zext_64(X[rs2][63:32])
+X[rd] = to_bits(64, a * b)
+----
+
+
+<<<
 ==== PMULSU.H.B00
 
 Mnemonic::
@@ -25423,6 +25981,342 @@ for i = 0 .. (XLEN/16 - 1):
     d[(16*i+15):(16*i)] = to_bits(16, a * b)
 
 X[rd] = d
+----
+
+
+<<<
+==== PMULSU.W.H00 (RV64)
+
+Mnemonic::
+
+pmulsu.w.h00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULSU.W.H00 is encoded in the OP-32 major opcode producing packed 32-bit
+elements from halfword operands (signed×unsigned).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xc, attr: ['PMULSU.W.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
+and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d0 = to_bits(32, sext_32(s1[15:0])  * zext_32(s2[15:0]))
+d1 = to_bits(32, sext_32(s1[47:32]) * zext_32(s2[47:32]))
+
+X[rd] = d1 @ d0
+----
+
+
+<<<
+==== PMULSU.W.H11 (RV64)
+
+Mnemonic::
+
+pmulsu.w.h11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULSU.W.H11 is encoded in the OP-32 major opcode producing packed 32-bit
+elements from halfword operands (signed×unsigned).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xe, attr: ['PMULSU.W.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
+and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+d0 = to_bits(32, sext_32(s1[31:16]) * zext_32(s2[31:16]))
+d1 = to_bits(32, sext_32(s1[63:48]) * zext_32(s2[63:48]))
+
+X[rd] = d1 @ d0
+----
+
+
+<<<
+==== MULU.H00 (RV32)
+
+Mnemonic::
+
+mulu.h00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
+(unsigned×unsigned) producing a 32-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['MULU.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and writes
+the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_32(X[rs1][15:0])
+b = zext_32(X[rs2][15:0])
+X[rd] = to_bits(32, a * b)
+----
+
+
+<<<
+==== MULU.H01 (RV32)
+
+Mnemonic::
+
+mulu.h01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULU.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
+(unsigned×unsigned) producing a 32-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['MULU.H01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and writes
+the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_32(X[rs1][15:0])
+b = zext_32(X[rs2][31:16])
+X[rd] = to_bits(32, a * b)
+----
+
+
+<<<
+==== MULU.H11 (RV32)
+
+Mnemonic::
+
+mulu.h11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
+(unsigned×unsigned) producing a 32-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['MULU.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
+writes the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_32(X[rs1][31:16])
+b = zext_32(X[rs2][31:16])
+X[rd] = to_bits(32, a * b)
+----
+
+
+<<<
+==== MULU.W00 (RV64)
+
+Mnemonic::
+
+mulu.w00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
+(unsigned×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x4, attr: ['MULU.W00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
+writes the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_64(X[rs1][31:0])
+b = zext_64(X[rs2][31:0])
+X[rd] = to_bits(64, a * b)
+----
+
+
+<<<
+==== MULU.W01 (RV64)
+
+Mnemonic::
+
+mulu.w01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
+(unsigned×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['MULU.W01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
+writes the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_64(X[rs1][31:0])
+b = zext_64(X[rs2][63:32])
+X[rd] = to_bits(64, a * b)
+----
+
+
+<<<
+==== MULU.W11 (RV64)
+
+Mnemonic::
+
+mulu.w11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
+(unsigned×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['MULU.W11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
+writes the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_64(X[rs1][63:32])
+b = zext_64(X[rs2][63:32])
+X[rd] = to_bits(64, a * b)
 ----
 
 
@@ -25566,563 +26460,6 @@ X[rd] = d
 
 
 <<<
-==== MUL.H00 (RV32)
-
-Mnemonic::
-
-mul.h00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MUL.H00 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x0, attr: ['MUL.H00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MUL.H00 multiplies the low 16-bit halfword (h0) of `rs1` by the low 16-bit
-halfword (h0) of `rs2`, both treated as signed, producing a full 32-bit signed
-product that is written to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV32
-s1_h0 = X[rs1][15:0]
-s2_h0 = X[rs2][15:0]
-X[rd] = signed(s1_h0) * signed(s2_h0)
-----
-
-
-<<<
-==== MUL.H01 (RV32)
-
-Mnemonic::
-
-mul.h01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MUL.H01 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['MUL.H01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MUL.H01 multiplies the low 16-bit halfword (h0) of `rs1` by the high 16-bit
-halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
-product that is written to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV32
-s1_h0 = X[rs1][15:0]
-s2_h1 = X[rs2][31:16]
-X[rd] = signed(s1_h0) * signed(s2_h1)
-----
-
-
-<<<
-==== MUL.H11 (RV32)
-
-Mnemonic::
-
-mul.h11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MUL.H11 is encoded in the OP-32 major opcode as an XLEN-wide cross-halfword multiply.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['MUL.H11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MUL.H11 multiplies the high 16-bit halfword (h1) of `rs1` by the high 16-bit
-halfword (h1) of `rs2`, both treated as signed, producing a full 32-bit signed
-product that is written to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV32
-s1_h1 = X[rs1][31:16]
-s2_h1 = X[rs2][31:16]
-X[rd] = signed(s1_h1) * signed(s2_h1)
-----
-
-
-<<<
-==== MULSU.H00 (RV32)
-
-Mnemonic::
-
-mulsu.h00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULSU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
-(signed×unsigned) producing a 32-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xc, attr: ['MULSU.H00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and writes
-the 32-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_32(X[rs1][15:0])
-b = zext_32(X[rs2][15:0])
-X[rd] = to_bits(32, a * b)
-----
-
-
-<<<
-==== MULSU.H11 (RV32)
-
-Mnemonic::
-
-mulsu.h11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULSU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
-(signed×unsigned) producing a 32-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xe, attr: ['MULSU.H11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and writes
-the 32-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_32(X[rs1][31:16])
-b = zext_32(X[rs2][31:16])
-X[rd] = to_bits(32, a * b)
-----
-
-
-<<<
-==== MULU.H00 (RV32)
-
-Mnemonic::
-
-mulu.h00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
-(unsigned×unsigned) producing a 32-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x4, attr: ['MULU.H00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and writes
-the 32-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_32(X[rs1][15:0])
-b = zext_32(X[rs2][15:0])
-X[rd] = to_bits(32, a * b)
-----
-
-
-<<<
-==== MULU.H01 (RV32)
-
-Mnemonic::
-
-mulu.h01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULU.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
-(unsigned×unsigned) producing a 32-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x6, attr: ['MULU.H01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and writes
-the 32-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_32(X[rs1][15:0])
-b = zext_32(X[rs2][31:16])
-X[rd] = to_bits(32, a * b)
-----
-
-
-<<<
-==== MULU.H11 (RV32)
-
-Mnemonic::
-
-mulu.h11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
-(unsigned×unsigned) producing a 32-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x6, attr: ['MULU.H11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
-writes the 32-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_32(X[rs1][31:16])
-b = zext_32(X[rs2][31:16])
-X[rd] = to_bits(32, a * b)
-----
-
-
-<<<
-==== PMUL.W.H00 (RV64)
-
-Mnemonic::
-
-pmul.w.h00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMUL.W.H00 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x0, attr: ['PMUL.W.H00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMUL.W.H00 multiplies the low halfword (h0) of each packed 32-bit word element
-in `rs1` by the low halfword (h0) of the corresponding word element in `rs2`,
-both treated as signed, producing a 32-bit product per element that is written
-to the corresponding word of `rd`. This instruction is available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-d_w0 = signed(s1[15:0])  * signed(s2[15:0])
-d_w1 = signed(s1[47:32]) * signed(s2[47:32])
-X[rd] = d_w1 @ d_w0
-----
-
-
-<<<
-==== PMUL.W.H01 (RV64)
-
-Mnemonic::
-
-pmul.w.h01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMUL.W.H01 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['PMUL.W.H01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMUL.W.H01 multiplies the low halfword (h0) of each packed 32-bit word element
-in `rs1` by the high halfword (h1) of the corresponding word element in `rs2`,
-both treated as signed, producing a 32-bit product per element that is written
-to the corresponding word of `rd`. This instruction is available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-d_w0 = signed(s1[15:0])  * signed(s2[31:16])
-d_w1 = signed(s1[47:32]) * signed(s2[63:48])
-X[rd] = d_w1 @ d_w0
-----
-
-
-<<<
-==== PMUL.W.H11 (RV64)
-
-Mnemonic::
-
-pmul.w.h11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMUL.W.H11 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['PMUL.W.H11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMUL.W.H11 multiplies the high halfword (h1) of each packed 32-bit word
-element in `rs1` by the high halfword (h1) of the corresponding word element in
-`rs2`, both treated as signed, producing a 32-bit product per element that is
-written to the corresponding word of `rd`. This instruction is available only
-on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-d_w0 = signed(s1[31:16]) * signed(s2[31:16])
-d_w1 = signed(s1[63:48]) * signed(s2[63:48])
-X[rd] = d_w1 @ d_w0
-----
-
-
-<<<
-==== PMULSU.W.H00 (RV64)
-
-Mnemonic::
-
-pmulsu.w.h00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULSU.W.H00 is encoded in the OP-32 major opcode producing packed 32-bit
-elements from halfword operands (signed×unsigned).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xc, attr: ['PMULSU.W.H00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULSU.W.H00 multiplies, per 32-bit lane, the low halfwords of `rs1` (signed)
-and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-d0 = to_bits(32, sext_32(s1[15:0])  * zext_32(s2[15:0]))
-d1 = to_bits(32, sext_32(s1[47:32]) * zext_32(s2[47:32]))
-
-X[rd] = d1 @ d0
-----
-
-
-<<<
-==== PMULSU.W.H11 (RV64)
-
-Mnemonic::
-
-pmulsu.w.h11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULSU.W.H11 is encoded in the OP-32 major opcode producing packed 32-bit
-elements from halfword operands (signed×unsigned).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xe, attr: ['PMULSU.W.H11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULSU.W.H11 multiplies, per 32-bit lane, the high halfwords of `rs1` (signed)
-and `rs2` (unsigned) and writes packed 32-bit products to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-d0 = to_bits(32, sext_32(s1[31:16]) * zext_32(s2[31:16]))
-d1 = to_bits(32, sext_32(s1[63:48]) * zext_32(s2[63:48]))
-
-X[rd] = d1 @ d0
-----
-
-
-<<<
 ==== PMULU.W.H00 (RV64)
 
 Mnemonic::
@@ -26254,337 +26591,6 @@ d0 = to_bits(32, zext_32(s1[31:16]) * zext_32(s2[31:16]))
 d1 = to_bits(32, zext_32(s1[63:48]) * zext_32(s2[63:48]))
 
 X[rd] = d1 @ d0
-----
-
-
-<<<
-==== MUL.W00 (RV64)
-
-Mnemonic::
-
-mul.w00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MUL.W00 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x0, attr: ['MUL.W00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MUL.W00 multiplies the low 32-bit word (w0) of `rs1` by the low 32-bit word
-(w0) of `rs2`, both treated as signed, producing a full 64-bit signed product
-that is written to `rd`. This instruction is available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1_w0 = X[rs1][31:0]
-s2_w0 = X[rs2][31:0]
-X[rd] = signed(s1_w0) * signed(s2_w0)
-----
-
-
-<<<
-==== MUL.W01 (RV64)
-
-Mnemonic::
-
-mul.w01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MUL.W01 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x2, attr: ['MUL.W01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MUL.W01 multiplies the low 32-bit word (w0) of `rs1` by the high 32-bit word
-(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
-that is written to `rd`. This instruction is available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1_w0 = X[rs1][31:0]
-s2_w1 = X[rs2][63:32]
-X[rd] = signed(s1_w0) * signed(s2_w1)
-----
-
-
-<<<
-==== MUL.W11 (RV64)
-
-Mnemonic::
-
-mul.w11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MUL.W11 is encoded in the OP-32 major opcode as a cross-word multiply (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x2, attr: ['MUL.W11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MUL.W11 multiplies the high 32-bit word (w1) of `rs1` by the high 32-bit word
-(w1) of `rs2`, both treated as signed, producing a full 64-bit signed product
-that is written to `rd`. This instruction is available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1_w1 = X[rs1][63:32]
-s2_w1 = X[rs2][63:32]
-X[rd] = signed(s1_w1) * signed(s2_w1)
-----
-
-
-<<<
-==== MULSU.W00 (RV64)
-
-Mnemonic::
-
-mulsu.w00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
-(signed×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xc, attr: ['MULSU.W00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and writes
-the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_64(X[rs1][31:0])
-b = zext_64(X[rs2][31:0])
-X[rd] = to_bits(64, a * b)
-----
-
-
-<<<
-==== MULSU.W11 (RV64)
-
-Mnemonic::
-
-mulsu.w11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
-(signed×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xe, attr: ['MULSU.W11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and writes
-the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_64(X[rs1][63:32])
-b = zext_64(X[rs2][63:32])
-X[rd] = to_bits(64, a * b)
-----
-
-
-<<<
-==== MULU.W00 (RV64)
-
-Mnemonic::
-
-mulu.w00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
-(unsigned×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x4, attr: ['MULU.W00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
-writes the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_64(X[rs1][31:0])
-b = zext_64(X[rs2][31:0])
-X[rd] = to_bits(64, a * b)
-----
-
-
-<<<
-==== MULU.W01 (RV64)
-
-Mnemonic::
-
-mulu.w01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
-(unsigned×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x6, attr: ['MULU.W01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
-writes the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_64(X[rs1][31:0])
-b = zext_64(X[rs2][63:32])
-X[rd] = to_bits(64, a * b)
-----
-
-
-<<<
-==== MULU.W11 (RV64)
-
-Mnemonic::
-
-mulu.w11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
-(unsigned×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x6, attr: ['MULU.W11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
-writes the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_64(X[rs1][63:32])
-b = zext_64(X[rs2][63:32])
-X[rd] = to_bits(64, a * b)
 ----
 
 
@@ -26724,16 +26730,16 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== MACCSU.H00 (RV32)
+==== MACC.W00 (RV64)
 
 Mnemonic::
 
-maccsu.h00 _rd_, _rs1_, _rs2_
+macc.w00 _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MACCSU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
-accumulate (signed×unsigned).
+MACC.W00 is encoded in the OP-32 major opcode as a scalar word multiply
+accumulate (signed×signed) producing a 64-bit result.
 
 [wavedrom, ,svg]
 ....
@@ -26743,24 +26749,24 @@ accumulate (signed×unsigned).
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xd, attr: ['MACCSU.H00'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x1, attr: ['MACC.W00'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-MACCSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and adds
-the 32-bit product to `rd`.
+MACC.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as signed 32-bit values and adds
+the 64-bit product to `rd`.
 
 Operation::
 
 [source,pseudocode]
 ----
-a = sext_32(X[rs1][15:0])
-b = zext_32(X[rs2][15:0])
-X[rd] = X[rd] + to_bits(32, a * b)
+a = sext_64(X[rs1][31:0])
+b = sext_64(X[rs2][31:0])
+X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
 Notes::
@@ -26768,104 +26774,16 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== MACCSU.H11 (RV32)
+==== MACC.W01 (RV64)
 
 Mnemonic::
 
-maccsu.h11 _rd_, _rs1_, _rs2_
+macc.w01 _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MACCSU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
-accumulate (signed×unsigned).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xf, attr: ['MACCSU.H11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACCSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and adds
-the 32-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_32(X[rs1][31:16])
-b = zext_32(X[rs2][31:16])
-X[rd] = X[rd] + to_bits(32, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACCU.H00 (RV32)
-
-Mnemonic::
-
-maccu.h00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACCU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
-accumulate (unsigned×unsigned).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x5, attr: ['MACCU.H00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACCU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and adds
-the 32-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_32(X[rs1][15:0])
-b = zext_32(X[rs2][15:0])
-X[rd] = X[rd] + to_bits(32, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACCU.H01 (RV32)
-
-Mnemonic::
-
-maccu.h01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACCU.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
-accumulate (unsigned×unsigned).
+MACC.W01 is encoded in the OP-32 major opcode as a scalar word multiply
+accumulate (signed×signed) producing a 64-bit result.
 
 [wavedrom, ,svg]
 ....
@@ -26875,24 +26793,24 @@ accumulate (unsigned×unsigned).
     { bits: 3, name: 0x1 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x7, attr: ['MACCU.H01'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x3, attr: ['MACC.W01'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-MACCU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and adds
-the 32-bit product to `rd`.
+MACC.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as signed 32-bit values and adds
+the 64-bit product to `rd`.
 
 Operation::
 
 [source,pseudocode]
 ----
-a = zext_32(X[rs1][15:0])
-b = zext_32(X[rs2][31:16])
-X[rd] = X[rd] + to_bits(32, a * b)
+a = sext_64(X[rs1][31:0])
+b = sext_64(X[rs2][63:32])
+X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
 Notes::
@@ -26900,16 +26818,16 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== MACCU.H11 (RV32)
+==== MACC.W11 (RV64)
 
 Mnemonic::
 
-maccu.h11 _rd_, _rs1_, _rs2_
+macc.w11 _rd_, _rs1_, _rs2_
 
 Encoding::
 
-MACCU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
-accumulate (unsigned×unsigned).
+MACC.W11 is encoded in the OP-32 major opcode as a scalar word multiply
+accumulate (signed×signed) producing a 64-bit result.
 
 [wavedrom, ,svg]
 ....
@@ -26919,24 +26837,24 @@ accumulate (unsigned×unsigned).
     { bits: 3, name: 0x3 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x7, attr: ['MACCU.H11'] },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x3, attr: ['MACC.W11'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-MACCU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
-adds the 32-bit product to `rd`.
+MACC.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as signed 32-bit values and
+adds the 64-bit product to `rd`.
 
 Operation::
 
 [source,pseudocode]
 ----
-a = zext_32(X[rs1][31:16])
-b = zext_32(X[rs2][31:16])
-X[rd] = X[rd] + to_bits(32, a * b)
+a = sext_64(X[rs1][63:32])
+b = sext_64(X[rs2][63:32])
+X[rd] = X[rd] + to_bits(64, a * b)
 ----
 
 Notes::
@@ -27091,6 +27009,182 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
+==== MACCSU.H00 (RV32)
+
+Mnemonic::
+
+maccsu.h00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCSU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
+accumulate (signed×unsigned).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xd, attr: ['MACCSU.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCSU.H00 multiplies `rs1[15:0]` (signed) by `rs2[15:0]` (unsigned) and adds
+the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_32(X[rs1][15:0])
+b = zext_32(X[rs2][15:0])
+X[rd] = X[rd] + to_bits(32, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MACCSU.H11 (RV32)
+
+Mnemonic::
+
+maccsu.h11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCSU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
+accumulate (signed×unsigned).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xf, attr: ['MACCSU.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCSU.H11 multiplies `rs1[31:16]` (signed) by `rs2[31:16]` (unsigned) and adds
+the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_32(X[rs1][31:16])
+b = zext_32(X[rs2][31:16])
+X[rd] = X[rd] + to_bits(32, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MACCSU.W00 (RV64)
+
+Mnemonic::
+
+maccsu.w00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
+accumulate (signed×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xd, attr: ['MACCSU.W00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and adds the
+64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_64(X[rs1][31:0])
+b = zext_64(X[rs2][31:0])
+X[rd] = X[rd] + to_bits(64, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MACCSU.W11 (RV64)
+
+Mnemonic::
+
+maccsu.w11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
+accumulate (signed×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xf, attr: ['MACCSU.W11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and adds
+the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = sext_64(X[rs1][63:32])
+b = zext_64(X[rs2][63:32])
+X[rd] = X[rd] + to_bits(64, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
 ==== PMACCSU.W.H00 (RV64)
 
 Mnemonic::
@@ -27187,6 +27281,271 @@ X[rd] = d1 @ d0
 Notes::
 
 * This instruction reads and writes `rd`.
+
+<<<
+==== MACCU.H00 (RV32)
+
+Mnemonic::
+
+maccu.h00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCU.H00 is encoded in the OP-32 major opcode as a scalar halfword multiply
+accumulate (unsigned×unsigned).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x5, attr: ['MACCU.H00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCU.H00 multiplies `rs1[15:0]` and `rs2[15:0]` as unsigned halfwords and adds
+the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_32(X[rs1][15:0])
+b = zext_32(X[rs2][15:0])
+X[rd] = X[rd] + to_bits(32, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MACCU.H01 (RV32)
+
+Mnemonic::
+
+maccu.h01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCU.H01 is encoded in the OP-32 major opcode as a scalar halfword multiply
+accumulate (unsigned×unsigned).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['MACCU.H01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCU.H01 multiplies `rs1[15:0]` by `rs2[31:16]` as unsigned halfwords and adds
+the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_32(X[rs1][15:0])
+b = zext_32(X[rs2][31:16])
+X[rd] = X[rd] + to_bits(32, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MACCU.H11 (RV32)
+
+Mnemonic::
+
+maccu.h11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCU.H11 is encoded in the OP-32 major opcode as a scalar halfword multiply
+accumulate (unsigned×unsigned).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['MACCU.H11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCU.H11 multiplies `rs1[31:16]` and `rs2[31:16]` as unsigned halfwords and
+adds the 32-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_32(X[rs1][31:16])
+b = zext_32(X[rs2][31:16])
+X[rd] = X[rd] + to_bits(32, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MACCU.W00 (RV64)
+
+Mnemonic::
+
+maccu.w00 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
+accumulate (unsigned×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x5, attr: ['MACCU.W00'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
+adds the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_64(X[rs1][31:0])
+b = zext_64(X[rs2][31:0])
+X[rd] = X[rd] + to_bits(64, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MACCU.W01 (RV64)
+
+Mnemonic::
+
+maccu.w01 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
+accumulate (unsigned×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x1 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x7, attr: ['MACCU.W01'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
+adds the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_64(X[rs1][31:0])
+b = zext_64(X[rs2][63:32])
+X[rd] = X[rd] + to_bits(64, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MACCU.W11 (RV64)
+
+Mnemonic::
+
+maccu.w11 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MACCU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
+accumulate (unsigned×unsigned) producing a 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x3 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x7, attr: ['MACCU.W11'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MACCU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
+adds the 64-bit product to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a = zext_64(X[rs1][63:32])
+b = zext_64(X[rs2][63:32])
+X[rd] = X[rd] + to_bits(64, a * b)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
 
 <<<
 ==== PMACCU.W.H00 (RV64)
@@ -27337,359 +27696,6 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== MACC.W00 (RV64)
-
-Mnemonic::
-
-macc.w00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACC.W00 is encoded in the OP-32 major opcode as a scalar word multiply
-accumulate (signed×signed) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x1, attr: ['MACC.W00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACC.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as signed 32-bit values and adds
-the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_64(X[rs1][31:0])
-b = sext_64(X[rs2][31:0])
-X[rd] = X[rd] + to_bits(64, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACC.W01 (RV64)
-
-Mnemonic::
-
-macc.w01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACC.W01 is encoded in the OP-32 major opcode as a scalar word multiply
-accumulate (signed×signed) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x3, attr: ['MACC.W01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACC.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as signed 32-bit values and adds
-the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_64(X[rs1][31:0])
-b = sext_64(X[rs2][63:32])
-X[rd] = X[rd] + to_bits(64, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACC.W11 (RV64)
-
-Mnemonic::
-
-macc.w11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACC.W11 is encoded in the OP-32 major opcode as a scalar word multiply
-accumulate (signed×signed) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x3, attr: ['MACC.W11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACC.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as signed 32-bit values and
-adds the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_64(X[rs1][63:32])
-b = sext_64(X[rs2][63:32])
-X[rd] = X[rd] + to_bits(64, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACCSU.W00 (RV64)
-
-Mnemonic::
-
-maccsu.w00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACCSU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
-accumulate (signed×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xd, attr: ['MACCSU.W00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACCSU.W00 multiplies `rs1[31:0]` (signed) by `rs2[31:0]` (unsigned) and adds the
-64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_64(X[rs1][31:0])
-b = zext_64(X[rs2][31:0])
-X[rd] = X[rd] + to_bits(64, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACCSU.W11 (RV64)
-
-Mnemonic::
-
-maccsu.w11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACCSU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
-accumulate (signed×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xf, attr: ['MACCSU.W11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACCSU.W11 multiplies `rs1[63:32]` (signed) by `rs2[63:32]` (unsigned) and adds
-the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = sext_64(X[rs1][63:32])
-b = zext_64(X[rs2][63:32])
-X[rd] = X[rd] + to_bits(64, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACCU.W00 (RV64)
-
-Mnemonic::
-
-maccu.w00 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACCU.W00 is encoded in the OP-32 major opcode as a scalar word multiply
-accumulate (unsigned×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x5, attr: ['MACCU.W00'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACCU.W00 multiplies `rs1[31:0]` and `rs2[31:0]` as unsigned 32-bit values and
-adds the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_64(X[rs1][31:0])
-b = zext_64(X[rs2][31:0])
-X[rd] = X[rd] + to_bits(64, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACCU.W01 (RV64)
-
-Mnemonic::
-
-maccu.w01 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACCU.W01 is encoded in the OP-32 major opcode as a scalar word multiply
-accumulate (unsigned×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x1 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x7, attr: ['MACCU.W01'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACCU.W01 multiplies `rs1[31:0]` by `rs2[63:32]` as unsigned 32-bit values and
-adds the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_64(X[rs1][31:0])
-b = zext_64(X[rs2][63:32])
-X[rd] = X[rd] + to_bits(64, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MACCU.W11 (RV64)
-
-Mnemonic::
-
-maccu.w11 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MACCU.W11 is encoded in the OP-32 major opcode as a scalar word multiply
-accumulate (unsigned×unsigned) producing a 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x3 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x7, attr: ['MACCU.W11'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MACCU.W11 multiplies `rs1[63:32]` and `rs2[63:32]` as unsigned 32-bit values and
-adds the 64-bit product to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a = zext_64(X[rs1][63:32])
-b = zext_64(X[rs2][63:32])
-X[rd] = X[rd] + to_bits(64, a * b)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-
-<<<
 === PM2 Horizontal Multiply-Add/Subtract
 
 ==== PM2ADD.H
@@ -27740,6 +27746,338 @@ for i = 0 .. (XLEN/32 - 1):
         to_bits(32, a0 * b0) + to_bits(32, a1 * b1)
 
 X[rd] = d
+----
+
+
+<<<
+==== PM2ADD.W (RV64)
+
+Mnemonic::
+
+pm2add.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2ADD.W is encoded in the OP-32 major opcode as a packed word-pair multiply-add
+instruction producing a scalar 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x0, attr: ['PM2ADD.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2ADD.W multiplies the low words and high words of `rs1` and `rs2` as signed
+32-bit values and adds the two 64-bit products to produce the result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = sext_64(X[rs1][31:0])
+b0 = sext_64(X[rs2][31:0])
+a1 = sext_64(X[rs1][63:32])
+b1 = sext_64(X[rs2][63:32])
+
+X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
+----
+
+
+<<<
+==== PM2ADDSU.H
+
+Mnemonic::
+
+pm2addsu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2ADDSU.H is encoded in the OP-32 major opcode using packed halfword operands,
+performing signed×unsigned multiplies per halfword pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xc, attr: ['PM2ADDSU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PM2ADDSU.H instruction performs signed×unsigned halfword multiplications
+(low×low and high×high within each 32-bit lane) and sums the two 32-bit products
+to produce each packed 32-bit result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    a0 = sext_32(s1[(32*i+15):(32*i)])
+    a1 = sext_32(s1[(32*i+31):(32*i+16)])
+    b0 = zext_32(s2[(32*i+15):(32*i)])
+    b1 = zext_32(s2[(32*i+31):(32*i+16)])
+
+    d[(32*i+31):(32*i)] =
+        to_bits(32, a0 * b0) + to_bits(32, a1 * b1)
+
+X[rd] = d
+----
+
+
+<<<
+==== PM2ADDSU.W (RV64)
+
+Mnemonic::
+
+pm2addsu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2ADDSU.W is encoded in the OP-32 major opcode as a packed word-pair
+signed×unsigned multiply-add instruction.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xc, attr: ['PM2ADDSU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2ADDSU.W multiplies corresponding word pairs as signed×unsigned (low×low and
+high×high) and adds the two 64-bit products to produce the result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = sext_64(X[rs1][31:0])
+b0 = zext_64(X[rs2][31:0])
+a1 = sext_64(X[rs1][63:32])
+b1 = zext_64(X[rs2][63:32])
+
+X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
+----
+
+
+<<<
+==== PM2ADDU.H
+
+Mnemonic::
+
+pm2addu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2ADDU.H is encoded in the OP-32 major opcode using packed halfword operands and
+performing unsigned×unsigned multiplies per halfword pair.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x4, attr: ['PM2ADDU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PM2ADDU.H instruction performs unsigned×unsigned halfword multiplications
+(low×low and high×high within each 32-bit lane) and sums the two 32-bit products
+to produce each packed 32-bit result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    a0 = zext_32(s1[(32*i+15):(32*i)])
+    a1 = zext_32(s1[(32*i+31):(32*i+16)])
+    b0 = zext_32(s2[(32*i+15):(32*i)])
+    b1 = zext_32(s2[(32*i+31):(32*i+16)])
+
+    d[(32*i+31):(32*i)] =
+        to_bits(32, a0 * b0) + to_bits(32, a1 * b1)
+
+X[rd] = d
+----
+
+
+<<<
+==== PM2ADDU.W (RV64)
+
+Mnemonic::
+
+pm2addu.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2ADDU.W is encoded in the OP-32 major opcode as a packed word-pair
+unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['PM2ADDU.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2ADDU.W multiplies corresponding word pairs as unsigned×unsigned and adds the
+two 64-bit products to produce the result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = zext_64(X[rs1][31:0])
+b0 = zext_64(X[rs2][31:0])
+a1 = zext_64(X[rs1][63:32])
+b1 = zext_64(X[rs2][63:32])
+
+X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
+----
+
+
+<<<
+==== PM2ADD.HX
+
+Mnemonic::
+
+pm2add.hx _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2ADD.HX is encoded in the OP-32 major opcode using packed halfword operands and
+producing packed 32-bit results from cross products (low×high and high×low).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x2, attr: ['PM2ADD.HX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PM2ADD.HX instruction multiplies cross halfword pairs within each 32-bit
+lane (low of `rs1` × high of `rs2`, and high of `rs1` × low of `rs2`) and sums the
+two 32-bit products to produce each packed 32-bit result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    a0 = sext_32(s1[(32*i+15):(32*i)])
+    a1 = sext_32(s1[(32*i+31):(32*i+16)])
+    b0 = sext_32(s2[(32*i+15):(32*i)])
+    b1 = sext_32(s2[(32*i+31):(32*i+16)])
+
+    d[(32*i+31):(32*i)] =
+        to_bits(32, a0 * b1) + to_bits(32, a1 * b0)
+
+X[rd] = d
+----
+
+
+<<<
+==== PM2ADD.WX (RV64)
+
+Mnemonic::
+
+pm2add.wx _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2ADD.WX is encoded in the OP-32 major opcode as a packed word-pair multiply-add
+instruction using cross products.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x2, attr: ['PM2ADD.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2ADD.WX multiplies cross word pairs (low of `rs1` × high of `rs2`, and high of
+`rs1` × low of `rs2`) as signed values and sums the two 64-bit products.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = sext_64(X[rs1][31:0])
+a1 = sext_64(X[rs1][63:32])
+b0 = sext_64(X[rs2][31:0])
+b1 = sext_64(X[rs2][63:32])
+
+X[rd] = to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
 ----
 
 
@@ -27799,16 +28137,15 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== PM2ADDSU.H
+==== PM2ADDA.W (RV64)
 
 Mnemonic::
 
-pm2addsu.h _rd_, _rs1_, _rs2_
+pm2adda.w _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PM2ADDSU.H is encoded in the OP-32 major opcode using packed halfword operands,
-performing signed×unsigned multiplies per halfword pair.
+PM2ADDA.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 
 [wavedrom, ,svg]
 ....
@@ -27818,35 +28155,30 @@ performing signed×unsigned multiplies per halfword pair.
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xc, attr: ['PM2ADDSU.H'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x1, attr: ['PM2ADDA.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The PM2ADDSU.H instruction performs signed×unsigned halfword multiplications
-(low×low and high×high within each 32-bit lane) and sums the two 32-bit products
-to produce each packed 32-bit result in `rd`.
+PM2ADDA.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
+`rs1` and `rs2`, sums the two 64-bit products, and accumulates the result into
+`rd`. This instruction is the accumulating variant of PM2ADD.W.
 
 Operation::
 
 [source,pseudocode]
 ----
+// RV64 only
 s1 = X[rs1]
 s2 = X[rs2]
 
-for i = 0 .. (XLEN/32 - 1):
-    a0 = sext_32(s1[(32*i+15):(32*i)])
-    a1 = sext_32(s1[(32*i+31):(32*i+16)])
-    b0 = zext_32(s2[(32*i+15):(32*i)])
-    b1 = zext_32(s2[(32*i+31):(32*i+16)])
-
-    d[(32*i+31):(32*i)] =
-        to_bits(32, a0 * b0) + to_bits(32, a1 * b1)
-
-X[rd] = d
+// Multiply two signed 32-bit word pairs and accumulate sum into rd
+X[rd] = X[rd]
+      + sext64(signed(s1[31:0])  * signed(s2[31:0]))
+      + sext64(signed(s1[63:32]) * signed(s2[63:32]))
 ----
 
 
@@ -27906,16 +28238,16 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== PM2ADDU.H
+==== PM2ADDASU.W (RV64)
 
 Mnemonic::
 
-pm2addu.h _rd_, _rs1_, _rs2_
+pm2addasu.w _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PM2ADDU.H is encoded in the OP-32 major opcode using packed halfword operands and
-performing unsigned×unsigned multiplies per halfword pair.
+PM2ADDASU.W is encoded in the OP-32 major opcode as an accumulating form of
+PM2ADDSU.W.
 
 [wavedrom, ,svg]
 ....
@@ -27925,37 +28257,31 @@ performing unsigned×unsigned multiplies per halfword pair.
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x4, attr: ['PM2ADDU.H'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xd, attr: ['PM2ADDASU.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The PM2ADDU.H instruction performs unsigned×unsigned halfword multiplications
-(low×low and high×high within each 32-bit lane) and sums the two 32-bit products
-to produce each packed 32-bit result in `rd`.
+PM2ADDASU.W adds the PM2ADDSU.W result into `rd`.
 
 Operation::
 
 [source,pseudocode]
 ----
-s1 = X[rs1]
-s2 = X[rs2]
+a0 = sext_64(X[rs1][31:0])
+b0 = zext_64(X[rs2][31:0])
+a1 = sext_64(X[rs1][63:32])
+b1 = zext_64(X[rs2][63:32])
 
-for i = 0 .. (XLEN/32 - 1):
-    a0 = zext_32(s1[(32*i+15):(32*i)])
-    a1 = zext_32(s1[(32*i+31):(32*i+16)])
-    b0 = zext_32(s2[(32*i+15):(32*i)])
-    b1 = zext_32(s2[(32*i+31):(32*i+16)])
-
-    d[(32*i+31):(32*i)] =
-        to_bits(32, a0 * b0) + to_bits(32, a1 * b1)
-
-X[rd] = d
+X[rd] = X[rd] + to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
 ----
 
+Notes::
+
+* This instruction reads and writes `rd`.
 
 <<<
 ==== PM2ADDAU.H
@@ -28013,16 +28339,15 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== PM2ADD.HX
+==== PM2ADDAU.W (RV64)
 
 Mnemonic::
 
-pm2add.hx _rd_, _rs1_, _rs2_
+pm2addau.w _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PM2ADD.HX is encoded in the OP-32 major opcode using packed halfword operands and
-producing packed 32-bit results from cross products (low×high and high×low).
+PM2ADDAU.W is encoded in the OP-32 major opcode with word elements (RV64 only).
 
 [wavedrom, ,svg]
 ....
@@ -28032,35 +28357,30 @@ producing packed 32-bit results from cross products (low×high and high×low).
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x2, attr: ['PM2ADD.HX'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x5, attr: ['PM2ADDAU.W'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-The PM2ADD.HX instruction multiplies cross halfword pairs within each 32-bit
-lane (low of `rs1` × high of `rs2`, and high of `rs1` × low of `rs2`) and sums the
-two 32-bit products to produce each packed 32-bit result in `rd`.
+PM2ADDAU.W (RV64 only) multiplies two pairs of unsigned 32-bit word elements
+from `rs1` and `rs2`, sums the two 64-bit products, and accumulates the result
+into `rd`. This instruction is the unsigned accumulating variant of PM2ADDU.W.
 
 Operation::
 
 [source,pseudocode]
 ----
+// RV64 only
 s1 = X[rs1]
 s2 = X[rs2]
 
-for i = 0 .. (XLEN/32 - 1):
-    a0 = sext_32(s1[(32*i+15):(32*i)])
-    a1 = sext_32(s1[(32*i+31):(32*i+16)])
-    b0 = sext_32(s2[(32*i+15):(32*i)])
-    b1 = sext_32(s2[(32*i+31):(32*i+16)])
-
-    d[(32*i+31):(32*i)] =
-        to_bits(32, a0 * b1) + to_bits(32, a1 * b0)
-
-X[rd] = d
+// Multiply two unsigned 32-bit word pairs and accumulate sum into rd
+X[rd] = X[rd]
+      + zext64(unsigned(s1[31:0])  * unsigned(s2[31:0]))
+      + zext64(unsigned(s1[63:32]) * unsigned(s2[63:32]))
 ----
 
 
@@ -28120,6 +28440,255 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
+==== PM2ADDA.WX (RV64)
+
+Mnemonic::
+
+pm2adda.wx _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2ADDA.WX is encoded in the OP-32 major opcode as an accumulating form of
+PM2ADD.WX.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x3, attr: ['PM2ADDA.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2ADDA.WX adds the PM2ADD.WX result into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = sext_64(X[rs1][31:0])
+a1 = sext_64(X[rs1][63:32])
+b0 = sext_64(X[rs2][31:0])
+b1 = sext_64(X[rs2][63:32])
+
+X[rd] = X[rd] + to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== PM2SUB.H
+
+Mnemonic::
+
+pm2sub.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2SUB.H is encoded in the OP-32 major opcode with packed halfword elements.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0x8, attr: ['PM2SUB.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2SUB.H multiplies two pairs of signed 16-bit halfword elements from `rs1` and
+`rs2` within each 32-bit group, then subtracts the upper product from the lower
+product. The 32-bit difference for each group is written to the corresponding
+32-bit position in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    // Extract halfword pairs from each 32-bit group
+    s1_h0 = s1[(i*32+15):(i*32)]
+    s1_h1 = s1[(i*32+31):(i*32+16)]
+    s2_h0 = s2[(i*32+15):(i*32)]
+    s2_h1 = s2[(i*32+31):(i*32+16)]
+    // Multiply pairs and subtract: product0 - product1
+    d[(i*32+31):(i*32)] =
+        sext32(signed(s1_h0) * signed(s2_h0))
+      - sext32(signed(s1_h1) * signed(s2_h1))
+
+X[rd] = d
+----
+
+
+<<<
+==== PM2SUB.W (RV64)
+
+Mnemonic::
+
+pm2sub.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2SUB.W is encoded in the OP-32 major opcode with word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x8, attr: ['PM2SUB.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2SUB.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
+`rs1` and `rs2`, then subtracts the upper product from the lower product. The
+64-bit difference is written to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+// RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Multiply two signed 32-bit word pairs and subtract products
+X[rd] = sext64(signed(s1[31:0])  * signed(s2[31:0]))
+      - sext64(signed(s1[63:32]) * signed(s2[63:32]))
+----
+
+
+<<<
+==== PM2SUB.HX
+
+Mnemonic::
+
+pm2sub.hx _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2SUB.HX is encoded in the OP-32 major opcode with packed halfword elements
+and crossed operands.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x0 },
+    { bits: 4, name: 0xa, attr: ['PM2SUB.HX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2SUB.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
+and `rs2` within each 32-bit group using crossed `rs2` operands, then subtracts
+the upper product from the lower product. The lower halfword of `rs1` is
+multiplied with the upper halfword of `rs2`, and vice versa. The 32-bit
+difference for each group is written to the corresponding 32-bit position
+in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. (XLEN/32 - 1):
+    // Extract halfword pairs from each 32-bit group
+    s1_h0 = s1[(i*32+15):(i*32)]
+    s1_h1 = s1[(i*32+31):(i*32+16)]
+    s2_h0 = s2[(i*32+15):(i*32)]
+    s2_h1 = s2[(i*32+31):(i*32+16)]
+    // Cross-multiply pairs and subtract: product0 - product1
+    d[(i*32+31):(i*32)] =
+        sext32(signed(s1_h0) * signed(s2_h1))
+      - sext32(signed(s1_h1) * signed(s2_h0))
+
+X[rd] = d
+----
+
+
+<<<
+==== PM2SUB.WX (RV64)
+
+Mnemonic::
+
+pm2sub.wx _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2SUB.WX is encoded in the OP-32 major opcode with word elements and crossed
+operands (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xa, attr: ['PM2SUB.WX'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2SUB.WX (RV64 only) multiplies two pairs of signed 32-bit word elements from
+`rs1` and `rs2` using crossed `rs2` operands, then subtracts the upper product
+from the lower product. The lower word of `rs1` is multiplied with the upper
+word of `rs2`, and vice versa. The 64-bit difference is written to `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+// RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Cross-multiply two signed 32-bit word pairs and subtract products
+X[rd] = sext64(signed(s1[31:0])  * signed(s2[63:32]))
+      - sext64(signed(s1[63:32]) * signed(s2[31:0]))
+----
+
+
+<<<
 ==== PM2SUBA.H
 
 Mnemonic::
@@ -28168,6 +28737,53 @@ for i = 0 .. (XLEN/32 - 1):
         d[(32*i+31):(32*i)] + to_bits(32, a0 * b0) - to_bits(32, a1 * b1)
 
 X[rd] = d
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== PM2SUBA.W (RV64)
+
+Mnemonic::
+
+pm2suba.w _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM2SUBA.W is encoded in the OP-32 major opcode as an accumulating
+multiply-add-subtract instruction using packed word pairs.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x9, attr: ['PM2SUBA.W'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM2SUBA.W updates `rd` by adding the low×low signed word product and subtracting
+the high×high signed word product.
+
+Operation::
+
+[source,pseudocode]
+----
+a0 = sext_64(X[rs1][31:0])
+b0 = sext_64(X[rs2][31:0])
+a1 = sext_64(X[rs1][63:32])
+b1 = sext_64(X[rs2][63:32])
+
+X[rd] = X[rd] + to_bits(64, a0 * b0) - to_bits(64, a1 * b1)
 ----
 
 Notes::
@@ -28231,15 +28847,16 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== PM2SUB.H
+==== PM2SUBA.WX (RV64)
 
 Mnemonic::
 
-pm2sub.h _rd_, _rs1_, _rs2_
+pm2suba.wx _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PM2SUB.H is encoded in the OP-32 major opcode with packed halfword elements.
+PM2SUBA.WX is encoded in the OP-32 major opcode as an accumulating
+multiply-add-subtract instruction using cross word products.
 
 [wavedrom, ,svg]
 ....
@@ -28249,96 +28866,32 @@ PM2SUB.H is encoded in the OP-32 major opcode with packed halfword elements.
     { bits: 3, name: 0x5 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0x8, attr: ['PM2SUB.H'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xb, attr: ['PM2SUBA.WX'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-PM2SUB.H multiplies two pairs of signed 16-bit halfword elements from `rs1` and
-`rs2` within each 32-bit group, then subtracts the upper product from the lower
-product. The 32-bit difference for each group is written to the corresponding
-32-bit position in `rd`.
+PM2SUBA.WX updates `rd` by adding the low×high signed word product and
+subtracting the high×low signed word product.
 
 Operation::
 
 [source,pseudocode]
 ----
-s1 = X[rs1]
-s2 = X[rs2]
+a0 = sext_64(X[rs1][31:0])
+a1 = sext_64(X[rs1][63:32])
+b0 = sext_64(X[rs2][31:0])
+b1 = sext_64(X[rs2][63:32])
 
-for i = 0 .. (XLEN/32 - 1):
-    // Extract halfword pairs from each 32-bit group
-    s1_h0 = s1[(i*32+15):(i*32)]
-    s1_h1 = s1[(i*32+31):(i*32+16)]
-    s2_h0 = s2[(i*32+15):(i*32)]
-    s2_h1 = s2[(i*32+31):(i*32+16)]
-    // Multiply pairs and subtract: product0 - product1
-    d[(i*32+31):(i*32)] =
-        sext32(signed(s1_h0) * signed(s2_h0))
-      - sext32(signed(s1_h1) * signed(s2_h1))
-
-X[rd] = d
+X[rd] = X[rd] + to_bits(64, a0 * b1) - to_bits(64, a1 * b0)
 ----
 
+Notes::
 
-<<<
-==== PM2SUB.HX
-
-Mnemonic::
-
-pm2sub.hx _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2SUB.HX is encoded in the OP-32 major opcode with packed halfword elements
-and crossed operands.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x0 },
-    { bits: 4, name: 0xa, attr: ['PM2SUB.HX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2SUB.HX multiplies two pairs of signed 16-bit halfword elements from `rs1`
-and `rs2` within each 32-bit group using crossed `rs2` operands, then subtracts
-the upper product from the lower product. The lower halfword of `rs1` is
-multiplied with the upper halfword of `rs2`, and vice versa. The 32-bit
-difference for each group is written to the corresponding 32-bit position
-in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. (XLEN/32 - 1):
-    // Extract halfword pairs from each 32-bit group
-    s1_h0 = s1[(i*32+15):(i*32)]
-    s1_h1 = s1[(i*32+31):(i*32+16)]
-    s2_h0 = s2[(i*32+15):(i*32)]
-    s2_h1 = s2[(i*32+31):(i*32+16)]
-    // Cross-multiply pairs and subtract: product0 - product1
-    d[(i*32+31):(i*32)] =
-        sext32(signed(s1_h0) * signed(s2_h1))
-      - sext32(signed(s1_h1) * signed(s2_h0))
-
-X[rd] = d
-----
+* This instruction reads and writes `rd`.
 
 
 <<<
@@ -28452,553 +29005,6 @@ X[rd] = d
 
 
 <<<
-==== PM2ADD.W (RV64)
-
-Mnemonic::
-
-pm2add.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2ADD.W is encoded in the OP-32 major opcode as a packed word-pair multiply-add
-instruction producing a scalar 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x0, attr: ['PM2ADD.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2ADD.W multiplies the low words and high words of `rs1` and `rs2` as signed
-32-bit values and adds the two 64-bit products to produce the result in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_64(X[rs1][31:0])
-b0 = sext_64(X[rs2][31:0])
-a1 = sext_64(X[rs1][63:32])
-b1 = sext_64(X[rs2][63:32])
-
-X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
-----
-
-
-<<<
-==== PM2ADDA.W (RV64)
-
-Mnemonic::
-
-pm2adda.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2ADDA.W is encoded in the OP-32 major opcode with word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x1, attr: ['PM2ADDA.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2ADDA.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
-`rs1` and `rs2`, sums the two 64-bit products, and accumulates the result into
-`rd`. This instruction is the accumulating variant of PM2ADD.W.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Multiply two signed 32-bit word pairs and accumulate sum into rd
-X[rd] = X[rd]
-      + sext64(signed(s1[31:0])  * signed(s2[31:0]))
-      + sext64(signed(s1[63:32]) * signed(s2[63:32]))
-----
-
-
-<<<
-==== PM2ADDSU.W (RV64)
-
-Mnemonic::
-
-pm2addsu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2ADDSU.W is encoded in the OP-32 major opcode as a packed word-pair
-signed×unsigned multiply-add instruction.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xc, attr: ['PM2ADDSU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2ADDSU.W multiplies corresponding word pairs as signed×unsigned (low×low and
-high×high) and adds the two 64-bit products to produce the result in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_64(X[rs1][31:0])
-b0 = zext_64(X[rs2][31:0])
-a1 = sext_64(X[rs1][63:32])
-b1 = zext_64(X[rs2][63:32])
-
-X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
-----
-
-
-<<<
-==== PM2ADDASU.W (RV64)
-
-Mnemonic::
-
-pm2addasu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2ADDASU.W is encoded in the OP-32 major opcode as an accumulating form of
-PM2ADDSU.W.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xd, attr: ['PM2ADDASU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2ADDASU.W adds the PM2ADDSU.W result into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_64(X[rs1][31:0])
-b0 = zext_64(X[rs2][31:0])
-a1 = sext_64(X[rs1][63:32])
-b1 = zext_64(X[rs2][63:32])
-
-X[rd] = X[rd] + to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== PM2ADDU.W (RV64)
-
-Mnemonic::
-
-pm2addu.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2ADDU.W is encoded in the OP-32 major opcode as a packed word-pair
-unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x4, attr: ['PM2ADDU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2ADDU.W multiplies corresponding word pairs as unsigned×unsigned and adds the
-two 64-bit products to produce the result in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = zext_64(X[rs1][31:0])
-b0 = zext_64(X[rs2][31:0])
-a1 = zext_64(X[rs1][63:32])
-b1 = zext_64(X[rs2][63:32])
-
-X[rd] = to_bits(64, a0 * b0) + to_bits(64, a1 * b1)
-----
-
-
-<<<
-==== PM2ADDAU.W (RV64)
-
-Mnemonic::
-
-pm2addau.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2ADDAU.W is encoded in the OP-32 major opcode with word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x5, attr: ['PM2ADDAU.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2ADDAU.W (RV64 only) multiplies two pairs of unsigned 32-bit word elements
-from `rs1` and `rs2`, sums the two 64-bit products, and accumulates the result
-into `rd`. This instruction is the unsigned accumulating variant of PM2ADDU.W.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Multiply two unsigned 32-bit word pairs and accumulate sum into rd
-X[rd] = X[rd]
-      + zext64(unsigned(s1[31:0])  * unsigned(s2[31:0]))
-      + zext64(unsigned(s1[63:32]) * unsigned(s2[63:32]))
-----
-
-
-<<<
-==== PM2ADD.WX (RV64)
-
-Mnemonic::
-
-pm2add.wx _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2ADD.WX is encoded in the OP-32 major opcode as a packed word-pair multiply-add
-instruction using cross products.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x2, attr: ['PM2ADD.WX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2ADD.WX multiplies cross word pairs (low of `rs1` × high of `rs2`, and high of
-`rs1` × low of `rs2`) as signed values and sums the two 64-bit products.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_64(X[rs1][31:0])
-a1 = sext_64(X[rs1][63:32])
-b0 = sext_64(X[rs2][31:0])
-b1 = sext_64(X[rs2][63:32])
-
-X[rd] = to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
-----
-
-
-<<<
-==== PM2ADDA.WX (RV64)
-
-Mnemonic::
-
-pm2adda.wx _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2ADDA.WX is encoded in the OP-32 major opcode as an accumulating form of
-PM2ADD.WX.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x3, attr: ['PM2ADDA.WX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2ADDA.WX adds the PM2ADD.WX result into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_64(X[rs1][31:0])
-a1 = sext_64(X[rs1][63:32])
-b0 = sext_64(X[rs2][31:0])
-b1 = sext_64(X[rs2][63:32])
-
-X[rd] = X[rd] + to_bits(64, a0 * b1) + to_bits(64, a1 * b0)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== PM2SUBA.W (RV64)
-
-Mnemonic::
-
-pm2suba.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2SUBA.W is encoded in the OP-32 major opcode as an accumulating
-multiply-add-subtract instruction using packed word pairs.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x9, attr: ['PM2SUBA.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2SUBA.W updates `rd` by adding the low×low signed word product and subtracting
-the high×high signed word product.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_64(X[rs1][31:0])
-b0 = sext_64(X[rs2][31:0])
-a1 = sext_64(X[rs1][63:32])
-b1 = sext_64(X[rs2][63:32])
-
-X[rd] = X[rd] + to_bits(64, a0 * b0) - to_bits(64, a1 * b1)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== PM2SUBA.WX (RV64)
-
-Mnemonic::
-
-pm2suba.wx _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2SUBA.WX is encoded in the OP-32 major opcode as an accumulating
-multiply-add-subtract instruction using cross word products.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xb, attr: ['PM2SUBA.WX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2SUBA.WX updates `rd` by adding the low×high signed word product and
-subtracting the high×low signed word product.
-
-Operation::
-
-[source,pseudocode]
-----
-a0 = sext_64(X[rs1][31:0])
-a1 = sext_64(X[rs1][63:32])
-b0 = sext_64(X[rs2][31:0])
-b1 = sext_64(X[rs2][63:32])
-
-X[rd] = X[rd] + to_bits(64, a0 * b1) - to_bits(64, a1 * b0)
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-
-<<<
-==== PM2SUB.W (RV64)
-
-Mnemonic::
-
-pm2sub.w _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2SUB.W is encoded in the OP-32 major opcode with word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x8, attr: ['PM2SUB.W'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2SUB.W (RV64 only) multiplies two pairs of signed 32-bit word elements from
-`rs1` and `rs2`, then subtracts the upper product from the lower product. The
-64-bit difference is written to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Multiply two signed 32-bit word pairs and subtract products
-X[rd] = sext64(signed(s1[31:0])  * signed(s2[31:0]))
-      - sext64(signed(s1[63:32]) * signed(s2[63:32]))
-----
-
-
-<<<
-==== PM2SUB.WX (RV64)
-
-Mnemonic::
-
-pm2sub.wx _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM2SUB.WX is encoded in the OP-32 major opcode with word elements and crossed
-operands (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xa, attr: ['PM2SUB.WX'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PM2SUB.WX (RV64 only) multiplies two pairs of signed 32-bit word elements from
-`rs1` and `rs2` using crossed `rs2` operands, then subtracts the upper product
-from the lower product. The lower word of `rs1` is multiplied with the upper
-word of `rs2`, and vice versa. The 64-bit difference is written to `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Cross-multiply two signed 32-bit word pairs and subtract products
-X[rd] = sext64(signed(s1[31:0])  * signed(s2[63:32]))
-      - sext64(signed(s1[63:32]) * signed(s2[31:0]))
-----
-
-
-<<<
 === PM4 Horizontal Multiply-Add
 
 ==== PM4ADD.B
@@ -29054,6 +29060,53 @@ for i = 0 .. (XLEN/32 - 1):
         to_bits(32, a0*b0) + to_bits(32, a1*b1) + to_bits(32, a2*b2) + to_bits(32, a3*b3)
 
 X[rd] = d
+----
+
+
+<<<
+==== PM4ADD.H (RV64)
+
+Mnemonic::
+
+pm4add.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM4ADD.H is encoded in the OP-32 major opcode as a packed halfword-group
+multiply-add instruction producing a scalar 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x0, attr: ['PM4ADD.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PM4ADD.H instruction multiplies the four packed 16-bit halfwords of `rs1`
+and `rs2` as signed values and sums the four 64-bit products to produce the
+result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+X[rd] =
+      to_bits(64, sext_64(s1[15:0])  * sext_64(s2[15:0]))
+    + to_bits(64, sext_64(s1[31:16]) * sext_64(s2[31:16]))
+    + to_bits(64, sext_64(s1[47:32]) * sext_64(s2[47:32]))
+    + to_bits(64, sext_64(s1[63:48]) * sext_64(s2[63:48]))
 ----
 
 
@@ -29115,6 +29168,53 @@ X[rd] = d
 
 
 <<<
+==== PM4ADDSU.H (RV64)
+
+Mnemonic::
+
+pm4addsu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM4ADDSU.H is encoded in the OP-32 major opcode as a packed halfword-group
+signed×unsigned multiply-add instruction producing a scalar 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xc, attr: ['PM4ADDSU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PM4ADDSU.H instruction multiplies the four packed halfwords of `rs1` (signed)
+with the four packed halfwords of `rs2` (unsigned) and sums the products to
+produce the 64-bit result in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+X[rd] =
+      to_bits(64, sext_64(s1[15:0])  * zext_64(s2[15:0]))
+    + to_bits(64, sext_64(s1[31:16]) * zext_64(s2[31:16]))
+    + to_bits(64, sext_64(s1[47:32]) * zext_64(s2[47:32]))
+    + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
+----
+
+
+<<<
 ==== PM4ADDU.B
 
 Mnemonic::
@@ -29168,6 +29268,53 @@ for i = 0 .. (XLEN/32 - 1):
         to_bits(32, a0*b0) + to_bits(32, a1*b1) + to_bits(32, a2*b2) + to_bits(32, a3*b3)
 
 X[rd] = d
+----
+
+
+<<<
+==== PM4ADDU.H (RV64)
+
+Mnemonic::
+
+pm4addu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM4ADDU.H is encoded in the OP-32 major opcode as a packed halfword-group
+unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x4, attr: ['PM4ADDU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PM4ADDU.H instruction multiplies the four packed 16-bit halfwords of `rs1`
+and `rs2` as unsigned values and sums the products to produce the 64-bit result
+in `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+X[rd] =
+      to_bits(64, zext_64(s1[15:0])  * zext_64(s2[15:0]))
+    + to_bits(64, zext_64(s1[31:16]) * zext_64(s2[31:16]))
+    + to_bits(64, zext_64(s1[47:32]) * zext_64(s2[47:32]))
+    + to_bits(64, zext_64(s1[63:48]) * zext_64(s2[63:48]))
 ----
 
 
@@ -29230,6 +29377,55 @@ for i = 0 .. (XLEN/32 - 1):
         + sext32(signed(s1_b3) * signed(s2_b3))
 
 X[rd] = d
+----
+
+
+<<<
+==== PM4ADDA.H (RV64)
+
+Mnemonic::
+
+pm4adda.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM4ADDA.H is encoded in the OP-32 major opcode with packed halfword elements
+(RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x1, attr: ['PM4ADDA.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PM4ADDA.H (RV64 only) multiplies four pairs of signed 16-bit halfword elements
+from `rs1` and `rs2`, sums the four 64-bit products, and accumulates the result
+into `rd`. This instruction is the accumulating variant of PM4ADD.H.
+
+Operation::
+
+[source,pseudocode]
+----
+// RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Multiply four signed 16-bit halfword pairs and accumulate sum into rd
+X[rd] = X[rd]
+      + sext64(signed(s1[15:0])   * signed(s2[15:0]))
+      + sext64(signed(s1[31:16])  * signed(s2[31:16]))
+      + sext64(signed(s1[47:32])  * signed(s2[47:32]))
+      + sext64(signed(s1[63:48])  * signed(s2[63:48]))
 ----
 
 
@@ -29297,6 +29493,55 @@ X[rd] = d
 
 
 <<<
+==== PM4ADDASU.H (RV64)
+
+Mnemonic::
+
+pm4addasu.h _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PM4ADDASU.H is encoded in the OP-32 major opcode as an accumulating form of
+PM4ADDSU.H.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x5 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xd, attr: ['PM4ADDASU.H'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PM4ADDASU.H instruction adds the PM4ADDSU.H sum-of-products result into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+X[rd] =
+    X[rd]
+  + to_bits(64, sext_64(s1[15:0])  * zext_64(s2[15:0]))
+  + to_bits(64, sext_64(s1[31:16]) * zext_64(s2[31:16]))
+  + to_bits(64, sext_64(s1[47:32]) * zext_64(s2[47:32]))
+  + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
 ==== PM4ADDAU.B
 
 Mnemonic::
@@ -29360,196 +29605,6 @@ X[rd] = d
 
 
 <<<
-==== PM4ADD.H (RV64)
-
-Mnemonic::
-
-pm4add.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM4ADD.H is encoded in the OP-32 major opcode as a packed halfword-group
-multiply-add instruction producing a scalar 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x0, attr: ['PM4ADD.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PM4ADD.H instruction multiplies the four packed 16-bit halfwords of `rs1`
-and `rs2` as signed values and sums the four 64-bit products to produce the
-result in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-X[rd] =
-      to_bits(64, sext_64(s1[15:0])  * sext_64(s2[15:0]))
-    + to_bits(64, sext_64(s1[31:16]) * sext_64(s2[31:16]))
-    + to_bits(64, sext_64(s1[47:32]) * sext_64(s2[47:32]))
-    + to_bits(64, sext_64(s1[63:48]) * sext_64(s2[63:48]))
-----
-
-
-<<<
-==== PM4ADDSU.H (RV64)
-
-Mnemonic::
-
-pm4addsu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM4ADDSU.H is encoded in the OP-32 major opcode as a packed halfword-group
-signed×unsigned multiply-add instruction producing a scalar 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xc, attr: ['PM4ADDSU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PM4ADDSU.H instruction multiplies the four packed halfwords of `rs1` (signed)
-with the four packed halfwords of `rs2` (unsigned) and sums the products to
-produce the 64-bit result in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-X[rd] =
-      to_bits(64, sext_64(s1[15:0])  * zext_64(s2[15:0]))
-    + to_bits(64, sext_64(s1[31:16]) * zext_64(s2[31:16]))
-    + to_bits(64, sext_64(s1[47:32]) * zext_64(s2[47:32]))
-    + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
-----
-
-
-<<<
-==== PM4ADDASU.H (RV64)
-
-Mnemonic::
-
-pm4addasu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM4ADDASU.H is encoded in the OP-32 major opcode as an accumulating form of
-PM4ADDSU.H.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xd, attr: ['PM4ADDASU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PM4ADDASU.H instruction adds the PM4ADDSU.H sum-of-products result into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-X[rd] =
-    X[rd]
-  + to_bits(64, sext_64(s1[15:0])  * zext_64(s2[15:0]))
-  + to_bits(64, sext_64(s1[31:16]) * zext_64(s2[31:16]))
-  + to_bits(64, sext_64(s1[47:32]) * zext_64(s2[47:32]))
-  + to_bits(64, sext_64(s1[63:48]) * zext_64(s2[63:48]))
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== PM4ADDU.H (RV64)
-
-Mnemonic::
-
-pm4addu.h _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PM4ADDU.H is encoded in the OP-32 major opcode as a packed halfword-group
-unsigned×unsigned multiply-add instruction producing a scalar 64-bit result.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x4, attr: ['PM4ADDU.H'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PM4ADDU.H instruction multiplies the four packed 16-bit halfwords of `rs1`
-and `rs2` as unsigned values and sums the products to produce the 64-bit result
-in `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-X[rd] =
-      to_bits(64, zext_64(s1[15:0])  * zext_64(s2[15:0]))
-    + to_bits(64, zext_64(s1[31:16]) * zext_64(s2[31:16]))
-    + to_bits(64, zext_64(s1[47:32]) * zext_64(s2[47:32]))
-    + to_bits(64, zext_64(s1[63:48]) * zext_64(s2[63:48]))
-----
-
-
-<<<
 ==== PM4ADDAU.H (RV64)
 
 Mnemonic::
@@ -29600,57 +29655,92 @@ Notes::
 
 
 <<<
-==== PM4ADDA.H (RV64)
+=== Mixed-width Multiply-High
+
+==== MULH.H0 (RV32)
 
 Mnemonic::
 
-pm4adda.h _rd_, _rs1_, _rs2_
+mulh.h0 _rd_, _rs1_, _rs2_
 
 Encoding::
 
-PM4ADDA.H is encoded in the OP-32 major opcode with packed halfword elements
-(RV64 only).
+MULH.H0 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using a halfword.
 
 [wavedrom, ,svg]
 ....
 {reg:[
     { bits: 7, name: 0x3b, attr: ['OP-32'] },
     { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x5 },
+    { bits: 3, name: 0x7 },
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x1, attr: ['PM4ADDA.H'] },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['MULH.H0'] },
     { bits: 1, name: 0x1 },
 ]}
 ....
 
 Description::
 
-PM4ADDA.H (RV64 only) multiplies four pairs of signed 16-bit halfword elements
-from `rs1` and `rs2`, sums the four 64-bit products, and accumulates the result
-into `rd`. This instruction is the accumulating variant of PM4ADD.H.
+MULH.H0 multiplies the full signed XLEN-bit value of `rs1` by the low 16-bit
+halfword (h0) of `rs2` treated as signed, producing a (XLEN+16)-bit
+intermediate product, and writes bits [47:16] to `rd`, effectively providing
+the upper XLEN bits of the product after discarding the low 16 bits.
 
 Operation::
 
 [source,pseudocode]
 ----
-// RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Multiply four signed 16-bit halfword pairs and accumulate sum into rd
-X[rd] = X[rd]
-      + sext64(signed(s1[15:0])   * signed(s2[15:0]))
-      + sext64(signed(s1[31:16])  * signed(s2[31:16]))
-      + sext64(signed(s1[47:32])  * signed(s2[47:32]))
-      + sext64(signed(s1[63:48])  * signed(s2[63:48]))
+# RV32
+s2_h0 = X[rs2][15:0]
+X[rd] = (signed(X[rs1]) * signed(s2_h0))[47:16]
 ----
 
 
 <<<
-=== Mixed-width Multiply-High
+==== MULH.H1 (RV32)
 
+Mnemonic::
+
+mulh.h1 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULH.H1 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using a halfword.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['MULH.H1'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULH.H1 multiplies the full signed XLEN-bit value of `rs1` by the high 16-bit
+halfword (h1) of `rs2` treated as signed, producing a (XLEN+16)-bit
+intermediate product, and writes bits [47:16] to `rd`, effectively providing
+the upper XLEN bits of the product after discarding the low 16 bits.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV32
+s2_h1 = X[rs2][31:16]
+X[rd] = (signed(X[rs1]) * signed(s2_h1))[47:16]
+----
+
+
+<<<
 ==== PMULH.H.B0
 
 Mnemonic::
@@ -29753,6 +29843,186 @@ X[rd] = d
 
 
 <<<
+==== PMULH.W.H0 (RV64)
+
+Mnemonic::
+
+pmulh.w.h0 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULH.W.H0 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['PMULH.W.H0'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULH.W.H0 multiplies each signed packed 32-bit word element of `rs1` by the
+low halfword (h0) of the corresponding word element of `rs2` treated as signed,
+producing a 48-bit intermediate product per element, and writes bits [47:16] of
+each product to the corresponding word of `rd`. This instruction is available
+only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = (signed(s1[31:0])  * signed(s2[15:0]) )[47:16]
+d_w1 = (signed(s1[63:32]) * signed(s2[47:32]))[47:16]
+X[rd] = d_w1 @ d_w0
+----
+
+
+<<<
+==== PMULH.W.H1 (RV64)
+
+Mnemonic::
+
+pmulh.w.h1 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULH.W.H1 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['PMULH.W.H1'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULH.W.H1 multiplies each signed packed 32-bit word element of `rs1` by the
+high halfword (h1) of the corresponding word element of `rs2` treated as
+signed, producing a 48-bit intermediate product per element, and writes bits
+[47:16] of each product to the corresponding word of `rd`. This instruction is
+available only on RV64.
+
+Operation::
+
+[source,pseudocode]
+----
+# RV64 only
+s1 = X[rs1]
+s2 = X[rs2]
+d_w0 = (signed(s1[31:0])  * signed(s2[31:16]))[47:16]
+d_w1 = (signed(s1[63:32]) * signed(s2[63:48]))[47:16]
+X[rd] = d_w1 @ d_w0
+----
+
+
+<<<
+==== MULHSU.H0 (RV32)
+
+Mnemonic::
+
+mulhsu.h0 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULHSU.H0 is encoded in the OP-32 major opcode with a scalar `rs1` and a
+halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
+48-bit signed×unsigned product.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x4, attr: ['MULHSU.H0'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULHSU.H0 multiplies the 32-bit signed value in `rs1` by the low halfword of
+`rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
+`rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a  = sext_48(X[rs1])                  // XLEN=32 signed
+b0 = zext_48(X[rs2][15:0])            // halfword 0 (unsigned)
+p  = a * b0
+X[rd] = to_bits(48, p)[47:16]
+----
+
+
+<<<
+==== MULHSU.H1 (RV32)
+
+Mnemonic::
+
+mulhsu.h1 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MULHSU.H1 is encoded in the OP-32 major opcode with a scalar `rs1` and a
+halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
+48-bit signed×unsigned product.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['MULHSU.H1'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MULHSU.H1 multiplies the 32-bit signed value in `rs1` by the high halfword of
+`rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
+`rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a  = sext_48(X[rs1])                  // XLEN=32 signed
+b1 = zext_48(X[rs2][31:16])           // halfword 1 (unsigned)
+p  = a * b1
+X[rd] = to_bits(48, p)[47:16]
+----
+
+
+<<<
 ==== PMULHSU.H.B0
 
 Mnemonic::
@@ -29851,6 +30121,106 @@ for i = 0 .. (XLEN/16 - 1):
     d[(16*i+15):(16*i)] = to_bits(24, p)[23:8]
 
 X[rd] = d
+----
+
+
+<<<
+==== PMULHSU.W.H0 (RV64)
+
+Mnemonic::
+
+pmulhsu.w.h0 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULHSU.W.H0 is encoded in the OP-32 major opcode producing packed 32-bit
+elements from word×halfword operands (signed×unsigned), taking the high 32 bits
+of each 48-bit product.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x4, attr: ['PMULHSU.W.H0'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULHSU.W.H0 multiplies each 32-bit word of `rs1` (signed) by the low halfword of
+the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of each
+48-bit product, and packs the two 32-bit results into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+p0 = sext_48(s1[31:0])  * zext_48(s2[15:0])
+p1 = sext_48(s1[63:32]) * zext_48(s2[47:32])
+
+d0 = to_bits(48, p0)[47:16]
+d1 = to_bits(48, p1)[47:16]
+
+X[rd] = d1 @ d0
+----
+
+
+<<<
+==== PMULHSU.W.H1 (RV64)
+
+Mnemonic::
+
+pmulhsu.w.h1 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMULHSU.W.H1 is encoded in the OP-32 major opcode producing packed 32-bit
+elements from word×halfword operands (signed×unsigned), taking the high 32 bits
+of each 48-bit product.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x6, attr: ['PMULHSU.W.H1'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+PMULHSU.W.H1 multiplies each 32-bit word of `rs1` (signed) by the high halfword
+of the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of
+each 48-bit product, and packs the two 32-bit results into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+p0 = sext_48(s1[31:0])  * zext_48(s2[31:16])
+p1 = sext_48(s1[63:32]) * zext_48(s2[63:48])
+
+d0 = to_bits(48, p0)[47:16]
+d1 = to_bits(48, p1)[47:16]
+
+X[rd] = d1 @ d0
 ----
 
 
@@ -29965,286 +30335,6 @@ Notes::
 * This instruction reads and writes `rd`.
 
 <<<
-==== PMHACCSU.H.B0
-
-Mnemonic::
-
-pmhaccsu.h.b0 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMHACCSU.H.B0 is encoded in the OP-32 major opcode as an accumulating form of
-PMULHSU.H.B0.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x5, attr: ['PMHACCSU.H.B0'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMHACCSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
-(signed) by the low byte of the corresponding element of `rs2` (unsigned), takes
-the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d  = X[rd]
-
-for i = 0 .. (XLEN/16 - 1):
-    a  = sext_24(s1[(16*i+15):(16*i)])              // signed halfword
-    b0 = zext_24(s2[(16*i+7):(16*i)])               // unsigned byte 0
-    p  = a * b0
-    d[(16*i+15):(16*i)] =
-        d[(16*i+15):(16*i)] + to_bits(24, p)[23:8]
-
-X[rd] = d
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== PMHACCSU.H.B1
-
-Mnemonic::
-
-pmhaccsu.h.b1 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMHACCSU.H.B1 is encoded in the OP-32 major opcode as an accumulating form of
-PMULHSU.H.B1.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x7, attr: ['PMHACCSU.H.B1'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-The PMHACCSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
-(signed) by the high byte of the corresponding element of `rs2` (unsigned), takes
-the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-d  = X[rd]
-
-for i = 0 .. (XLEN/16 - 1):
-    a  = sext_24(s1[(16*i+15):(16*i)])              // signed halfword
-    b1 = zext_24(s2[(16*i+15):(16*i+8)])            // unsigned byte 1
-    p  = a * b1
-    d[(16*i+15):(16*i)] =
-        d[(16*i+15):(16*i)] + to_bits(24, p)[23:8]
-
-X[rd] = d
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MULH.H0 (RV32)
-
-Mnemonic::
-
-mulh.h0 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULH.H0 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using a halfword.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x4, attr: ['MULH.H0'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULH.H0 multiplies the full signed XLEN-bit value of `rs1` by the low 16-bit
-halfword (h0) of `rs2` treated as signed, producing a (XLEN+16)-bit
-intermediate product, and writes bits [47:16] to `rd`, effectively providing
-the upper XLEN bits of the product after discarding the low 16 bits.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV32
-s2_h0 = X[rs2][15:0]
-X[rd] = (signed(X[rs1]) * signed(s2_h0))[47:16]
-----
-
-
-<<<
-==== MULH.H1 (RV32)
-
-Mnemonic::
-
-mulh.h1 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULH.H1 is encoded in the OP-32 major opcode as an XLEN-wide multiply high using a halfword.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x6, attr: ['MULH.H1'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULH.H1 multiplies the full signed XLEN-bit value of `rs1` by the high 16-bit
-halfword (h1) of `rs2` treated as signed, producing a (XLEN+16)-bit
-intermediate product, and writes bits [47:16] to `rd`, effectively providing
-the upper XLEN bits of the product after discarding the low 16 bits.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV32
-s2_h1 = X[rs2][31:16]
-X[rd] = (signed(X[rs1]) * signed(s2_h1))[47:16]
-----
-
-
-<<<
-==== MULHSU.H0 (RV32)
-
-Mnemonic::
-
-mulhsu.h0 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULHSU.H0 is encoded in the OP-32 major opcode with a scalar `rs1` and a
-halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
-48-bit signed×unsigned product.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x4, attr: ['MULHSU.H0'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULHSU.H0 multiplies the 32-bit signed value in `rs1` by the low halfword of
-`rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
-`rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a  = sext_48(X[rs1])                  // XLEN=32 signed
-b0 = zext_48(X[rs2][15:0])            // halfword 0 (unsigned)
-p  = a * b0
-X[rd] = to_bits(48, p)[47:16]
-----
-
-
-<<<
-==== MULHSU.H1 (RV32)
-
-Mnemonic::
-
-mulhsu.h1 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MULHSU.H1 is encoded in the OP-32 major opcode with a scalar `rs1` and a
-halfword-selected `rs2` operand. The instruction writes the high 32 bits of the
-48-bit signed×unsigned product.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x6, attr: ['MULHSU.H1'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MULHSU.H1 multiplies the 32-bit signed value in `rs1` by the high halfword of
-`rs2` treated as unsigned, and writes bits [47:16] of the 48-bit product to
-`rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a  = sext_48(X[rs1])                  // XLEN=32 signed
-b1 = zext_48(X[rs2][31:16])           // halfword 1 (unsigned)
-p  = a * b1
-X[rd] = to_bits(48, p)[47:16]
-----
-
-
-<<<
 ==== MHACC.H0 (RV32)
 
 Mnemonic::
@@ -30335,290 +30425,6 @@ X[rd] = X[rd] + to_bits(48, p)[47:16]
 Notes::
 
 * This instruction reads and writes `rd`.
-
-<<<
-==== MHACCSU.H0 (RV32)
-
-Mnemonic::
-
-mhaccsu.h0 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MHACCSU.H0 is encoded in the OP-32 major opcode as an accumulating form of
-MULHSU.H0 (signed×unsigned), producing the high 32 bits of a 48-bit product.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x5, attr: ['MHACCSU.H0'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MHACCSU.H0 multiplies the signed 32-bit value in `rs1` by the low halfword of
-`rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
-accumulates the extracted value into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a  = sext_48(X[rs1])
-b0 = zext_48(X[rs2][15:0])
-p  = a * b0
-X[rd] = X[rd] + to_bits(48, p)[47:16]
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== MHACCSU.H1 (RV32)
-
-Mnemonic::
-
-mhaccsu.h1 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-MHACCSU.H1 is encoded in the OP-32 major opcode as an accumulating form of
-MULHSU.H1 (signed×unsigned), producing the high 32 bits of a 48-bit product.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x7, attr: ['MHACCSU.H1'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-MHACCSU.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
-`rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
-accumulates the extracted value into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-a  = sext_48(X[rs1])
-b1 = zext_48(X[rs2][31:16])
-p  = a * b1
-X[rd] = X[rd] + to_bits(48, p)[47:16]
-----
-
-Notes::
-
-* This instruction reads and writes `rd`.
-
-<<<
-==== PMULH.W.H0 (RV64)
-
-Mnemonic::
-
-pmulh.w.h0 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULH.W.H0 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x4, attr: ['PMULH.W.H0'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULH.W.H0 multiplies each signed packed 32-bit word element of `rs1` by the
-low halfword (h0) of the corresponding word element of `rs2` treated as signed,
-producing a 48-bit intermediate product per element, and writes bits [47:16] of
-each product to the corresponding word of `rd`. This instruction is available
-only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-d_w0 = (signed(s1[31:0])  * signed(s2[15:0]) )[47:16]
-d_w1 = (signed(s1[63:32]) * signed(s2[47:32]))[47:16]
-X[rd] = d_w1 @ d_w0
-----
-
-
-<<<
-==== PMULH.W.H1 (RV64)
-
-Mnemonic::
-
-pmulh.w.h1 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULH.W.H1 is encoded in the OP-32 major opcode with packed word elements (RV64 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x6, attr: ['PMULH.W.H1'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULH.W.H1 multiplies each signed packed 32-bit word element of `rs1` by the
-high halfword (h1) of the corresponding word element of `rs2` treated as
-signed, producing a 48-bit intermediate product per element, and writes bits
-[47:16] of each product to the corresponding word of `rd`. This instruction is
-available only on RV64.
-
-Operation::
-
-[source,pseudocode]
-----
-# RV64 only
-s1 = X[rs1]
-s2 = X[rs2]
-d_w0 = (signed(s1[31:0])  * signed(s2[31:16]))[47:16]
-d_w1 = (signed(s1[63:32]) * signed(s2[63:48]))[47:16]
-X[rd] = d_w1 @ d_w0
-----
-
-
-<<<
-==== PMULHSU.W.H0 (RV64)
-
-Mnemonic::
-
-pmulhsu.w.h0 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULHSU.W.H0 is encoded in the OP-32 major opcode producing packed 32-bit
-elements from word×halfword operands (signed×unsigned), taking the high 32 bits
-of each 48-bit product.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x4, attr: ['PMULHSU.W.H0'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULHSU.W.H0 multiplies each 32-bit word of `rs1` (signed) by the low halfword of
-the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of each
-48-bit product, and packs the two 32-bit results into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-p0 = sext_48(s1[31:0])  * zext_48(s2[15:0])
-p1 = sext_48(s1[63:32]) * zext_48(s2[47:32])
-
-d0 = to_bits(48, p0)[47:16]
-d1 = to_bits(48, p1)[47:16]
-
-X[rd] = d1 @ d0
-----
-
-
-<<<
-==== PMULHSU.W.H1 (RV64)
-
-Mnemonic::
-
-pmulhsu.w.h1 _rd_, _rs1_, _rs2_
-
-Encoding::
-
-PMULHSU.W.H1 is encoded in the OP-32 major opcode producing packed 32-bit
-elements from word×halfword operands (signed×unsigned), taking the high 32 bits
-of each 48-bit product.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x3b, attr: ['OP-32'] },
-    { bits: 5, name: 'rd' },
-    { bits: 3, name: 0x7 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x6, attr: ['PMULHSU.W.H1'] },
-    { bits: 1, name: 0x1 },
-]}
-....
-
-Description::
-
-PMULHSU.W.H1 multiplies each 32-bit word of `rs1` (signed) by the high halfword
-of the corresponding 32-bit word of `rs2` (unsigned), extracts bits [47:16] of
-each 48-bit product, and packs the two 32-bit results into `rd`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-p0 = sext_48(s1[31:0])  * zext_48(s2[31:16])
-p1 = sext_48(s1[63:32]) * zext_48(s2[63:48])
-
-d0 = to_bits(48, p0)[47:16]
-d1 = to_bits(48, p1)[47:16]
-
-X[rd] = d1 @ d0
-----
-
 
 <<<
 ==== PMHACC.W.H0 (RV64)
@@ -30728,6 +30534,206 @@ d0 = din[31:0]  + to_bits(48, p0)[47:16]
 d1 = din[63:32] + to_bits(48, p1)[47:16]
 
 X[rd] = d1 @ d0
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MHACCSU.H0 (RV32)
+
+Mnemonic::
+
+mhaccsu.h0 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MHACCSU.H0 is encoded in the OP-32 major opcode as an accumulating form of
+MULHSU.H0 (signed×unsigned), producing the high 32 bits of a 48-bit product.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x5, attr: ['MHACCSU.H0'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MHACCSU.H0 multiplies the signed 32-bit value in `rs1` by the low halfword of
+`rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
+accumulates the extracted value into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a  = sext_48(X[rs1])
+b0 = zext_48(X[rs2][15:0])
+p  = a * b0
+X[rd] = X[rd] + to_bits(48, p)[47:16]
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== MHACCSU.H1 (RV32)
+
+Mnemonic::
+
+mhaccsu.h1 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+MHACCSU.H1 is encoded in the OP-32 major opcode as an accumulating form of
+MULHSU.H1 (signed×unsigned), producing the high 32 bits of a 48-bit product.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x7, attr: ['MHACCSU.H1'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+MHACCSU.H1 multiplies the signed 32-bit value in `rs1` by the high halfword of
+`rs2` treated as unsigned, takes bits [47:16] of the 48-bit product, and
+accumulates the extracted value into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+a  = sext_48(X[rs1])
+b1 = zext_48(X[rs2][31:16])
+p  = a * b1
+X[rd] = X[rd] + to_bits(48, p)[47:16]
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== PMHACCSU.H.B0
+
+Mnemonic::
+
+pmhaccsu.h.b0 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMHACCSU.H.B0 is encoded in the OP-32 major opcode as an accumulating form of
+PMULHSU.H.B0.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x5, attr: ['PMHACCSU.H.B0'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMHACCSU.H.B0 instruction multiplies each packed 16-bit element of `rs1`
+(signed) by the low byte of the corresponding element of `rs2` (unsigned), takes
+the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d  = X[rd]
+
+for i = 0 .. (XLEN/16 - 1):
+    a  = sext_24(s1[(16*i+15):(16*i)])              // signed halfword
+    b0 = zext_24(s2[(16*i+7):(16*i)])               // unsigned byte 0
+    p  = a * b0
+    d[(16*i+15):(16*i)] =
+        d[(16*i+15):(16*i)] + to_bits(24, p)[23:8]
+
+X[rd] = d
+----
+
+Notes::
+
+* This instruction reads and writes `rd`.
+
+<<<
+==== PMHACCSU.H.B1
+
+Mnemonic::
+
+pmhaccsu.h.b1 _rd_, _rs1_, _rs2_
+
+Encoding::
+
+PMHACCSU.H.B1 is encoded in the OP-32 major opcode as an accumulating form of
+PMULHSU.H.B1.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x3b, attr: ['OP-32'] },
+    { bits: 5, name: 'rd' },
+    { bits: 3, name: 0x7 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x7, attr: ['PMHACCSU.H.B1'] },
+    { bits: 1, name: 0x1 },
+]}
+....
+
+Description::
+
+The PMHACCSU.H.B1 instruction multiplies each packed 16-bit element of `rs1`
+(signed) by the high byte of the corresponding element of `rs2` (unsigned), takes
+the upper 16 bits of the 24-bit product, and accumulates it into `rd`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+d  = X[rd]
+
+for i = 0 .. (XLEN/16 - 1):
+    a  = sext_24(s1[(16*i+15):(16*i)])              // signed halfword
+    b1 = zext_24(s2[(16*i+15):(16*i+8)])            // unsigned byte 1
+    p  = a * b1
+    d[(16*i+15):(16*i)] =
+        d[(16*i+15):(16*i)] + to_bits(24, p)[23:8]
+
+X[rd] = d
 ----
 
 Notes::
@@ -30852,6 +30858,53 @@ Notes::
 <<<
 === Widening Multiply
 
+==== WMUL (RV32)
+
+Mnemonic::
+
+wmul _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WMUL is encoded in the widening register-pair format (RV32 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x4, attr: ['WMUL'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WMUL (RV32 only) performs a widening signed multiplication of the full 32-bit
+values in `rs1` and `rs2`, producing a 64-bit signed product. The result is
+written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
+discarded.
+
+Operation::
+
+[source,pseudocode]
+----
+// RV32 only
+// Widening signed multiply: XLEN x XLEN -> 2*XLEN
+d = signed(X[rs1]) * signed(X[rs2])
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
 ==== PWMUL.B (RV32)
 
 Mnemonic::
@@ -30898,117 +30951,6 @@ for i = 0 .. 3:
     s1_b = s1[(i*8+7):(i*8)]
     s2_b = s2[(i*8+7):(i*8)]
     d[(i*16+15):(i*16)] = signed(s1_b) * signed(s2_b)
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== PWMULSU.B (RV32)
-
-Mnemonic::
-
-pwmulsu.b _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWMULSU.B is encoded in a register-pair (rd_p) OP-IMM-32 format. It writes a 64-bit
-result into the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0xc, attr: ['PWMULSU.B'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-The PWMULSU.B instruction performs four signed×unsigned byte multiplications
-between corresponding bytes of `rs1` and `rs2`. Each 16-bit product is packed
-into a 64-bit result, which is written to the destination register pair selected
-by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-for i = 0 .. 3:
-    a = sext_16(s1[(8*i+7):(8*i)])      // signed byte
-    b = zext_16(s2[(8*i+7):(8*i)])      // unsigned byte
-    d[(16*i+15):(16*i)] = to_bits(16, a * b)
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-Notes::
-
-* If `rd_p=0`, the result is not written (no architectural destination).
-* The destination is the register pair `{X[2*rd_p+1], X[2*rd_p]}`.
-
-<<<
-==== PWMULU.B (RV32)
-
-Mnemonic::
-
-pwmulu.b _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PWMULU.B is encoded in the widening register-pair format with packed byte
-elements and unsigned multiplication (RV32 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x2 },
-    { bits: 4, name: 0x6, attr: ['PWMULU.B'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PWMULU.B (RV32 only) performs packed widening unsigned multiplication of four
-8-bit byte element pairs from `rs1` and `rs2`. Each pair of unsigned bytes
-produces an unsigned 16-bit halfword product. The four halfword results are
-written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
-discarded.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV32 only
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Widening unsigned multiply of four byte pairs to halfwords
-for i = 0 .. 3:
-    s1_b = s1[(i*8+7):(i*8)]
-    s2_b = s2[(i*8+7):(i*8)]
-    d[(i*16+15):(i*16)] = unsigned(s1_b) * unsigned(s2_b)
 
 if (rd_p != 0):
     X[rd_p*2]   = d[31:0]
@@ -31069,6 +31011,113 @@ if (rd_p != 0):
 
 
 <<<
+==== WMULSU (RV32)
+
+Mnemonic::
+
+wmulsu _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WMULSU is encoded in a register-pair (rd_p) OP-IMM-32 format. It computes a 64-bit
+signed×unsigned product and writes it to the destination register pair selected
+by `rd_p` when `rd_p != 0`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xc, attr: ['WMULSU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+The WMULSU instruction multiplies `rs1` as a signed 32-bit integer by `rs2` as an
+unsigned 32-bit integer, producing a 64-bit product. The product is written to
+the destination register pair selected by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+p = to_bits(64, sext_64(X[rs1]) * zext_64(X[rs2]))
+
+if (rd_p != 0):
+    X[2*rd_p]   = p[31:0]
+    X[2*rd_p+1] = p[63:32]
+----
+
+Notes::
+
+* If `rd_p=0`, the result is not written.
+* The destination is the register pair `{X[2*rd_p+1], X[2*rd_p]}`.
+
+
+<<<
+==== PWMULSU.B (RV32)
+
+Mnemonic::
+
+pwmulsu.b _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWMULSU.B is encoded in a register-pair (rd_p) OP-IMM-32 format. It writes a 64-bit
+result into the register pair `{X[2*rd_p+1], X[2*rd_p]}` when `rd_p != 0`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0xc, attr: ['PWMULSU.B'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+The PWMULSU.B instruction performs four signed×unsigned byte multiplications
+between corresponding bytes of `rs1` and `rs2`. Each 16-bit product is packed
+into a 64-bit result, which is written to the destination register pair selected
+by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+for i = 0 .. 3:
+    a = sext_16(s1[(8*i+7):(8*i)])      // signed byte
+    b = zext_16(s2[(8*i+7):(8*i)])      // unsigned byte
+    d[(16*i+15):(16*i)] = to_bits(16, a * b)
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+Notes::
+
+* If `rd_p=0`, the result is not written (no architectural destination).
+* The destination is the register pair `{X[2*rd_p+1], X[2*rd_p]}`.
+
+<<<
 ==== PWMULSU.H (RV32)
 
 Mnemonic::
@@ -31121,6 +31170,109 @@ Notes::
 
 * If `rd_p=0`, the result is not written.
 * The destination is the register pair `X[2*rd_p]` and `X[2*rd_p+1]`.
+
+<<<
+==== WMULU (RV32)
+
+Mnemonic::
+
+wmulu _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WMULU is encoded in the widening register-pair format with unsigned
+multiplication (RV32 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x6, attr: ['WMULU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WMULU (RV32 only) performs a widening unsigned multiplication of the full 32-bit
+values in `rs1` and `rs2`, producing a 64-bit unsigned product. The result is
+written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
+discarded.
+
+Operation::
+
+[source,pseudocode]
+----
+// RV32 only
+// Widening unsigned multiply: XLEN x XLEN -> 2*XLEN
+d = unsigned(X[rs1]) * unsigned(X[rs2])
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
+==== PWMULU.B (RV32)
+
+Mnemonic::
+
+pwmulu.b _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PWMULU.B is encoded in the widening register-pair format with packed byte
+elements and unsigned multiplication (RV32 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x2 },
+    { bits: 4, name: 0x6, attr: ['PWMULU.B'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PWMULU.B (RV32 only) performs packed widening unsigned multiplication of four
+8-bit byte element pairs from `rs1` and `rs2`. Each pair of unsigned bytes
+produces an unsigned 16-bit halfword product. The four halfword results are
+written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
+discarded.
+
+Operation::
+
+[source,pseudocode]
+----
+// RV32 only
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Widening unsigned multiply of four byte pairs to halfwords
+for i = 0 .. 3:
+    s1_b = s1[(i*8+7):(i*8)]
+    s2_b = s2[(i*8+7):(i*8)]
+    d[(i*16+15):(i*16)] = unsigned(s1_b) * unsigned(s2_b)
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
 
 <<<
 ==== PWMULU.H (RV32)
@@ -31176,154 +31328,60 @@ if (rd_p != 0):
 
 
 <<<
-==== WMUL (RV32)
-
-Mnemonic::
-
-wmul _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WMUL is encoded in the widening register-pair format (RV32 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x4, attr: ['WMUL'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WMUL (RV32 only) performs a widening signed multiplication of the full 32-bit
-values in `rs1` and `rs2`, producing a 64-bit signed product. The result is
-written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
-discarded.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV32 only
-// Widening signed multiply: XLEN x XLEN -> 2*XLEN
-d = signed(X[rs1]) * signed(X[rs2])
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== WMULSU (RV32)
-
-Mnemonic::
-
-wmulsu _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WMULSU is encoded in a register-pair (rd_p) OP-IMM-32 format. It computes a 64-bit
-signed×unsigned product and writes it to the destination register pair selected
-by `rd_p` when `rd_p != 0`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xc, attr: ['WMULSU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-The WMULSU instruction multiplies `rs1` as a signed 32-bit integer by `rs2` as an
-unsigned 32-bit integer, producing a 64-bit product. The product is written to
-the destination register pair selected by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-p = to_bits(64, sext_64(X[rs1]) * zext_64(X[rs2]))
-
-if (rd_p != 0):
-    X[2*rd_p]   = p[31:0]
-    X[2*rd_p+1] = p[63:32]
-----
-
-Notes::
-
-* If `rd_p=0`, the result is not written.
-* The destination is the register pair `{X[2*rd_p+1], X[2*rd_p]}`.
-
-
-<<<
-==== WMULU (RV32)
-
-Mnemonic::
-
-wmulu _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WMULU is encoded in the widening register-pair format with unsigned
-multiplication (RV32 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x6, attr: ['WMULU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WMULU (RV32 only) performs a widening unsigned multiplication of the full 32-bit
-values in `rs1` and `rs2`, producing a 64-bit unsigned product. The result is
-written as a 64-bit register pair `rd_p`. If `rd_p` is 0, the result is
-discarded.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV32 only
-// Widening unsigned multiply: XLEN x XLEN -> 2*XLEN
-d = unsigned(X[rs1]) * unsigned(X[rs2])
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
 === Widening Multiply-Accumulate
 
+==== WMACC (RV32)
+
+Mnemonic::
+
+wmacc _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WMACC is encoded in the widening register-pair format with multiply-accumulate
+(RV32 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x5, attr: ['WMACC'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WMACC (RV32 only) performs a widening signed multiply-accumulate. It multiplies
+the full 32-bit signed values in `rs1` and `rs2`, producing a 64-bit signed
+product, and adds the product to the existing 64-bit value in register pair
+`rd_p`. The result is written back to register pair `rd_p`. If `rd_p` is 0,
+the result is discarded.
+
+Operation::
+
+[source,pseudocode]
+----
+// RV32 only
+// Load existing 64-bit accumulator from register pair
+d = if (rd_p == 0) then 0 else (X[rd_p*2+1] @ X[rd_p*2])
+
+// Widening signed multiply-accumulate: XLEN x XLEN -> 2*XLEN
+d = d + signed(X[rs1]) * signed(X[rs2])
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+
+<<<
 ==== PWMACC.H (RV32)
 
 Mnemonic::
@@ -31379,6 +31437,59 @@ Notes::
 * This instruction reads and writes the destination register pair.
 * If `rd_p=0`, the instruction does not write back; the upper accumulator input is
   treated as zero.
+
+<<<
+==== WMACCSU (RV32)
+
+Mnemonic::
+
+wmaccsu _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WMACCSU is encoded in a register-pair (rd_p) OP-IMM-32 format as an accumulating form
+of WMULSU.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0xd, attr: ['WMACCSU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+The WMACCSU instruction multiplies `rs1` (signed 32-bit) by `rs2` (unsigned
+32-bit) and accumulates the 64-bit product into the 64-bit accumulator stored in
+the destination register pair selected by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
+
+prod = to_bits(64, sext_64(X[rs1]) * zext_64(X[rs2]))
+acc  = acc + prod
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc[31:0]
+    X[2*rd_p+1] = acc[63:32]
+----
+
+Notes::
+
+* This instruction reads and writes the destination register pair.
+* If `rd_p=0`, the accumulator is treated as zero and no result is written back.
+
 
 <<<
 ==== PWMACCSU.H (RV32)
@@ -31438,6 +31549,57 @@ Notes::
   treated as zero.
 
 <<<
+==== WMACCU (RV32)
+
+Mnemonic::
+
+wmaccu _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+WMACCU is encoded in the widening register-pair format with unsigned
+multiply-accumulate (RV32 only).
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x1 },
+    { bits: 4, name: 0x7, attr: ['WMACCU'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+WMACCU (RV32 only) performs a widening unsigned multiply-accumulate. It
+multiplies the full 32-bit unsigned values in `rs1` and `rs2`, producing a
+64-bit unsigned product, and adds the product to the existing 64-bit value in
+register pair `rd_p`. The result is written back to register pair `rd_p`. If
+`rd_p` is 0, the result is discarded.
+
+Operation::
+
+[source,pseudocode]
+----
+// RV32 only
+// Load existing 64-bit accumulator from register pair
+d = if (rd_p == 0) then 0 else (X[rd_p*2+1] @ X[rd_p*2])
+
+// Widening unsigned multiply-accumulate: XLEN x XLEN -> 2*XLEN
+d = d + unsigned(X[rs1]) * unsigned(X[rs2])
+
+if (rd_p != 0):
+    X[rd_p*2]   = d[31:0]
+    X[rd_p*2+1] = d[63:32]
+----
+
+<<<
 ==== PWMACCU.H (RV32)
 
 Mnemonic::
@@ -31494,17 +31656,20 @@ Notes::
 * If `rd_p=0`, the instruction does not write back; the upper accumulator input is
   treated as zero.
 
+
 <<<
-==== WMACC (RV32)
+=== Widening Q-format Multiply-Accumulate
+
+==== MQWACC (RV32)
 
 Mnemonic::
 
-wmacc _rd_p_, _rs1_, _rs2_
+mqwacc _rd_p_, _rs1_, _rs2_
 
 Encoding::
 
-WMACC is encoded in the widening register-pair format with multiply-accumulate
-(RV32 only).
+MQWACC is encoded in a register-pair (rd_p) OP-IMM-32 format and accumulates into the
+64-bit destination register pair selected by `rd_p`.
 
 [wavedrom, ,svg]
 ....
@@ -31516,68 +31681,17 @@ WMACC is encoded in the widening register-pair format with multiply-accumulate
     { bits: 5, name: 'rs1' },
     { bits: 5, name: 'rs2' },
     { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x5, attr: ['WMACC'] },
+    { bits: 4, name: 0xf, attr: ['MQWACC'] },
     { bits: 1, name: 0x0 },
 ]}
 ....
 
 Description::
 
-WMACC (RV32 only) performs a widening signed multiply-accumulate. It multiplies
-the full 32-bit signed values in `rs1` and `rs2`, producing a 64-bit signed
-product, and adds the product to the existing 64-bit value in register pair
-`rd_p`. The result is written back to register pair `rd_p`. If `rd_p` is 0,
-the result is discarded.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV32 only
-// Load existing 64-bit accumulator from register pair
-d = if (rd_p == 0) then 0 else (X[rd_p*2+1] @ X[rd_p*2])
-
-// Widening signed multiply-accumulate: XLEN x XLEN -> 2*XLEN
-d = d + signed(X[rs1]) * signed(X[rs2])
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
-
-<<<
-==== WMACCSU (RV32)
-
-Mnemonic::
-
-wmaccsu _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WMACCSU is encoded in a register-pair (rd_p) OP-IMM-32 format as an accumulating form
-of WMULSU.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xd, attr: ['WMACCSU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-The WMACCSU instruction multiplies `rs1` (signed 32-bit) by `rs2` (unsigned
-32-bit) and accumulates the 64-bit product into the 64-bit accumulator stored in
-the destination register pair selected by `rd_p`.
+The MQWACC instruction multiplies `rs1` and `rs2` as signed 32-bit integers,
+takes the product shifted right by 31 (i.e., bits [94:31] of the sign-extended
+wide product), and accumulates the 64-bit term into the destination register
+pair selected by `rd_p`.
 
 Operation::
 
@@ -31585,8 +31699,12 @@ Operation::
 ----
 acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
 
-prod = to_bits(64, sext_64(X[rs1]) * zext_64(X[rs2]))
-acc  = acc + prod
+a = sext_95(X[rs1])                                 // XLEN=32 signed
+b = sext_95(X[rs2])
+p = a * b                                           // conceptually wide
+term = to_bits(95, p)[94:31]                        // arithmetic >> 31
+
+acc = acc + term
 
 if (rd_p != 0):
     X[2*rd_p]   = acc[31:0]
@@ -31595,65 +31713,11 @@ if (rd_p != 0):
 
 Notes::
 
-* This instruction reads and writes the destination register pair.
-* If `rd_p=0`, the accumulator is treated as zero and no result is written back.
-
-
-<<<
-==== WMACCU (RV32)
-
-Mnemonic::
-
-wmaccu _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-WMACCU is encoded in the widening register-pair format with unsigned
-multiply-accumulate (RV32 only).
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0x7, attr: ['WMACCU'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-WMACCU (RV32 only) performs a widening unsigned multiply-accumulate. It
-multiplies the full 32-bit unsigned values in `rs1` and `rs2`, producing a
-64-bit unsigned product, and adds the product to the existing 64-bit value in
-register pair `rd_p`. The result is written back to register pair `rd_p`. If
-`rd_p` is 0, the result is discarded.
-
-Operation::
-
-[source,pseudocode]
-----
-// RV32 only
-// Load existing 64-bit accumulator from register pair
-d = if (rd_p == 0) then 0 else (X[rd_p*2+1] @ X[rd_p*2])
-
-// Widening unsigned multiply-accumulate: XLEN x XLEN -> 2*XLEN
-d = d + unsigned(X[rs1]) * unsigned(X[rs2])
-
-if (rd_p != 0):
-    X[rd_p*2]   = d[31:0]
-    X[rd_p*2+1] = d[63:32]
-----
-
+* If `rd_p=0`, the accumulator is treated as zero and the result is not written
+  back.
+* The destination is a register pair `{X[2*rd_p+1], X[2*rd_p]}`.
 
 <<<
-=== Widening Q-format Multiply-Accumulate
-
 ==== PMQWACC.H (RV32)
 
 Mnemonic::
@@ -31718,6 +31782,63 @@ Notes::
 * The destination is a register pair `{X[2*rd_p+1], X[2*rd_p]}`.
 
 <<<
+==== MQRWACC (RV32)
+
+Mnemonic::
+
+mqrwacc _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+MQRWACC is encoded in the same register-pair (rd_p) OP-IMM-32 format as MQWACC, but
+uses the rounded variant.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xf, attr: ['MQRWACC'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+MQRWACC is the rounded form of MQWACC. It adds a rounding bias of 2^30^ before
+taking the product shifted right by 31, then accumulates the 64-bit term into
+the destination register pair selected by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
+
+a = sext_95(X[rs1])
+b = sext_95(X[rs2])
+p = a * b + (1 << 30)                               // rounding bias
+term = to_bits(95, p)[94:31]                        // arithmetic >> 31
+
+acc = acc + term
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc[31:0]
+    X[2*rd_p+1] = acc[63:32]
+----
+
+Notes::
+
+* If `rd_p=0`, the accumulator is treated as zero and the result is not written
+  back.
+* The destination is a register pair `{X[2*rd_p+1], X[2*rd_p]}`.
+
+<<<
 ==== PMQRWACC.H (RV32)
 
 Mnemonic::
@@ -31765,121 +31886,6 @@ for i = 0 .. 1:
     p = a * b + (1 << 14)                           // rounding bias
     hi = to_bits(47, p)[46:15]
     acc[(32*i+31):(32*i)] = acc[(32*i+31):(32*i)] + hi
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc[31:0]
-    X[2*rd_p+1] = acc[63:32]
-----
-
-Notes::
-
-* If `rd_p=0`, the accumulator is treated as zero and the result is not written
-  back.
-* The destination is a register pair `{X[2*rd_p+1], X[2*rd_p]}`.
-
-<<<
-==== MQWACC (RV32)
-
-Mnemonic::
-
-mqwacc _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-MQWACC is encoded in a register-pair (rd_p) OP-IMM-32 format and accumulates into the
-64-bit destination register pair selected by `rd_p`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x1 },
-    { bits: 4, name: 0xf, attr: ['MQWACC'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-The MQWACC instruction multiplies `rs1` and `rs2` as signed 32-bit integers,
-takes the product shifted right by 31 (i.e., bits [94:31] of the sign-extended
-wide product), and accumulates the 64-bit term into the destination register
-pair selected by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
-
-a = sext_95(X[rs1])                                 // XLEN=32 signed
-b = sext_95(X[rs2])
-p = a * b                                           // conceptually wide
-term = to_bits(95, p)[94:31]                        // arithmetic >> 31
-
-acc = acc + term
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc[31:0]
-    X[2*rd_p+1] = acc[63:32]
-----
-
-Notes::
-
-* If `rd_p=0`, the accumulator is treated as zero and the result is not written
-  back.
-* The destination is a register pair `{X[2*rd_p+1], X[2*rd_p]}`.
-
-<<<
-==== MQRWACC (RV32)
-
-Mnemonic::
-
-mqrwacc _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-MQRWACC is encoded in the same register-pair (rd_p) OP-IMM-32 format as MQWACC, but
-uses the rounded variant.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xf, attr: ['MQRWACC'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-MQRWACC is the rounded form of MQWACC. It adds a rounding bias of 2^30^ before
-taking the product shifted right by 31, then accumulates the 64-bit term into
-the destination register pair selected by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
-
-a = sext_95(X[rs1])
-b = sext_95(X[rs2])
-p = a * b + (1 << 30)                               // rounding bias
-term = to_bits(95, p)[94:31]                        // arithmetic >> 31
-
-acc = acc + term
 
 if (rd_p != 0):
     X[2*rd_p]   = acc[31:0]
@@ -32002,6 +32008,164 @@ if (rd_p != 0):
 
 
 <<<
+==== PM2WADDU.H (RV32)
+
+Mnemonic::
+
+pm2waddu.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PM2WADDU.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It performs
+unsigned×unsigned halfword multiplications and writes a 64-bit sum to the
+register pair selected by `rd_p` when `rd_p != 0`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x4, attr: ['PM2WADDU.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PM2WADDU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and `rs2`,
+sums the two 64-bit products, and writes the 64-bit result to the destination
+register pair selected by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+p0 = to_bits(64, zext_64(s1[15:0])  * zext_64(s2[15:0]))
+p1 = to_bits(64, zext_64(s1[31:16]) * zext_64(s2[31:16]))
+d  = p0 + p1
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
+==== PM2WADD.HX (RV32)
+
+Mnemonic::
+
+pm2wadd.hx _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PM2WADD.HX is encoded in a register-pair (rd_p) OP-IMM-32 format. It uses cross
+halfword products (h0×h1 and h1×h0) and writes a 64-bit sum to the register pair
+selected by `rd_p` when `rd_p != 0`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x2, attr: ['PM2WADD.HX'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PM2WADD.HX multiplies the low halfword of `rs1` by the high halfword of `rs2` and
+the high halfword of `rs1` by the low halfword of `rs2` (both signed), sums the
+two 64-bit products, and writes the 64-bit result to the destination register
+pair selected by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+p0 = to_bits(64, sext_64(s1[15:0])  * sext_64(s2[31:16]))
+p1 = to_bits(64, sext_64(s1[31:16]) * sext_64(s2[15:0]))
+d  = p0 + p1
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
+==== PM2WADDA.H (RV32)
+
+Mnemonic::
+
+pm2wadda.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PM2WADDA.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an
+accumulating form of PM2WADD.H.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x1, attr: ['PM2WADDA.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PM2WADDA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`
+(halfword0*halfword0 and halfword1*halfword1), sums the two 64-bit products, and
+accumulates the sum into the 64-bit accumulator held in the destination register
+pair selected by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+// Read accumulator from register pair; treat as zero when rd_p=0
+acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
+
+p0 = to_bits(64, sext_64(s1[15:0])  * sext_64(s2[15:0]))
+p1 = to_bits(64, sext_64(s1[31:16]) * sext_64(s2[31:16]))
+
+acc = acc + p0 + p1
+
+if (rd_p != 0):
+    X[2*rd_p]   = acc[31:0]
+    X[2*rd_p+1] = acc[63:32]
+----
+
+
+<<<
 ==== PM2WADDASU.H (RV32)
 
 Mnemonic::
@@ -32057,57 +32221,6 @@ Notes::
 
 * This instruction reads and writes the destination register pair.
 * If `rd_p=0`, the accumulator is treated as zero and no result is written back.
-
-<<<
-==== PM2WADDU.H (RV32)
-
-Mnemonic::
-
-pm2waddu.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PM2WADDU.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It performs
-unsigned×unsigned halfword multiplications and writes a 64-bit sum to the
-register pair selected by `rd_p` when `rd_p != 0`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x4, attr: ['PM2WADDU.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PM2WADDU.H multiplies corresponding unsigned 16-bit halfwords of `rs1` and `rs2`,
-sums the two 64-bit products, and writes the 64-bit result to the destination
-register pair selected by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-p0 = to_bits(64, zext_64(s1[15:0])  * zext_64(s2[15:0]))
-p1 = to_bits(64, zext_64(s1[31:16]) * zext_64(s2[31:16]))
-d  = p0 + p1
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
 
 <<<
 ==== PM2WADDAU.H (RV32)
@@ -32167,216 +32280,6 @@ Notes::
 * If `rd_p=0`, the accumulator is treated as zero and no result is written back.
 
 <<<
-==== PM2WADD.HX (RV32)
-
-Mnemonic::
-
-pm2wadd.hx _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PM2WADD.HX is encoded in a register-pair (rd_p) OP-IMM-32 format. It uses cross
-halfword products (h0×h1 and h1×h0) and writes a 64-bit sum to the register pair
-selected by `rd_p` when `rd_p != 0`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x2, attr: ['PM2WADD.HX'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PM2WADD.HX multiplies the low halfword of `rs1` by the high halfword of `rs2` and
-the high halfword of `rs1` by the low halfword of `rs2` (both signed), sums the
-two 64-bit products, and writes the 64-bit result to the destination register
-pair selected by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-p0 = to_bits(64, sext_64(s1[15:0])  * sext_64(s2[31:16]))
-p1 = to_bits(64, sext_64(s1[31:16]) * sext_64(s2[15:0]))
-d  = p0 + p1
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== PM2WSUB.H (RV32)
-
-Mnemonic::
-
-pm2wsub.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PM2WSUB.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It subtracts the
-high-halfword product from the low-halfword product and writes a 64-bit result to
-the register pair selected by `rd_p` when `rd_p != 0`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x8, attr: ['PM2WSUB.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PM2WSUB.H multiplies corresponding signed halfwords of `rs1` and `rs2` and
-computes (low×low) minus (high×high), writing the 64-bit result to the register
-pair selected by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-p0 = to_bits(64, sext_64(s1[15:0])  * sext_64(s2[15:0]))
-p1 = to_bits(64, sext_64(s1[31:16]) * sext_64(s2[31:16]))
-d  = p0 - p1
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-<<<
-==== PM2WSUB.HX (RV32)
-
-Mnemonic::
-
-pm2wsub.hx _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PM2WSUB.HX is encoded in a register-pair (rd_p) OP-IMM-32 format. It uses cross
-halfword products (h0×h1 and h1×h0) and writes the 64-bit difference to the
-register pair selected by `rd_p` when `rd_p != 0`.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0xa, attr: ['PM2WSUB.HX'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PM2WSUB.HX multiplies cross halfword pairs and computes (h0 of `rs1` × h1 of
-`rs2`) minus (h1 of `rs1` × h0 of `rs2`), writing the 64-bit result to the
-destination register pair selected by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-p0 = to_bits(64, sext_64(s1[15:0])  * sext_64(s2[31:16]))
-p1 = to_bits(64, sext_64(s1[31:16]) * sext_64(s2[15:0]))
-d  = p0 - p1
-
-if (rd_p != 0):
-    X[2*rd_p]   = d[31:0]
-    X[2*rd_p+1] = d[63:32]
-----
-
-
-
-<<<
-==== PM2WADDA.H (RV32)
-
-Mnemonic::
-
-pm2wadda.h _rd_p_, _rs1_, _rs2_
-
-Encoding::
-
-PM2WADDA.H is encoded in a register-pair (rd_p) OP-IMM-32 format as an
-accumulating form of PM2WADD.H.
-
-[wavedrom, ,svg]
-....
-{reg:[
-    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
-    { bits: 1, name: 0x1 },
-    { bits: 4, name: 'rd_p' },
-    { bits: 3, name: 0x2 },
-    { bits: 5, name: 'rs1' },
-    { bits: 5, name: 'rs2' },
-    { bits: 2, name: 0x3 },
-    { bits: 4, name: 0x1, attr: ['PM2WADDA.H'] },
-    { bits: 1, name: 0x0 },
-]}
-....
-
-Description::
-
-PM2WADDA.H multiplies corresponding signed 16-bit halfwords of `rs1` and `rs2`
-(halfword0*halfword0 and halfword1*halfword1), sums the two 64-bit products, and
-accumulates the sum into the 64-bit accumulator held in the destination register
-pair selected by `rd_p`.
-
-Operation::
-
-[source,pseudocode]
-----
-s1 = X[rs1]
-s2 = X[rs2]
-
-// Read accumulator from register pair; treat as zero when rd_p=0
-acc = (rd_p == 0) ? 0 : (X[2*rd_p+1] @ X[2*rd_p])
-
-p0 = to_bits(64, sext_64(s1[15:0])  * sext_64(s2[15:0]))
-p1 = to_bits(64, sext_64(s1[31:16]) * sext_64(s2[31:16]))
-
-acc = acc + p0 + p1
-
-if (rd_p != 0):
-    X[2*rd_p]   = acc[31:0]
-    X[2*rd_p+1] = acc[63:32]
-----
-
-
-<<<
 ==== PM2WADDA.HX (RV32)
 
 Mnemonic::
@@ -32432,6 +32335,57 @@ if (rd_p != 0):
 
 
 <<<
+==== PM2WSUB.H (RV32)
+
+Mnemonic::
+
+pm2wsub.h _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PM2WSUB.H is encoded in a register-pair (rd_p) OP-IMM-32 format. It subtracts the
+high-halfword product from the low-halfword product and writes a 64-bit result to
+the register pair selected by `rd_p` when `rd_p != 0`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0x8, attr: ['PM2WSUB.H'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PM2WSUB.H multiplies corresponding signed halfwords of `rs1` and `rs2` and
+computes (low×low) minus (high×high), writing the 64-bit result to the register
+pair selected by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+p0 = to_bits(64, sext_64(s1[15:0])  * sext_64(s2[15:0]))
+p1 = to_bits(64, sext_64(s1[31:16]) * sext_64(s2[31:16]))
+d  = p0 - p1
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
+
+<<<
 ==== PM2WSUBA.H (RV32)
 
 Mnemonic::
@@ -32483,6 +32437,58 @@ if (rd_p != 0):
     X[2*rd_p]   = acc[31:0]
     X[2*rd_p+1] = acc[63:32]
 ----
+
+
+<<<
+==== PM2WSUB.HX (RV32)
+
+Mnemonic::
+
+pm2wsub.hx _rd_p_, _rs1_, _rs2_
+
+Encoding::
+
+PM2WSUB.HX is encoded in a register-pair (rd_p) OP-IMM-32 format. It uses cross
+halfword products (h0×h1 and h1×h0) and writes the 64-bit difference to the
+register pair selected by `rd_p` when `rd_p != 0`.
+
+[wavedrom, ,svg]
+....
+{reg:[
+    { bits: 7, name: 0x1b, attr: ['OP-IMM-32'] },
+    { bits: 1, name: 0x1 },
+    { bits: 4, name: 'rd_p' },
+    { bits: 3, name: 0x2 },
+    { bits: 5, name: 'rs1' },
+    { bits: 5, name: 'rs2' },
+    { bits: 2, name: 0x3 },
+    { bits: 4, name: 0xa, attr: ['PM2WSUB.HX'] },
+    { bits: 1, name: 0x0 },
+]}
+....
+
+Description::
+
+PM2WSUB.HX multiplies cross halfword pairs and computes (h0 of `rs1` × h1 of
+`rs2`) minus (h1 of `rs1` × h0 of `rs2`), writing the 64-bit result to the
+destination register pair selected by `rd_p`.
+
+Operation::
+
+[source,pseudocode]
+----
+s1 = X[rs1]
+s2 = X[rs2]
+
+p0 = to_bits(64, sext_64(s1[15:0])  * sext_64(s2[31:16]))
+p1 = to_bits(64, sext_64(s1[31:16]) * sext_64(s2[15:0]))
+d  = p0 - p1
+
+if (rd_p != 0):
+    X[2*rd_p]   = d[31:0]
+    X[2*rd_p+1] = d[63:32]
+----
+
 
 
 <<<


### PR DESCRIPTION
Group all the operation that do the same thing on different element sizes or register widths.

The order within each group is: scalar version, XLEN-sized packed verison, XLEN*2-sized packed version.

I've split PMQ2ADD and PMQR2ADD into their own section.

We probably want to review the order and names of sections soon.