### PR TITLE
Add RV32 MVD pseudo-instruction.

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -1371,6 +1371,10 @@ Mnemonic::
 
 padd.dw _rd_p_, _rs1_p_, _rs2_p_
 
+Pseudoinstructions::
+
+mvd _rd_p_, _rs_p_ &#8594; padd.dw _rd_p_, zero, _rs_p_
+
 Encoding::
 
 PADD.DW is encoded in the OP-IMM-32 major opcode using the double-wide


### PR DESCRIPTION
This change follows John Hauser's suggestion and provides a convenient pseudo-instruction for copying a doubleword register-pair value on RV32 P.

https://lists.riscv.org/g/tech-p-ext/message/999

Add the RV32 MVD pseudo-instruction for moving a doubleword register pair:

```
mvd _rd_p_, _rs_p_ -> padd.dw _rd_p_, zero, _rs_p_
```