### PR TITLE
Rename RV64 PWCVT and PNCVT pseudo-instructions.

### DIFF
--- a/P-ext-intrinsics.adoc
+++ b/P-ext-intrinsics.adoc
@@ -2298,29 +2298,35 @@ __riscv_psshlr_s_u32x2(uint32x2_t rs1, int shamt);
 
 | `int16x4_t __riscv_pwcvt_i16x4(int8x4_t rs1);`
 | `pwcvt.b`(RV32), +
-  `pwcvtu.b`+`psext.h.b`(RV64)
+  `pwcvtu.wb`+`psext.h.b`(RV64)
 
 | `int32x2_t __riscv_pwcvt_i32x2(int16x2_t rs1);`
 | `pwcvt.h`(RV32), +
-  `pwcvtu.h`+`psext.w.h`(RV64)
+  `pwcvtu.wh`+`psext.w.h`(RV64)
 
 | `uint16x4_t __riscv_pwcvtu_u16x4(uint8x4_t rs1);`
-| `pwcvtu.b`
+| `pwcvtu.b`(RV32), +
+  `pwcvtu.wb`(RV64)
 
 | `uint32x2_t __riscv_pwcvtu_u32x2(uint16x2_t rs1);`
-| `pwcvtu.h`
+| `pwcvtu.h`(RV32), +
+  `pwcvtu.wh`(RV64)
 
 | `int16x4_t __riscv_pwcvth_i16x4(int8x4_t rs1);`
-| `pwcvth.b`
+| `pwcvth.b`(RV32), +
+  `pwcvth.wb`(RV64)
 
 | `uint16x4_t __riscv_pwcvth_u16x4(uint8x4_t rs1);`
-| `pwcvth.b`
+| `pwcvth.b`(RV32), +
+  `pwcvth.wb`(RV64)
 
 | `int32x2_t __riscv_pwcvth_i32x2(int16x2_t rs1);`
-| `pwcvth.h`
+| `pwcvth.h`(RV32), +
+  `pwcvth.wh`(RV64)
 
 | `uint32x2_t __riscv_pwcvth_u32x2(uint16x2_t rs1);`
-| `pwcvth.h`
+| `pwcvth.h`(RV32), +
+  `pwcvth.wh`(RV64)
 |===
 
 
@@ -2333,28 +2339,36 @@ __riscv_psshlr_s_u32x2(uint32x2_t rs1, int shamt);
 | Instruction
 
 | `int8x4_t __riscv_pncvt_i8x4(int16x4_t rs1);`
-| `pncvt.b`
+| `pncvt.b`(RV32), +
+  `pncvt.wb`(RV64)
 
 | `uint8x4_t __riscv_pncvt_u8x4(uint16x4_t rs1);`
-| `pncvt.b`
+| `pncvt.b`(RV32), +
+  `pncvt.wb`(RV64)
 
 | `int16x2_t __riscv_pncvt_i16x2(int32x2_t rs1);`
-| `pncvt.h`
+| `pncvt.h`(RV32), +
+  `pncvt.wh`(RV64)
 
 | `uint16x2_t __riscv_pncvt_u16x2(uint32x2_t rs1);`
-| `pncvt.h`
+| `pncvt.h`(RV32), +
+  `pncvt.wh`(RV64)
 
 | `int8x4_t __riscv_pncvth_i8x4(int16x4_t rs1);`
-| `pncvth.b`
+| `pncvth.b`(RV32), +
+  `pncvth.wb`(RV64)
 
 | `uint8x4_t __riscv_pncvth_u8x4(uint16x4_t rs1);`
-| `pncvth.b`
+| `pncvth.b`(RV32), +
+  `pncvth.wb`(RV64)
 
 | `int16x2_t __riscv_pncvth_i16x2(int32x2_t rs1);`
-| `pncvth.h`
+| `pncvth.h`(RV32), +
+  `pncvth.wh`(RV64)
 
 | `uint16x2_t __riscv_pncvth_u16x2(uint32x2_t rs1);`
-| `pncvth.h`
+| `pncvth.h`(RV32), +
+  `pncvth.wh`(RV64)
 |===
 
 
@@ -2393,28 +2407,36 @@ __riscv_psshlr_s_u32x2(uint32x2_t rs1, int shamt);
 | Instruction
 
 | `int8x4_t __riscv_punzipe_i8x4(int8x8_t rs1);`
-| `pncvt.b`
+| `pncvt.b`(RV32), +
+  `pncvt.wb`(RV64)
 
 | `int8x4_t __riscv_punzipo_i8x4(int8x8_t rs1);`
