### PR TITLE
Fix the 'psas*' instruction descriptions

### DIFF
--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -6233,10 +6233,10 @@ Description::
 
 PSAS.HX (Packed Saturating Add-Subtract Cross, Halfword) performs a cross
 saturating add-subtract on packed 16-bit halfword pairs. Within each 32-bit
-word, the odd (upper) halfword is computed as a signed saturating addition of
-the odd (upper) halfword of `rs1` and the even (lower) halfword of `rs2`, while
-the even (lower) halfword is computed as a signed saturating subtraction of the
-even (lower) halfword of `rs1` and the odd (upper) halfword of `rs2`.
+word, the even (lower) halfword is computed as a signed saturating subtraction
+of the even (lower) halfword of `rs1` and the odd (upper) halfword of `rs2`,
+while the odd (upper) halfword is computed as a signed saturating addition of
+the odd (upper) halfword of `rs1` and the even (lower) halfword of `rs2`.
 Results are clamped to the range [-2^15^, 2^15^-1]. Sets `vxsat` on saturation.
 This instruction is useful for complex number arithmetic.
 
@@ -6303,12 +6303,12 @@ PSAS.WX is encoded in the OP-32 major opcode.
 Description::
 
 PSAS.WX (Packed Saturating Add-Subtract Cross, Word) performs a cross saturating
-add-subtract on packed 32-bit word pairs. The odd (upper) word is computed as a
-signed saturating addition of the odd (upper) word of `rs1` and the even (lower)
-word of `rs2`, while the even (lower) word is computed as a signed saturating
-subtraction of the even (lower) word of `rs1` and the odd (upper) word of `rs2`.
-Results are clamped to the range [-2^31^, 2^31^-1]. Sets `vxsat` on saturation.
-This instruction is useful for complex number arithmetic.
+add-subtract on packed 32-bit word pairs. The even (lower) word is computed as a
+signed saturating subtraction of the even (lower) word of `rs1` and the odd
+(upper) word of `rs2`, while the odd (upper) word is computed as a signed
+saturating addition of the odd (upper) word of `rs1` and the even (lower)
+word of `rs2`. Results are clamped to the range [-2^31^, 2^31^-1]. Sets `vxsat`
+on saturation. This instruction is useful for complex number arithmetic.
 
 Operation::
 

--- a/P-ext-proposal.adoc
+++ b/P-ext-proposal.adoc
@@ -6233,10 +6233,10 @@ Description::
 
 PSAS.HX (Packed Saturating Add-Subtract Cross, Halfword) performs a cross
 saturating add-subtract on packed 16-bit halfword pairs. Within each 32-bit
-word, the even (lower) halfword is computed as a signed saturating subtraction
-of the even (lower) halfword of `rs1` and the odd (upper) halfword of `rs2`,
-while the odd (upper) halfword is computed as a signed saturating addition of
-the odd (upper) halfword of `rs2` and the even (lower) halfword of `rs2`.
+word, the odd (upper) halfword is computed as a signed saturating addition of
+the odd (upper) halfword of `rs1` and the even (lower) halfword of `rs2`, while
+the even (lower) halfword is computed as a signed saturating subtraction of the
+even (lower) halfword of `rs1` and the odd (upper) halfword of `rs2`.
 Results are clamped to the range [-2^15^, 2^15^-1]. Sets `vxsat` on saturation.
 This instruction is useful for complex number arithmetic.
 
@@ -6303,12 +6303,12 @@ PSAS.WX is encoded in the OP-32 major opcode.
 Description::
 
 PSAS.WX (Packed Saturating Add-Subtract Cross, Word) performs a cross saturating
-add-subtract on packed 32-bit word pairs. The even (lower) word is computed as a
-signed saturating subtraction of the even (lower) word of `rs1` and the odd
-(upper) word of `rs2`, while the odd (upper) word is computed as a signed
-saturating addition of the odd (upper) word of `rs2` and the even (lower)
-word of `rs2`. Results are clamped to the range [-2^31^, 2^31^-1]. Sets `vxsat`
-on saturation. This instruction is useful for complex number arithmetic.
+add-subtract on packed 32-bit word pairs. The odd (upper) word is computed as a
+signed saturating addition of the odd (upper) word of `rs1` and the even (lower)
+word of `rs2`, while the even (lower) word is computed as a signed saturating
+subtraction of the even (lower) word of `rs1` and the odd (upper) word of `rs2`.
+Results are clamped to the range [-2^31^, 2^31^-1]. Sets `vxsat` on saturation.
+This instruction is useful for complex number arithmetic.
 
 Operation::
 


### PR DESCRIPTION
Fix the operand descriptions for `PSAS.HX` and `PSAS.WX`.

The descriptions incorrectly stated that the odd result was computed using
both the odd and even elements of `rs2`. The operation pseudocode already
defines the intended semantics:

- Odd result: signed saturating addition of `rs1.odd` and `rs2.even`.
- Even result: signed saturating subtraction of `rs1.even` and `rs2.odd`.