### PR TITLE
 Add 'sext_N' and 'zext_N' notation

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -733,6 +733,13 @@ model, are used throughout the Sail code in this specification:
 * `<_s`, `<=_s`, `>_s`, `>=_s` — signed comparisons of bit-vectors.
 * `<_u`, `>_u` — unsigned comparisons of bit-vectors.
 
+The following shorthand notations are also used:
+
+* `zext_N(bv)` — shorthand for `zero_extend(N, bv)`; `N` is the width
+  of the resulting bit-vector.
+* `sext_N(bv)` — shorthand for `sign_extend(N, bv)`; `N` is the width
+  of the resulting bit-vector.
+
 Arithmetic right shifts are modeled by first sign-extending the operand
 to a larger size and then applying the logical right shift operator.
 


### PR DESCRIPTION
Added these definitions under “Sail Code Conventions → Helper Functions and Operators”
and checked that the existing uses of sext_N and zext_N follow this convention.
Here, N denotes the total width of the resulting bit-vector, rather than the number of bits being added.