### PR TITLE
Fixing MQRACC.H00 section (to be displayed properly in ToC)

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -24650,6 +24650,7 @@ Notes::
 
 * This instruction reads and writes `rd`.
 * Rounding is performed by adding 2^14^.
+
 <<<
 ==== MQRACC.H00 (RV32)
 


### PR DESCRIPTION
ToC discrepancy discovered by @bradwu-sifive

I believe there was a missing newline between the previous list and the `MQRACC.H00` section.