-| `pncvth.b`
+| `pncvth.b`(RV32), +
+  `pncvth.wb`(RV64)
 
 | `uint8x4_t __riscv_punzipe_u8x4(uint8x8_t rs1);`
-| `pncvt.b`
+| `pncvt.b`(RV32), +
+  `pncvt.wb`(RV64)
 
 | `uint8x4_t __riscv_punzipo_u8x4(uint8x8_t rs1);`
-| `pncvth.b`
+| `pncvth.b`(RV32), +
+  `pncvth.wb`(RV64)
 
 | `int16x2_t __riscv_punzipe_i16x2(int16x4_t rs1);`
-| `pncvt.h`
+| `pncvt.h`(RV32), +
+  `pncvt.wh`(RV64)
 
 | `int16x2_t __riscv_punzipo_i16x2(int16x4_t rs1);`
-| `pncvth.h`
+| `pncvth.h`(RV32), +
+  `pncvth.wh`(RV64)
 
 | `uint16x2_t __riscv_punzipe_u16x2(uint16x4_t rs1);`
-| `pncvt.h`
+| `pncvt.h`(RV32), +
+  `pncvt.wh`(RV64)
 
 | `uint16x2_t __riscv_punzipo_u16x2(uint16x4_t rs1);`
-| `pncvth.h`
+| `pncvth.h`(RV32), +
+  `pncvth.wh`(RV64)
 |===
 
 
@@ -2602,7 +2624,7 @@ l|
 uint16x4_t
 __riscv_pwaddu_u16x4(uint8x4_t rs1, uint8x4_t rs2);
 | `pwaddu.b`(RV32), +
-  `pwcvtu.b`\+`pwcvtu.b`+`padd.h`(RV64)
+  `pwcvtu.wb`\+`pwcvtu.wb`+`padd.h`(RV64)
 
 l|
 uint32x2_t
@@ -2626,13 +2648,13 @@ l|
 uint16x4_t
 __riscv_pwsubu_u16x4(uint8x4_t rs1, uint8x4_t rs2);
 | `pwsubu.b`(RV32), +
-  `pwcvtu.b`\+`pwcvtu.b`+`psub.h`(RV64)
+  `pwcvtu.wb`\+`pwcvtu.wb`+`psub.h`(RV64)
 
 l|
 uint32x2_t
 __riscv_pwsubu_u32x2(uint16x2_t rs1, uint16x2_t rs2);
 | `pwsubu.h`(RV32), +
-  `pwcvtu.h`\+`pwcvtu.h`+`psub.w`(RV64)
+  `pwcvtu.wh`\+`pwcvtu.wh`+`psub.w`(RV64)
 |===
 
 
@@ -2668,7 +2690,7 @@ __riscv_pwaddau_u16x4(uint16x4_t rd,
                       uint8x4_t rs1,
                       uint8x4_t rs2);
 | `pwaddau.b`(RV32), +
-  `pwcvtu.b`\+`pwcvtu.b`+`padd.h`+`padd.h`(RV64)
+  `pwcvtu.wb`\+`pwcvtu.wb`+`padd.h`+`padd.h`(RV64)
 
 l|
 uint32x2_t
@@ -2700,7 +2722,7 @@ __riscv_pwsubau_u16x4(uint16x4_t rd,
                       uint8x4_t rs1,
                       uint8x4_t rs2);
 | `pwsubau.b`(RV32), +
-  `pwcvtu.b`\+`pwcvtu.b`+`psub.h`+`padd.h`(RV64)
+  `pwcvtu.wb`\+`pwcvtu.wb`+`psub.h`+`padd.h`(RV64)
 
 l|
 uint32x2_t
@@ -2708,7 +2730,7 @@ __riscv_pwsubau_u32x2(uint32x2_t rd,
                       uint16x2_t rs1,
                       uint16x2_t rs2);
 | `pwsubau.h`(RV32), +
-  `pwcvtu.h`\+`pwcvtu.h`+`psub.w`+`padd.w`(RV64)
+  `pwcvtu.wh`\+`pwcvtu.wh`+`psub.w`+`padd.w`(RV64)
 |===
 
 
@@ -2724,31 +2746,31 @@ l|
 uint16x4_t
 __riscv_pwsll_s_u16x4(uint8x4_t rs1, unsigned shamt);
 | `pwslli.b`, `pwsll.bs`(RV32), +
-  `pwcvtu.b`\+`pslli.h`, +
-  `pwcvtu.b`+`psll.hs`(RV64)
+  `pwcvtu.wb`\+`pslli.h`, +
+  `pwcvtu.wb`+`psll.hs`(RV64)
 
 l|
 uint32x2_t
 __riscv_pwsll_s_u32x2(uint16x2_t rs1, unsigned shamt);
 | `pwslli.h`, `pwsll.hs`(RV32), +
