### PR TITLE
Add intrinsic-utils tooling for spec parsing and API testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+intrinsic-utils/intrinsics.json
+intrinsic-utils/api-test

--- a/intrinsic-utils/Makefile
+++ b/intrinsic-utils/Makefile
@@ -1,0 +1,37 @@
+SCRIPT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT  := $(abspath $(SCRIPT_DIR)/..)
+SPEC       := $(REPO_ROOT)/P-ext-intrinsics.adoc
+JSON       := $(SCRIPT_DIR)/intrinsics.json
+API_TEST   := $(SCRIPT_DIR)/api-test
+
+MARCH      ?= rv64gcp
+MABI       ?= lp64
+JOBS       ?= $(shell nproc)
+
+all: json c-api-test
+
+json: $(JSON)
+
+$(JSON): $(SPEC) $(SCRIPT_DIR)/spec2json.py
+	python3 $(SCRIPT_DIR)/spec2json.py $(SPEC) $(JSON)
+
+c-api-test: $(JSON) $(SCRIPT_DIR)/gen_api_test.py
+	python3 $(SCRIPT_DIR)/gen_api_test.py --json $(JSON) --output $(API_TEST)
+
+run-c-api-test:
+ifeq ($(origin CC),default)
+	$(error CC is not set. Usage: make run-c-api-test CC=/path/to/compiler)
+endif
+	python3 $(SCRIPT_DIR)/api_tester.py \
+		--cc $(CC) \
+		--spec $(SPEC) \
+		--march $(MARCH) \
+		--mabi $(MABI) \
+		-j $(JOBS) \
+		-o $(API_TEST) \
+		$(EXTRA_OPTS)
+
+clean:
+	rm -rf $(JSON) $(API_TEST)
+
+.PHONY: all json c-api-test run-c-api-test clean

--- a/intrinsic-utils/README.md
+++ b/intrinsic-utils/README.md
@@ -1,0 +1,41 @@
+# intrinsic-utils
+
+Tooling for parsing the P extension intrinsics spec and running
+compile-only API tests against a RISC-V compiler.
+
+## Quick start
+
+```sh
+# Generate intrinsics.json from the spec
+$ make json
+
+# Generate .c test files
+$ make c-api-test
+
+# Compile all tests (CC is required)
+$ make run-c-api-test CC=riscv64-unknown-elf-gcc
+$ make run-c-api-test CC=clang MARCH=rv64gcp0p21
+
+# Or run the tester directly with extra options
+$ python3 api_tester.py --cc clang --march rv64gcp0p21 --mabi lp64 -j8
+```
+
+## Makefile targets
+
+| Target           | Description                                      |
+|------------------|--------------------------------------------------|
+| `all`            | Generate JSON and test files                     |
+| `json`           | Parse spec into `intrinsics.json`                |
+| `c-api-test`     | Generate `.c` test files under `api-test/`       |
+| `run-c-api-test` | Compile tests (requires `CC=`)                   |
+| `clean`          | Remove generated `intrinsics.json` and `api-test/` |
+
+## Variables
+
+| Variable     | Default         | Description                  |
+|--------------|-----------------|------------------------------|
+| `CC`         | (none)          | Compiler path (required for `run-c-api-test`) |
+| `MARCH`      | `rv64gcp`       | Architecture string          |
+| `MABI`       | `lp64`          | ABI string                   |
+| `JOBS`       | `nproc`         | Parallel compile jobs        |
+| `EXTRA_OPTS` | (none)          | Extra flags passed to `api_tester.py` |

