### PR TITLE
Off-by-one bit slice in PSSHL.WS operation

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -14428,7 +14428,7 @@ shamt = X[rs2][7:0]
 sshamt = signed(shamt)
 
 for i = 0 .. (XLEN/32 - 1):
-    w  = s1[(32*i+32):(32*i)]
+    w  = s1[(32*i+31):(32*i)]
     xw = zero_extend(64, w)
 
     if sshamt < 0:


### PR DESCRIPTION
The Sail code of operation computes 
a 32-bit packed element using:

w = s1[(32*i+32):(32*i)]

But under Sail's inclusive bit-slice notation, 
the result will show [32:0], 33bits. Should this instead be:

w = s1[(32*i+31):(32*i)]