-  `pwcvtu.h`\+`pslli.w`, +
-  `pwcvtu.h`+`psll.ws`(RV64)
+  `pwcvtu.wh`\+`pslli.w`, +
+  `pwcvtu.wh`+`psll.ws`(RV64)
 
 l|
 int16x4_t
 __riscv_pwsla_s_i16x4(int8x4_t rs1, unsigned shamt);
 | `pwslai.b`, `pwsla.bs`(RV32), +
-  `pwcvth.b`\+`psrai.h`, +
-  `pwcvth.b`+`pslli.h`, +
-  `pwcvtu.b`\+`psext.h.b`+`psll.hs`(RV64)
+  `pwcvth.wb`\+`psrai.h`, +
+  `pwcvth.wb`+`pslli.h`, +
+  `pwcvtu.wb`\+`psext.h.b`+`psll.hs`(RV64)
 
 l|
 int32x2_t
 __riscv_pwsla_s_i32x2(int16x2_t rs1, unsigned shamt);
 | `pwslai.h`, `pwsla.hs`(RV32), +
-  `pwcvth.h`\+`psrai.w`, +
-  `pwcvth.h`+`pslli.w`, +
-  `pwcvtu.h`\+`psext.w.h`+`psll.ws`(RV64)
+  `pwcvth.wh`\+`psrai.w`, +
+  `pwcvth.wh`+`pslli.w`, +
+  `pwcvtu.wh`\+`psext.w.h`+`psll.ws`(RV64)
 |===
 
 
@@ -4391,13 +4413,13 @@ l|
 int16x4_t
 __riscv_pwmulsu_i16x4(int8x4_t rs1, uint8x4_t rs2);
 | `pwmulsu.b`(RV32), +
-  `pwcvtu.b`\+`pwcvtu.b`+`pmulsu.h.b00`(RV64)
+  `pwcvtu.wb`\+`pwcvtu.wb`+`pmulsu.h.b00`(RV64)
 
 l|
 int32x2_t
 __riscv_pwmulsu_i32x2(int16x2_t rs1, uint16x2_t rs2);
 | `pwmulsu.h`(RV32), +
-  `pwcvtu.h`\+`pwcvtu.h`+`pmulsu.w.h00`(RV64)
+  `pwcvtu.wh`\+`pwcvtu.wh`+`pmulsu.w.h00`(RV64)
 |===
 
 
@@ -4433,7 +4455,7 @@ __riscv_pwmaccsu_i32x2(int32x2_t rd,
                        int16x2_t rs1,
                        uint16x2_t rs2);
 | `pwmaccsu.h`(RV32), +
-  `pwcvtu.h`\+`pwcvtu.h`+`zip16p`+`pmaccsu.w.h00`(RV64)
+  `pwcvtu.wh`\+`pwcvtu.wh`+`zip16p`+`pmaccsu.w.h00`(RV64)
 |===
 
 

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -16706,8 +16706,15 @@ zip8p _rd_, _rs1_, _rs2_
 
 Pseudoinstructions::
 
-pwcvtu.b _rd_, _rs1_ &#8594; zip8p _rd_, _rs1_, x0 +
-pwcvth.b _rd_, _rs2_ &#8594; zip8p _rd_, x0, _rs2_
+pwcvtu.wb _rd_, _rs1_ &#8594; zip8p _rd_, _rs1_, x0 +
+pwcvth.wb _rd_, _rs2_ &#8594; zip8p _rd_, x0, _rs2_
+
+NOTE: The `.WB` and `.WH` suffixes are used for these RV64
+pseudo-instructions because the source or destination is a word-sized packed
+vector held in the low 32 bits of a 64-bit register.  This avoids using the
+bare RV64 `PWCVT*` and `PNCVT*` names, leaving them available for possible
+future RV64 extensions that provide true register-pair widening or narrowing
+operations.
 
 Encoding::
 
@@ -16799,8 +16806,8 @@ zip16p _rd_, _rs1_, _rs2_
 
 Pseudoinstructions::
 
-pwcvtu.h _rd_, _rs1_ &#8594; zip16p _rd_, _rs1_, x0 +
-pwcvth.h _rd_, _rs2_ &#8594; zip16p _rd_, x0, _rs2_
+pwcvtu.wh _rd_, _rs1_ &#8594; zip16p _rd_, _rs1_, x0 +
+pwcvth.wh _rd_, _rs2_ &#8594; zip16p _rd_, x0, _rs2_
 
 Encoding::
 
@@ -16888,7 +16895,7 @@ unzip8p _rd_, _rs1_, _rs2_
 
 Pseudoinstructions::
 