--- a/intrinsic-utils/api_tester.py
+++ b/intrinsic-utils/api_tester.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Compile-only API tester for RISC-V P extension intrinsics.
+
+Generates test files from the spec dynamically and compiles each one
+to verify that the intrinsic exists with the correct signature.
+
+Usage:
+  python3 intrinsic-utils/api_tester.py --cc riscv64-unknown-elf-gcc
+  python3 intrinsic-utils/api_tester.py --cc gcc --march rv32gcp --mabi ilp32 -- -I/extra/include
+"""
+
+import argparse
+import json
+import multiprocessing
+import os
+import shutil
+import subprocess
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from spec2json import parse_spec
+from gen_api_test import generate_all
+
+
+def compile_one(args):
+    """Compile a single test file. Called in worker processes."""
+    base_cmd, filepath, xlen, verbose = args
+    name = Path(filepath).stem
+    cmd = base_cmd + [filepath]
+
+    if verbose:
+        cmd_str = " ".join(cmd)
+    else:
+        cmd_str = ""
+
+    content = Path(filepath).read_text()
+    if xlen and content.startswith("#if __riscv_xlen"):
+        guard_xlen = "32" if "== 32" in content.split('\n')[0] else "64"
+        if guard_xlen != xlen:
+            return ("SKIP", name, "", cmd_str)
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode == 0:
+        return ("PASS", name, "", cmd_str)
+
+    stderr = "\n".join(result.stderr.strip().splitlines()[:3])
+    return ("FAIL", name, stderr, cmd_str)
+
+
+def xlen_from_march(march):
+    """Infer XLEN from -march string."""
+    if "rv32" in march.lower():
+        return "32"
+    if "rv64" in march.lower():
+        return "64"
+    return None
+
+
+def run_tests(cc, test_dir, march, mabi, extra_opts, jobs, verbose=False):
+    """Compile each .c file in test_dir.
+
+    Returns dict mapping test name -> (status, stderr).
+    status is "PASS", "FAIL", or "SKIP".
+    """
+    test_files = sorted(test_dir.glob("*.c"))
+    total = len(test_files)
+
+    base_cmd = [cc, f"-march={march}", f"-mabi={mabi}", "-fsyntax-only"]
+    base_cmd.extend(extra_opts)
+
+    xlen = xlen_from_march(march)
+    tasks = [(base_cmd, str(f), xlen, verbose) for f in test_files]
+    results = {}
+
+    if verbose:
+        # Sequential for readable output
+        for i, task in enumerate(tasks, 1):
+            status, name, stderr, cmd_str = compile_one(task)
+            results[name] = (status, stderr)
+            print(f"  [{i}/{total}] {status} {name}")
+            if cmd_str:
+                print(f"    $ {cmd_str}")
+            if stderr:
+                for line in stderr.splitlines():
+                    print(f"    {line}")
+    else:
+        with ProcessPoolExecutor(max_workers=jobs) as executor:
+            futures = {executor.submit(compile_one, t): t for t in tasks}
+            for future in as_completed(futures):
+                status, name, stderr, _ = future.result()
+                results[name] = (status, stderr)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compile-only API tester for RISC-V P extension intrinsics",
+    )
+    parser.add_argument("--cc", required=True, help="Path to C compiler")
+    parser.add_argument("--march", default="rv64gcp",
+                        help="Architecture string (default: rv64gcp)")
+    parser.add_argument("--mabi", default="lp64",
+                        help="ABI string (default: lp64)")
+    parser.add_argument("--spec", default=None,
+                        help="Path to spec file (default: P-ext-intrinsics.adoc)")
+    parser.add_argument("-j", "--jobs", type=int, default=multiprocessing.cpu_count(),
+                        help="Number of parallel jobs (default: nproc)")
+    parser.add_argument("-I", dest="include_paths", action="append", default=[],
+                        help="Add include path (can be specified multiple times)")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Show detailed compile commands and results")
+    parser.add_argument("-o", "--output", default="api-test",
+                        help="Output directory for test files (default: ./api-test)")
+    parser.add_argument("extra_opts", nargs="*",
+                        help="Extra compiler options (put after --)")
+    args = parser.parse_args()
+
+    spec_path = Path(args.spec) if args.spec else REPO_ROOT / "P-ext-intrinsics.adoc"
+    if not spec_path.exists():
+        print(f"Error: spec file not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Verify compiler exists
+    cc = shutil.which(args.cc) or args.cc
+    try:
+        result = subprocess.run([cc, "--version"], capture_output=True, text=True)
+    except OSError as e:
+        print(f"Error: cannot run compiler: {cc}: {e}", file=sys.stderr)
+        sys.exit(1)
+    if result.returncode != 0:
+        print(f"Error: compiler not found or not working: {cc}", file=sys.stderr)
+        sys.exit(1)
+
+    # Prepend -I flags to extra opts
+    for inc in args.include_paths:
+        args.extra_opts = [f"-I{inc}"] + args.extra_opts
+
+    # Auto-detect clang without riscv target prefix
+    cc_basename = Path(cc).name
+    is_clang = "clang" in result.stdout.lower() or "clang" in cc_basename
+    has_riscv_prefix = cc_basename.startswith("riscv")
+    if is_clang and not has_riscv_prefix:
+        xlen = "32" if "32" in args.march else "64"
+        clang_extra = [f"-target", f"riscv{xlen}-elf",
+                       "-menable-experimental-extensions"]
+        args.extra_opts = clang_extra + args.extra_opts
+
+    # Parse spec -> JSON
+    print(f"Parsing spec: {spec_path}")
+    data = parse_spec(spec_path)
+    total_intrinsics = sum(len(s["intrinsics"]) for s in data["sections"])
+
+    # Generate test files
+    test_dir = Path(args.output)
+
+    count = generate_all(data, test_dir)
+    print(f"Generated {count} test files")
+
+    # Run compilation tests
+    print(f"Compiler: {cc}")
+    print(f"Options: -march={args.march} -mabi={args.mabi} {' '.join(args.extra_opts)}")
+    print(f"Jobs: {args.jobs}")
+    print()
+
+    results = run_tests(
+        cc, test_dir, args.march, args.mabi, args.extra_opts,
+        jobs=args.jobs, verbose=args.verbose
+    )
+
+    # Build intrinsic name -> test name mapping (strip __riscv_ prefix)
+    name_to_section = {}
+    for section in data["sections"]:
+        section_name = section["name"]
+        for intr in section["intrinsics"]:
+            test_name = intr["name"].removeprefix("__riscv_")
+            name_to_section[test_name] = section_name
+
+    # Group results by section
+    section_results = {}
+    for test_name, (status, stderr) in results.items():
+        section_name = name_to_section.get(test_name, "Unknown")
+        if section_name not in section_results:
+            section_results[section_name] = {"PASS": 0, "FAIL": 0, "SKIP": 0}
+        section_results[section_name][status] += 1
+
+    # Print per-section summary
+    total_pass = sum(r["PASS"] for r in section_results.values())
+    total_fail = sum(r["FAIL"] for r in section_results.values())
+    total_skip = sum(r["SKIP"] for r in section_results.values())
+
+    # Dynamic column width based on longest section name
+    col_w = max(len(s["name"]) for s in data["sections"]) + 2  # +2 for mark prefix
+    line_w = col_w + 18  # 3 columns * 6 chars each
+
+    print("=" * line_w)
+    print(f"  {'Section':<{col_w - 2}} {'PASS':>5} {'FAIL':>5} {'SKIP':>5}")
+    print("-" * line_w)
+
+    # Use section order from spec
+    seen = set()
+    for section in data["sections"]:
+        sn = section["name"]
+        if sn in seen or sn not in section_results:
+            continue
+        seen.add(sn)
+        r = section_results[sn]
+        mark = " " if r["FAIL"] == 0 else "*"
+        print(f"{mark} {sn:<{col_w - 2}} {r['PASS']:>5} {r['FAIL']:>5} {r['SKIP']:>5}")
+
+    print("-" * line_w)
+    print(f"  {'Total':<{col_w - 2}} {total_pass:>5} {total_fail:>5} {total_skip:>5}")
+    print("=" * line_w)
+    print()
+
+    # List all failures with error details
+    all_failed = sorted(
+        [(name, stderr) for name, (status, stderr) in results.items()
+         if status == "FAIL"]
+    )
+    if all_failed:
+        print(f"Failed tests ({len(all_failed)}):")
+        print()
+        for name, stderr in all_failed:
+            section_name = name_to_section.get(name, "Unknown")
+            print(f"  FAIL __riscv_{name}  [{section_name}]")
+            for line in stderr.splitlines():
+                print(f"    {line}")
+        print()
+
+    print(f"Results: {total_pass} passed, {total_fail} failed, {total_skip} skipped "
+          f"/ {count} total")
+    print(f"Test files: {test_dir}")
+
+    sys.exit(1 if total_fail else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/intrinsic-utils/gen_api_test.py
+++ b/intrinsic-utils/gen_api_test.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Generate compile-only API test files from intrinsics JSON data.
+
+Each intrinsic gets one .c file that verifies the intrinsic exists
+and has the correct signature by calling it with dummy arguments.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Default value expressions for each type used as a function argument.
+DEFAULT_VALUES = {
+    "int8_t":       "(int8_t)0",
+    "uint8_t":      "(uint8_t)0",
+    "int16_t":      "(int16_t)0",
+    "uint16_t":     "(uint16_t)0",
+    "int32_t":      "(int32_t)0",
+    "uint32_t":     "(uint32_t)0",
+    "int64_t":      "(int64_t)0",
+    "uint64_t":     "(uint64_t)0",
+    "int":          "(int)0",
+    "unsigned":     "(unsigned)0",
+    "unsigned int": "(unsigned int)0",
+    "int8x4_t":     "v_i8x4",
+    "uint8x4_t":    "v_u8x4",
+    "int16x2_t":    "v_i16x2",
+    "uint16x2_t":   "v_u16x2",
+    "int8x8_t":     "v_i8x8",
+    "uint8x8_t":    "v_u8x8",
+    "int16x4_t":    "v_i16x4",
+    "uint16x4_t":   "v_u16x4",
+    "int32x2_t":    "v_i32x2",
+    "uint32x2_t":   "v_u32x2",
+    # Pointer types
+    "int8_t *":     "&s_i8",
+    "uint8_t *":    "&s_u8",
+    "int16_t *":    "&s_i16",
+    "uint16_t *":   "&s_u16",
+    "int32_t *":    "&s_i32",
+    "uint32_t *":   "&s_u32",
+    # const immediate types
+    "const unsigned": "1",
+}
+
+# Packed types that need local variable declarations.
+PACKED_TYPES = [
+    "int8x4_t", "uint8x4_t", "int16x2_t", "uint16x2_t",
+    "int8x8_t", "uint8x8_t", "int16x4_t", "uint16x4_t",
+    "int32x2_t", "uint32x2_t",
+]
+
+# Scalar types that need pointer targets.
+POINTER_TARGETS = {
+    "int8_t *":    ("int8_t",   "s_i8"),
+    "uint8_t *":   ("uint8_t",  "s_u8"),
+    "int16_t *":   ("int16_t",  "s_i16"),
+    "uint16_t *":  ("uint16_t", "s_u16"),
+    "int32_t *":   ("int32_t",  "s_i32"),
+    "uint32_t *":  ("uint32_t", "s_u32"),
+}
+
+
+def collect_needed_decls(intrinsic):
+    """Collect which local variable declarations this intrinsic needs."""
+    needed_packed = set()
+    needed_pointers = set()
+
+    all_types = [a["type"] for a in intrinsic["arguments"]]
+
+    for t in all_types:
+        if t in PACKED_TYPES:
+            needed_packed.add(t)
+        if t in POINTER_TARGETS:
+            needed_pointers.add(t)
+
+    return needed_packed, needed_pointers
+
+
+HEADER = "riscv_packed_simd.h"
+
+
+def generate_test(intrinsic):
+    """Generate C source for a compile-only API test."""
+    name = intrinsic["name"]
+    ret_type = intrinsic["return_type"]
+    args = intrinsic["arguments"]
+    availability = intrinsic["availability"]
+
+    needed_packed, needed_pointers = collect_needed_decls(intrinsic)
+
+    lines = []
+    lines.append(f"/* Compile-only API test for {name} */")
+    lines.append(f'#include <{HEADER}>')
+    lines.append('')
+    lines.append('void test(void) {')
+
+    # Declare packed type variables
+    for t in sorted(needed_packed):
+        var = DEFAULT_VALUES[t]
+        lines.append(f'  {t} {var} = {{0}};')
+
+    # Declare pointer target variables
+    for t in sorted(needed_pointers):
+        base_type, var_name = POINTER_TARGETS[t]
+        lines.append(f'  {base_type} {var_name} = 0;')
+
+    # Build argument list
+    arg_exprs = []
+    for a in args:
+        t = a["type"]
+        val = DEFAULT_VALUES.get(t)
+        if val is None:
+            val = f"/* unknown type: {t} */ 0"
+        arg_exprs.append(val)
+
+    call_expr = f'{name}({", ".join(arg_exprs)})'
+
+    # Generate the call
+    if ret_type == "void":
+        lines.append(f'  {call_expr};')
+    else:
+        lines.append(f'  {ret_type} result = {call_expr};')
+        lines.append('  (void)result;')
+
+    lines.append('}')
+    lines.append('')
+
+    body = '\n'.join(lines)
+
+    # Wrap with availability guard if needed
+    if availability == "rv32_only":
+        body = f'#if __riscv_xlen == 32\n{body}\n#endif\n'
+    elif availability == "rv64_only":
+        body = f'#if __riscv_xlen == 64\n{body}\n#endif\n'
+
+    return body
+
+
+def generate_all(data, output_dir):
+    """Generate all test files. Returns count of files generated."""
+    if output_dir.exists():
+        for old in output_dir.glob("*.c"):
+            old.unlink()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for section in data["sections"]:
+        for intrinsic in section["intrinsics"]:
+            name = intrinsic["name"]
+            filename = name.removeprefix("__riscv_") + ".c"
+            filepath = output_dir / filename
+            content = generate_test(intrinsic)
+            filepath.write_text(content)
+            count += 1
+    return count
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Generate compile-only API test files")
+    parser.add_argument("--json", default=None, help="Path to intrinsics.json")
+    parser.add_argument("--output", default=None, help="Output directory")
+    args = parser.parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
+    json_path = Path(args.json) if args.json else script_dir / "intrinsics.json"
+    output_dir = Path(args.output) if args.output else script_dir / "api-test"
+
+    if not json_path.exists():
+        print(f"Error: {json_path} not found. Run spec2json.py first.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    with open(json_path) as f:
+        data = json.load(f)
+
+    count = generate_all(data, output_dir)
+    print(f"Generated {count} test files in {output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/intrinsic-utils/spec2json.py
+++ b/intrinsic-utils/spec2json.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Extract intrinsic information from P-ext-intrinsics.adoc into JSON format."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+# Packed SIMD type definitions from the spec.
+PACKED_TYPES = [
+    {"name": "int8x4_t",   "size_bytes": 4, "alignment_bytes": 4, "description": "Four signed 8-bit integers",     "element_type": "int8_t",   "element_count": 4, "total_bits": 32},
+    {"name": "uint8x4_t",  "size_bytes": 4, "alignment_bytes": 4, "description": "Four unsigned 8-bit integers",   "element_type": "uint8_t",  "element_count": 4, "total_bits": 32},
+    {"name": "int16x2_t",  "size_bytes": 4, "alignment_bytes": 4, "description": "Two signed 16-bit integers",     "element_type": "int16_t",  "element_count": 2, "total_bits": 32},
+    {"name": "uint16x2_t", "size_bytes": 4, "alignment_bytes": 4, "description": "Two unsigned 16-bit integers",   "element_type": "uint16_t", "element_count": 2, "total_bits": 32},
+    {"name": "int8x8_t",   "size_bytes": 8, "alignment_bytes": 8, "description": "Eight signed 8-bit integers",    "element_type": "int8_t",   "element_count": 8, "total_bits": 64},
+    {"name": "uint8x8_t",  "size_bytes": 8, "alignment_bytes": 8, "description": "Eight unsigned 8-bit integers",  "element_type": "uint8_t",  "element_count": 8, "total_bits": 64},
+    {"name": "int16x4_t",  "size_bytes": 8, "alignment_bytes": 8, "description": "Four signed 16-bit integers",    "element_type": "int16_t",  "element_count": 4, "total_bits": 64},
+    {"name": "uint16x4_t", "size_bytes": 8, "alignment_bytes": 8, "description": "Four unsigned 16-bit integers",  "element_type": "uint16_t", "element_count": 4, "total_bits": 64},
+    {"name": "int32x2_t",  "size_bytes": 8, "alignment_bytes": 8, "description": "Two signed 32-bit integers",     "element_type": "int32_t",  "element_count": 2, "total_bits": 64},
+    {"name": "uint32x2_t", "size_bytes": 8, "alignment_bytes": 8, "description": "Two unsigned 32-bit integers",   "element_type": "uint32_t", "element_count": 2, "total_bits": 64},
+]
+
+# Regex to extract prototype: return_type func_name(args);
+PROTO_RE = re.compile(
+    r'^(?P<ret>.+?)\s+(?P<name>__riscv_\w+)\((?P<args>[^)]*)\);?$'
+)
+
+# Regex to parse a single argument
+ARG_RE = re.compile(
+    r'^(?P<type>(?:const\s+)?[\w]+(?:\s+[\w]+)*(?:\s*\*)?)\s+(?P<name>\w+)$'
+)
+
+# Constraint column: "0 ≤ name ≤ N"
+CONSTRAINT_RE = re.compile(r'(\d+)\s*[≤<=]+\s*(\w+)\s*[≤<=]+\s*(\d+)')
+
+# AsciiDoc heading level detection
+HEADING_RE = re.compile(r'^(?P<equals>={2,4})\s+(?P<title>.+)$')
+
+# Availability from heading title
+AVAILABILITY_RE = re.compile(r'\((?P<avail>RV32|RV64)\s+Only\)', re.IGNORECASE)
+
+
+def parse_argument(arg_str):
+    """Parse a single C argument string into type and name.
+
+    Handles cases like:
+      int32_t rs1        -> type="int32_t", name="rs1"
+      const unsigned shamt -> type="const unsigned", name="shamt"
+      int8_t *p          -> type="int8_t *", name="p"
+      uint8x4_t v        -> type="uint8x4_t", name="v"
+    """
+    arg_str = arg_str.strip()
+    if not arg_str:
+        return None
+
+    # Handle pointer: "int8_t *p" or "int8_t* p"
+    m = re.match(r'^(.+?)\s*(\*)\s*(\w+)$', arg_str)
+    if m:
+        return {"type": m.group(1).strip() + ' *', "name": m.group(3)}
+
+    # Regular: split on last whitespace
+    m = ARG_RE.match(arg_str)
+    if m:
+        return {"type": m.group('type').strip(), "name": m.group('name').strip()}
+
+    # Fallback: split on last space
+    parts = arg_str.rsplit(None, 1)
+    if len(parts) == 2:
+        return {"type": parts[0].strip(), "name": parts[1].strip()}
+
+    return {"type": arg_str, "name": ""}
+
+
+def parse_prototype(proto_str):
+    """Parse a C prototype string into return_type, name, and arguments."""
+    proto_str = proto_str.strip().rstrip(';').strip()
+    m = PROTO_RE.match(proto_str)
+    if not m:
+        return None
+    ret = m.group('ret').strip()
+    name = m.group('name').strip()
+    args_str = m.group('args').strip()
+
+    arguments = []
+    if args_str:
+        for arg in args_str.split(','):
+            arg = arg.strip()
+            parsed_arg = parse_argument(arg)
+            if parsed_arg:
+                arguments.append(parsed_arg)
+
+    return {"return_type": ret, "name": name, "arguments": arguments}
+
+
+def parse_instructions(instr_str, availability):
+    """Parse instruction column into rv32/rv64 instruction lists.
+
+    Platform annotations like (RV32) or (RV64) apply to all preceding
+    unannotated parts since the last annotation (backward-scan).
+    """
+    if not instr_str or not instr_str.strip():
+        return {"rv32": [], "rv64": []}
+
+    instr_str = instr_str.strip()
+
+    parts = split_instruction_parts(instr_str)
+
+    # First pass: extract instruction names and platform annotations per part
+    parsed_parts = []
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+
+        insn_names = re.findall(r'`([^`]+)`', part)
+        if not insn_names:
+            continue
+        insn_str = '+'.join(insn_names)
+
+        platform = None
+        plat_match = re.search(r'\(RV(32|64)\)\s*$', part)
+        if plat_match:
+            platform = f"rv{plat_match.group(1)}"
+
+        parsed_parts.append({"insn": insn_str, "platform": platform})
+
+    # Second pass: backward-scan for platform assignment
+    assigned = [p["platform"] for p in parsed_parts]
+    for i in range(len(assigned) - 1, -1, -1):
+        if assigned[i] is not None:
+            for j in range(i - 1, -1, -1):
+                if assigned[j] is not None:
+                    break
+                assigned[j] = assigned[i]
+
+    rv32_instrs = []
+    rv64_instrs = []
+    generic_instrs = []
+
+    for i, pp in enumerate(parsed_parts):
+        platform = assigned[i]
+        if platform == 'rv32':
+            rv32_instrs.append(pp["insn"])
+        elif platform == 'rv64':
+            rv64_instrs.append(pp["insn"])
+        else:
+            generic_instrs.append(pp["insn"])
+
+    # Assign generic instructions based on availability
+    if availability == 'rv32_only':
+        rv32_instrs = generic_instrs + rv32_instrs
+        rv64_instrs = []
+    elif availability == 'rv64_only':
+        rv64_instrs = generic_instrs + rv64_instrs
+        rv32_instrs = []
+    else:
+        if rv32_instrs or rv64_instrs:
+            if generic_instrs:
+                rv32_instrs = generic_instrs + rv32_instrs
+                rv64_instrs = generic_instrs + rv64_instrs
+        else:
+            rv32_instrs = generic_instrs[:]
+            rv64_instrs = generic_instrs[:]
+
+    return {"rv32": rv32_instrs, "rv64": rv64_instrs}
+
+
+def split_instruction_parts(s):
+    """Split instruction string by commas, respecting parentheses."""
+    parts = []
+    depth = 0
+    current = []
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch == '(':
+            depth += 1
+            current.append(ch)
+        elif ch == ')':
+            depth = max(0, depth - 1)
+            current.append(ch)
+        elif ch == ',' and depth == 0:
+            parts.append(''.join(current))
+            current = []
+            i += 1
+            while i < len(s) and s[i] == ' ':
+                i += 1
+            continue
+        else:
+            current.append(ch)
+        i += 1
+    if current:
+        parts.append(''.join(current))
+    return parts
+
+
+def parse_availability(title):
+    """Derive availability from section/subsection title."""
+    # Match "(RV32 Only)" or "(RV64 Only)" with parentheses
+    m = AVAILABILITY_RE.search(title)
+    if m:
+        return f"{m.group('avail').lower()}_only"
+    # Match "RV32 Only" or "RV64 Only" without parentheses
+    m2 = re.search(r'\bRV(32|64)\s+Only\b', title, re.IGNORECASE)
+    if m2:
+        return f"rv{m2.group(1)}_only"
+    return "both"
+
+
+def count_cols(cols_attr):
+    """Count columns from AsciiDoc [cols="..."] attribute."""
+    m = re.match(r'\[cols="([^"]+)"\]', cols_attr)
+    if m:
+        return len(m.group(1).split(','))
+    return 0
+
+
+def parse_table_cells(lines, start_idx):
+    """Parse all cells from an AsciiDoc table body.
+
+    start_idx should point to the line AFTER the opening |===.
+    Returns (cells, end_idx) where cells is a list of cell content strings.
+    """
+    cells = []
+    current_lines = []
+    is_literal = False
+
+    def flush():
+        nonlocal current_lines, is_literal
+        if not current_lines:
+            return
+        if is_literal:
+            # Join literal cell lines with space
+            content = ' '.join(l for l in current_lines if l)
+        else:
+            # Handle AsciiDoc soft break: strip trailing ' +' before joining
+            processed = []
+            for l in current_lines:
+                if l.endswith(' +'):
+                    l = l[:-2].rstrip()
+                if l:
+                    processed.append(l)
+            content = ' '.join(processed)
+        cells.append(content)
+        current_lines = []
+
+    i = start_idx
+    while i < len(lines):
+        stripped = lines[i].strip()
+
+        if stripped == '|===':
+            flush()
+            return cells, i + 1
+
+        if stripped == '':
+            # Empty line - row separator in AsciiDoc tables
+            flush()
+            i += 1
+            continue
+
+        if stripped.startswith('l|'):
+            flush()
+            rest = stripped[2:].strip()
+            current_lines = [rest] if rest else []
+            is_literal = True
+        elif stripped.startswith('|'):
+            flush()
+            rest = stripped[1:].strip()
+            current_lines = [rest] if rest else []
+            is_literal = False
+        else:
+            # Continuation line
+            current_lines.append(stripped)
+
+        i += 1
+
+    flush()
+    return cells, i
+
+
+def parse_constraint(constraint_str):
+    """Parse a constraint string like '0 ≤ name ≤ 31' into (name, min, max)."""
+    if not constraint_str:
+        return None
+    m = CONSTRAINT_RE.search(constraint_str)
+    if m:
+        return (m.group(2), int(m.group(1)), int(m.group(3)))
+    return None
+
+
+def apply_constraint(arguments, constraint):
+    """Apply a parsed constraint (name, min, max) as imm_range on matching argument."""
+    if not constraint:
+        return
+    name, lo, hi = constraint
+    for arg in arguments:
+        if arg["name"] == name:
+            arg["imm_range"] = [lo, hi]
+            return
+
+
+def extract_prototype(cell_content):
+    """Extract prototype string from a cell (may be backtick-quoted or plain)."""
+    # Check for backtick-quoted prototype
+    m = re.search(r'`([^`]+)`', cell_content)
+    if m and '__riscv_' in m.group(1):
+        return m.group(1)
+    # Plain text from literal cell
+    if '__riscv_' in cell_content:
+        return cell_content.strip()
+    return None
+
+
+def parse_spec(filepath):
+    """Parse the AsciiDoc spec file and return structured data."""
+    lines = Path(filepath).read_text().splitlines()
+
+    sections = []
+    current_category = ""
+    current_section_name = ""
+    current_section_desc = ""
+    current_availability = "both"
+    current_section = None
+
+    # Track description lines between heading and table
+    desc_lines = []
+    collecting_desc = False
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        # Skip page breaks
+        if stripped == '<<<':
+            i += 1
+            continue
+
+        # Check for headings
+        hm = HEADING_RE.match(stripped)
+        if hm:
+            level = len(hm.group('equals'))
+            title = hm.group('title').strip()
+
+            if level == 2:
+                # Major category
+                current_category = title
+                current_section_name = ""
+                current_availability = "both"
+                current_section = None
+                desc_lines = []
+                collecting_desc = True
+            elif level == 3:
+                # Check if this is a bit-width sub-heading like "=== 64-bit"
+                if re.match(r'^\d+-bit', title):
+                    current_availability = parse_availability(title)
+                else:
+                    # New section
+                    current_section_name = title
+                    current_availability = parse_availability(title)
+                    current_section = None
+                    desc_lines = []
+                    collecting_desc = True
+            elif level == 4:
+                # Sub-section: "==== 32-bit", "==== 64-bit (RV64 only)"
+                current_availability = parse_availability(title)
+
+            i += 1
+            continue
+
+        # Collect description text between heading and first table
+        if collecting_desc:
+            if (not stripped.startswith('[')
+                    and not stripped.startswith('|')
+                    and not stripped.startswith('l|')):
+                if stripped and not stripped.startswith('*'):
+                    desc_lines.append(stripped)
+                i += 1
+                continue
+            else:
+                collecting_desc = False
+                current_section_desc = ' '.join(desc_lines) if desc_lines else ""
+
+        # Check for table start: [cols="..."]
+        if stripped.startswith('[cols='):
+            num_cols = count_cols(stripped)
+            i += 1
+            # Find |=== on next non-empty line
+            while i < len(lines) and lines[i].strip() == '':
+                i += 1
+            if i < len(lines) and lines[i].strip() == '|===':
+                i += 1
+                # Parse table cells
+                all_cells, i = parse_table_cells(lines, i)
+                # Skip header cells (first num_cols cells)
+                data_cells = all_cells[num_cols:]
+                # Group into rows
+                for row_start in range(0, len(data_cells), num_cols):
+                    row = data_cells[row_start:row_start + num_cols]
+                    if len(row) < 1:
+                        continue
+
+                    proto_str = extract_prototype(row[0])
+                    if not proto_str or '__riscv_' not in proto_str:
+                        continue
+
+                    parsed = parse_prototype(proto_str)
+                    if not parsed:
+                        print(f"WARNING: Failed to parse prototype: {proto_str}",
+                              file=sys.stderr)
+                        continue
+
+                    # Ensure section exists
+                    if current_section is None:
+                        current_section = {
+                            "category": current_category,
+                            "name": current_section_name or current_category,
+                            "description": current_section_desc,
+                            "intrinsics": [],
+                        }
+                        sections.append(current_section)
+
+                    instr_str = ""
+                    if num_cols >= 2 and len(row) >= 2:
+                        # Replace \+ with + for instruction chaining
+                        instr_str = row[1].replace('\\+', '+')
+
+                    instructions = parse_instructions(instr_str, current_availability)
+
+                    # Parse constraint column if present
+                    constraint_str = ""
+                    if num_cols >= 3 and len(row) >= 3:
+                        constraint_str = row[2]
+                    constraint = parse_constraint(constraint_str)
+                    apply_constraint(parsed["arguments"], constraint)
+
+                    intrinsic = {
+                        "name": parsed["name"],
+                        "return_type": parsed["return_type"],
+                        "arguments": parsed["arguments"],
+                        "instructions": instructions,
+                        "availability": current_availability,
+                    }
+
+                    current_section["intrinsics"].append(intrinsic)
+            continue
+
+        i += 1
+
+    # Remove empty sections
+    sections = [s for s in sections if s["intrinsics"]]
+
+    return {"types": PACKED_TYPES, "sections": sections}
+
+
+def main():
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
+    spec_path = repo_root / "P-ext-intrinsics.adoc"
+    output_path = script_dir / "intrinsics.json"
+
+    if len(sys.argv) > 1:
+        spec_path = Path(sys.argv[1])
+    if len(sys.argv) > 2:
+        output_path = Path(sys.argv[2])
+
+    if not spec_path.exists():
+        print(f"Error: {spec_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    result = parse_spec(spec_path)
+
+    total = sum(len(s["intrinsics"]) for s in result["sections"])
+    print(f"Parsed {len(result['sections'])} sections, {total} intrinsics")
+    for s in result["sections"]:
+        print(f"  {s['name']}: {len(s['intrinsics'])} intrinsics")
+
+    with open(output_path, 'w') as f:
+        json.dump(result, f, indent=2)
+        f.write('\n')
+
+    print(f"Written to {output_path}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Generating machine readable data for the intrinsic and simple API testing.

```sh
$ make json

$ make c-api-test

$ make run-c-api-test CC=riscv64-unknown-elf-gcc
$ make run-c-api-test CC=clang MARCH=rv64gcp0p21

$ python3 api_tester.py --cc clang --march rv64gcp0p21 --mabi lp64 -j8
```

Example output for API test:
```
$ python3 api_tester.py --cc clang --march rv64gcp0p21 --mabi lp64 -j8
Parsing spec: /home/kitoc/p-ext-intrinsics/riscv-p-spec/P-ext-intrinsics.adoc
Generated 971 test files
Compiler: /home/kitoc/llvm-workspace/build-upstream/bin/clang
Options: -march=rv64gcp0p21 -mabi=lp64 -target riscv64-elf -menable-experimental-extensions
Jobs: 8

==========================================================================================
  Section                                                                 PASS  FAIL  SKIP
------------------------------------------------------------------------------------------
* Bitmanip                                                                   0     6    13
* Saturating Addition and Subtraction                                        0     4     0
* Averaging Addition and Subtraction                                         0     4     0
* Shift-Add                                                                  0     1     0
* Absolute Value                                                             0     1     1
* Comparison                                                                 0     6     0
* Merge                                                                      0     4     0
* Saturation                                                                 0     2     2
* Saturating and Rounding Shifts                                             0     4     4
* Narrowing Clip                                                             0     5     0
* Multiply High                                                              0     6     0
* Multiply High Accumulate                                                   0     6     0
* "Q-format" Multiplication                                                  0     2     0
* "Q-format" Multiply with Widening Accumulate                               0     2     0
  Packed Splat                                                              10     0     0
  Packed Addition and Subtraction                                           25     0     0
  Packed Addition with Scalar                                               10     0     0
  Packed Saturating Addition and Subtraction                                20     0     0
  Packed Averaging Addition and Subtraction                                 20     0     0
  Packed Shift-Add                                                           9     0     0
* Packed Exchanged Addition and Subtraction                                  0    18     0
  Packed Absolute Value and Absolute Difference                             12     0     0
* Packed Absolute Difference Sum                                             0     6     0
...
* Packed Slide                                                               0    20     0
* Packed &#8596; Scalar                                                      0    40     0
* Packed &#8596; Packed                                                      0    42     0
------------------------------------------------------------------------------------------
  Total                                                                    246   699    20
==========================================================================================

...
  FAIL __riscv_usati_u32  [Saturation]
    /home/kitoc/p-ext-intrinsics/riscv-p-spec/intrinsic-utils/api-test/usati_u32.c:5:21: error: call to undeclared function '__riscv_usati_u32'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        5 |   uint32_t result = __riscv_usati_u32((int32_t)0, 1);
          |                     ^
  FAIL __riscv_wzip16p_64  [Bitmanip]
    /home/kitoc/p-ext-intrinsics/riscv-p-spec/intrinsic-utils/api-test/wzip16p_64.c:5:21: error: call to undeclared function '__riscv_wzip16p_64'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        5 |   uint64_t result = __riscv_wzip16p_64((uint32_t)0, (uint32_t)0);
          |                     ^
  FAIL __riscv_wzip8p_64  [Bitmanip]
    /home/kitoc/p-ext-intrinsics/riscv-p-spec/intrinsic-utils/api-test/wzip8p_64.c:5:21: error: call to undeclared function '__riscv_wzip8p_64'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        5 |   uint64_t result = __riscv_wzip8p_64((uint32_t)0, (uint32_t)0);
          |                     ^

Results: 246 passed, 699 failed, 20 skipped / 971 total
Test files: /home/kitoc/p-ext-intrinsics/riscv-p-spec/intrinsic-utils/api-test
make: *** [Makefile:25: run-c-api-test] Error 1

```