### PR TITLE
Fix PPAIR instruction names in the intrinsics specification

### DIFF
--- a/P-ext-intrinsics.adoc
+++ b/P-ext-intrinsics.adoc
@@ -4765,7 +4765,7 @@ int64_t
 __riscv_pm2wadda_x_i64(int64_t rd, int16x2_t rs1,
                        int16x2_t rs2);
 | `pm2wadda.hx`(RV32), +
-  `zext.w`\+`pairoe.h`+`pm4adda.h`(RV64)
+  `zext.w`\+`ppairoe.h`+`pm4adda.h`(RV64)
 
 l|
 uint64_t
@@ -5259,12 +5259,12 @@ Intrinsics to join multiple scalars into a packed vector.
 l|
 int8x4_t
 __riscv_pjoin4_i8x4(int8_t e0, int8_t e1, int8_t e2, int8_t e3);
-| Multiple `pack` or `ppair`
+| Multiple `pack` or PPAIR-family instructions
 
 l|
 uint8x4_t
 __riscv_pjoin4_u8x4(uint8_t e0, uint8_t e1, uint8_t e2, uint8_t e3);
-| Multiple `pack` or `ppair`
+| Multiple `pack` or PPAIR-family instructions
 
 l|
 int16x2_t
@@ -5290,12 +5290,12 @@ __riscv_pjoin2_u16x2(uint16_t e0, uint16_t e1);
 l|
 int16x4_t
 __riscv_pjoin4_i16x4(int16_t e0, int16_t e1, int16_t e2, int16_t e3);
-| Multiple `pack` or `ppair`
+| Multiple `pack` or PPAIR-family instructions
 
 l|
 uint16x4_t
 __riscv_pjoin4_u16x4(uint16_t e0, uint16_t e1, uint16_t e2, uint16_t e3);
-| Multiple `pack` or `ppair`
+| Multiple `pack` or PPAIR-family instructions
 
 l|
 int32x2_t


### PR DESCRIPTION
Update the PPAIR instruction names