### PR TITLE
Take an unsigned rs1 in __riscv_sshl_u32/__riscv_sshlr_u32

### DIFF
--- a/P-ext-intrinsics.adoc
+++ b/P-ext-intrinsics.adoc
@@ -367,11 +367,11 @@ and do not include the `u` in their type suffix.
 | `sshar`, `sslai`, `srari`(RV32), +
   `psshar.ws`, `psslai.w`, `psrari.w`(RV64)
 
-| `uint32_t __riscv_sshl_u32(int32_t rs1, int rs2);`
+| `uint32_t __riscv_sshl_u32(uint32_t rs1, int rs2);`
 | `sshl`(RV32), +
   `psshl.ws`(RV64)
 
-| `uint32_t __riscv_sshlr_u32(int32_t rs1, int rs2);`
+| `uint32_t __riscv_sshlr_u32(uint32_t rs1, int rs2);`
 | `sshlr`(RV32), +
   `psshlr.ws`(RV64)
 |===


### PR DESCRIPTION
SSHL and SSHLR are unsigned operations: both zero-extend rs1 and saturate to the unsigned 32-bit range. The 64-bit forms shl_u64/shlr_u64 and the packed forms psshl_s_u16x2/psshlr_s_u16x2 already take unsigned inputs.