### PR TITLE
Fix RV32 instruction sequence for exchanged add/sub i32x2 intrinsics

### DIFF
--- a/P-ext-intrinsics.adoc
+++ b/P-ext-intrinsics.adoc
@@ -1050,27 +1050,27 @@ Adds a scalar to every element of a packed value.
 
 | `int32x2_t __riscv_pas_x_i32x2(int32x2_t rs1, int32x2_t rs2);`
 | `pas.wx`(RV64), +
-  `pas.wx`+`pas.wx`(RV32)
+  `add`+`sub`(RV32)
 
 | `int32x2_t __riscv_psa_x_i32x2(int32x2_t rs1, int32x2_t rs2);`
 | `psa.wx`(RV64), +
-  `psa.wx`+`psa.wx`(RV32)
+  `add`+`sub`(RV32)
 
 | `int32x2_t __riscv_psas_x_i32x2(int32x2_t rs1, int32x2_t rs2);`
 | `psas.wx`(RV64), +
-  `psas.wx`+`psas.wx`(RV32)
+  `sadd`+`ssub`(RV32)
 
 | `int32x2_t __riscv_pssa_x_i32x2(int32x2_t rs1, int32x2_t rs2);`
 | `pssa.wx`(RV64), +
-  `pssa.wx`+`pssa.wx`(RV32)
+  `sadd`+`ssub`(RV32)
 
 | `int32x2_t __riscv_paas_x_i32x2(int32x2_t rs1, int32x2_t rs2);`
 | `paas.wx`(RV64), +
-  `paas.wx`+`paas.wx`(RV32)
+  `aadd`+`asub`(RV32)
 
 | `int32x2_t __riscv_pasa_x_i32x2(int32x2_t rs1, int32x2_t rs2);`
 | `pasa.wx`(RV64), +
-  `pasa.wx`+`pasa.wx`(RV32)
+  `aadd`+`asub`(RV32)
 |===
 
 


### PR DESCRIPTION
`PAS/PSA/PSAS/PSSA/PAAS/PASA.WX` are RV64-only. Replace the RV32 lowering of the `*_x_i32x2` intrinsics with the equivalent scalar ops:

| intrinsic | RV32 |
|---|---|
| `pas_x` / `psa_x`   | `add` + `sub`   |
| `psas_x` / `pssa_x` | `sadd` + `ssub` |
| `paas_x` / `pasa_x` | `aadd` + `asub` |