### PR TITLE
Rename __riscv_pm2wadd{,a}su_u64 to _i64

### DIFF
--- a/P-ext-intrinsics.adoc
+++ b/P-ext-intrinsics.adoc
@@ -4737,7 +4737,7 @@ __riscv_pm2wsub_x_i64(int16x2_t rs1, int16x2_t rs2);
 
 l|
 int64_t
-__riscv_pm2waddsu_u64(int16x2_t rs1, uint16x2_t rs2);
+__riscv_pm2waddsu_i64(int16x2_t rs1, uint16x2_t rs2);
 | `pm2waddsu.h`(RV32), +
   `zext.w`+`pm4addsu.h`(RV64)
 |===
@@ -4790,7 +4790,7 @@ __riscv_pm2wsuba_x_i64(int64_t rd, int16x2_t rs1,
 
 l|
 int64_t
-__riscv_pm2waddasu_u64(int64_t rd, int16x2_t rs1,
+__riscv_pm2waddasu_i64(int64_t rd, int16x2_t rs1,
                        uint16x2_t rs2);
 | `pm2waddasu.h`(RV32), +
   `zext.w`+`pm4addasu.h`(RV64)


### PR DESCRIPTION
Both return int64_t. PM2WADDSU.H computes sext_64(rs1) * zext_64(rs2), so the result is signed, and pm2waddasu takes an int64_t accumulator.

Same kind of fix as #346.