-pncvt.b _rd_, _rs1_ &#8594; unzip8p _rd_, _rs1_, x0
+pncvt.wb _rd_, _rs1_ &#8594; unzip8p _rd_, _rs1_, x0
 
 Encoding::
 
@@ -16936,7 +16943,7 @@ unzip8hp _rd_, _rs1_, _rs2_
 
 Pseudoinstructions::
 
-pncvth.b _rd_, _rs1_ &#8594; unzip8hp _rd_, _rs1_, x0
+pncvth.wb _rd_, _rs1_ &#8594; unzip8hp _rd_, _rs1_, x0
 
 Encoding::
 
@@ -16984,7 +16991,7 @@ unzip16p _rd_, _rs1_, _rs2_
 
 Pseudoinstructions::
 
-pncvt.h _rd_, _rs1_ &#8594; unzip16p _rd_, _rs1_, x0
+pncvt.wh _rd_, _rs1_ &#8594; unzip16p _rd_, _rs1_, x0
 
 Encoding::
 
@@ -17030,7 +17037,7 @@ unzip16hp _rd_, _rs1_, _rs2_
 
 Pseudoinstructions::
 
-pncvth.h _rd_, _rs1_ &#8594; unzip16hp _rd_, _rs1_, x0
+pncvth.wh _rd_, _rs1_ &#8594; unzip16hp _rd_, _rs1_, x0
 
 Encoding::
 

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -393,6 +393,15 @@ distance. As with widening instructions, the appearance of the narrowing
 operation in the name (NSRL, NCLIPR, NSRAR) is the indication that the
 first source operand is a register pair.
 
+==== RV64 word-sized conversion pseudo-instructions
+
+NOTE: The `.WB` and `.WH` suffixes are used for these RV64
+pseudo-instructions because the source or destination is a word-sized packed
+vector held in the low 32 bits of a 64-bit register. This avoids using the
+bare RV64 `PWCVT*` and `PNCVT*` names, leaving them available for possible
+future RV64 extensions that provide true register-pair widening or narrowing
+operations.
+
 ==== Double-wide packed-SIMD instructions
 
 In addition to widening and narrowing instructions, other double-wide
@@ -16708,13 +16717,6 @@ Pseudoinstructions::
 
 pwcvtu.wb _rd_, _rs1_ &#8594; zip8p _rd_, _rs1_, x0 +
 pwcvth.wb _rd_, _rs2_ &#8594; zip8p _rd_, x0, _rs2_
-
-NOTE: The `.WB` and `.WH` suffixes are used for these RV64
-pseudo-instructions because the source or destination is a word-sized packed
-vector held in the low 32 bits of a 64-bit register.  This avoids using the
-bare RV64 `PWCVT*` and `PNCVT*` names, leaving them available for possible
-future RV64 extensions that provide true register-pair widening or narrowing
-operations.
 
 Encoding::
 


### PR DESCRIPTION
## Rationale

The original RV64 pseudo-instruction names used the bare `PWCVT*` and `PNCVT*` forms for operations that are implemented with ZIP/UNZIP-style instructions inside a 64-bit register.

John Hauser pointed out that these names would be better reserved for possible future RV64 packed-SIMD extensions that provide true register-pair widening or narrowing operations. The `.WB` and `.WH` suffixes make the current RV64 pseudo-instructions more explicit: the source or destination is a word-sized packed vector held in the low 32 bits of a 64-bit register.

https://lists.riscv.org/g/tech-p-ext/message/999

## Changes

Rename the RV64 ZIP/UNZIP-style `PWCVT` and `PNCVT` pseudo-instructions to use the new `.WB` and `.WH` suffixes suggested by John Hauser.

The renamed RV64 pseudo-instructions are:

```text
PWCVTU.B  -> PWCVTU.WB
PWCVTH.B  -> PWCVTH.WB
PWCVTU.H  -> PWCVTU.WH
PWCVTH.H  -> PWCVTH.WH

PNCVT.B   -> PNCVT.WB
PNCVTH.B  -> PNCVTH.WB
PNCVT.H   -> PNCVT.WH
PNCVTH.H  -> PNCVTH.WH
```

The real instruction expansions remain unchanged:

```text
PWCVTU.WB  -> ZIP8P
PWCVTH.WB  -> ZIP8P
PWCVTU.WH  -> ZIP16P
PWCVTH.WH  -> ZIP16P

PNCVT.WB   -> UNZIP8P
PNCVTH.WB  -> UNZIP8HP
PNCVT.WH   -> UNZIP16P
PNCVTH.WH  -> UNZIP16HP
```